### PR TITLE
docs(readme): promote hook to H3 for first-glance clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,10 @@
   </picture>
 </div>
 
-<p align="center"><strong>Turn team conversations into a living, searchable knowledge base — automatically!</strong></p>
+<h3 align="center">
+  Turn your team's Slack, Discord, Teams &amp; Mattermost chats<br>
+  into a self-maintaining wiki — automatically.
+</h3>
 
 <p align="center">
   <a href="https://docs.beever.ai/atlas"><img src="https://img.shields.io/badge/DOCS-docs.beever.ai/atlas-FFC107?style=for-the-badge&labelColor=4A4A4A" alt="Docs" /></a>
@@ -28,7 +31,7 @@
   <a href="https://beever.ai/"><img src="https://img.shields.io/badge/WEBSITE-beever.ai-15404E?style=for-the-badge&labelColor=4A4A4A" alt="beever.ai" /></a>
 </p>
 
-**Beever Atlas turns the conversations your team already has on Slack, Discord, Microsoft Teams, and Mattermost into a self-maintaining wiki.** Atomic facts get extracted, deduplicated, and clustered into topic pages with citations. A graph store links the people, decisions, and projects mentioned across channels. Ask questions in natural language and get answers cited back to the source messages — through the dashboard, or through MCP into Claude Code and Cursor.
+Beever Atlas pulls the conversations your team already has on Slack, Discord, Microsoft Teams, and Mattermost, extracts atomic facts, deduplicates them, and clusters them into topic pages with citations. A graph store links the people, decisions, and projects mentioned across channels. Ask questions in natural language and get answers cited back to the source messages — through the dashboard, or through MCP into Claude Code and Cursor.
 
 If you want a knowledge base that grows on its own from the chats your team already has, this is it.
 


### PR DESCRIPTION
## Summary
- Elevate the differentiating hook (platforms → self-maintaining wiki) from a bolded sentence buried in a paragraph to a centered `<h3>` directly under the banner.
- Split the one-liner across two lines so visitors can scan input (Slack/Discord/Teams/Mattermost) and output (self-maintaining wiki) separately.
- Reword the paragraph below so the platform names appear once, not twice — paragraph now reads as pure supporting detail.

Before: tagline was an italic one-liner, hook was a bolded sentence inside body text.
After: hook is the first large, centered line readers hit after the banner; paragraph explains *how*.

## Test plan
- [ ] Open README.md on GitHub preview and confirm the new `<h3>` renders centered and large directly under the banner on both light and dark themes.
- [ ] Confirm the hook sentence is no longer duplicated between the H3 and the paragraph below.
- [ ] Verify no other README sections (features, quickstart, etc.) shifted unintentionally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)