### PR TITLE
docs(readme): separate hero block from body with horizontal rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@
   <a href="https://beever.ai/"><img src="https://img.shields.io/badge/WEBSITE-beever.ai-15404E?style=for-the-badge&labelColor=4A4A4A" alt="beever.ai" /></a>
 </p>
 
+---
+
 Beever Atlas pulls the conversations your team already has on Slack, Discord, Microsoft Teams, and Mattermost, extracts atomic facts, deduplicates them, and clusters them into topic pages with citations. A graph store links the people, decisions, and projects mentioned across channels. Ask questions in natural language and get answers cited back to the source messages — through the dashboard, or through MCP into Claude Code and Cursor.
 
 If you want a knowledge base that grows on its own from the chats your team already has, this is it.


### PR DESCRIPTION
## Summary
- Add an `---` between the community badges row and the descriptive paragraph so the hero (banner + hook + badges + community) reads as a distinct block instead of flowing directly into body text.

## Test plan
- [ ] GitHub README preview shows a horizontal rule directly above the "Beever Atlas pulls the conversations…" paragraph.
- [ ] No other README sections shift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)