### PR TITLE
fix(security): gate MattermostBridge.proxyFile with assertPublicUrl (SSRF)

### DIFF
--- a/bot/src/bridge.mattermost-ssrf.test.ts
+++ b/bot/src/bridge.mattermost-ssrf.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Regression tests for the SSRF guard on MattermostBridge.proxyFile (issue #27).
+ *
+ * The fix adds `decodeURIComponent` + `await assertPublicUrl(decodedUrl)` to
+ * MattermostBridge.proxyFile, matching the pattern used by Slack/Discord/
+ * Teams/Telegram. We test `assertPublicUrl` directly (the function is
+ * exported as part of this fix) rather than instantiating MattermostBridge,
+ * because the security behavior lives in the validator. The proxyFile ->
+ * assertPublicUrl wiring is verified by an `awk` grep + tsc compile + the
+ * existing `npm test` suite.
+ *
+ * Coverage (10 cases):
+ *   1. IPv4 cloud metadata (169.254.169.254)
+ *   2. IPv4 loopback (127.0.0.1)
+ *   3. IPv4 RFC1918 (10.0.0.1)
+ *   4. URL-encoded bypass (decode-then-validate ordering contract)
+ *   5. Public URL pass (IP literal, no DNS)
+ *   6. Composed-baseUrl-with-private-IP
+ *   7. Non-http scheme (ftp://)
+ *   8. IPv6 loopback ([::1])
+ *   9. IPv6 link-local ([fe80::1])
+ *  10. IPv4-mapped IPv6 ([::ffff:127.0.0.1])
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { assertPublicUrl } from "./bridge.js";
+
+describe("assertPublicUrl — SSRF guard", () => {
+  it("rejects IPv4 cloud metadata (169.254.169.254)", async () => {
+    await assert.rejects(
+      () => assertPublicUrl("http://169.254.169.254/latest/meta-data/iam/security-credentials/"),
+      /private IP|169\.254/i,
+    );
+  });
+
+  it("rejects IPv4 loopback (127.0.0.1)", async () => {
+    await assert.rejects(
+      () => assertPublicUrl("http://127.0.0.1/secret"),
+      /private IP|127\./i,
+    );
+  });
+
+  it("rejects IPv4 RFC1918 (10.0.0.1)", async () => {
+    await assert.rejects(
+      () => assertPublicUrl("http://10.0.0.1/internal"),
+      /private IP|10\./i,
+    );
+  });
+
+  it("rejects URL-encoded bypass after decode (ordering contract)", async () => {
+    // Documents the decode-then-validate ordering contract;
+    // after decodeURIComponent, input equals case 1.
+    const decoded = decodeURIComponent("http://169.254.169.254%2flatest");
+    await assert.rejects(
+      () => assertPublicUrl(decoded),
+      /private IP|169\.254/i,
+    );
+  });
+
+  it("permits public IP literal (no DNS dependency)", async () => {
+    // 8.8.8.8 is a public IP literal; isIP() returns 4, isPrivateIP() returns false,
+    // so assertPublicUrl resolves without DNS lookup.
+    await assert.doesNotReject(() => assertPublicUrl("https://8.8.8.8/test"));
+  });
+
+  it("rejects composed-baseUrl with private IP", async () => {
+    // Mattermost's proxyFile composes ${baseUrl}${url} when url is a relative
+    // path. If baseUrl resolves to a private IP, the composed URL must still
+    // be rejected.
+    const composed = decodeURIComponent("http://10.0.0.5" + "/api/v4/files/abc");
+    await assert.rejects(
+      () => assertPublicUrl(composed),
+      /private IP|10\./i,
+    );
+  });
+
+  it("rejects non-http scheme (ftp://)", async () => {
+    await assert.rejects(
+      () => assertPublicUrl("ftp://internal.corp/"),
+      /unsupported scheme/i,
+    );
+  });
+
+  it("rejects IPv6 loopback ([::1])", async () => {
+    await assert.rejects(() => assertPublicUrl("http://[::1]/secret"));
+  });
+
+  it("rejects IPv6 link-local ([fe80::1])", async () => {
+    await assert.rejects(() => assertPublicUrl("http://[fe80::1]/secret"));
+  });
+
+  it("rejects IPv4-mapped IPv6 ([::ffff:127.0.0.1])", async () => {
+    await assert.rejects(() => assertPublicUrl("http://[::ffff:127.0.0.1]/secret"));
+  });
+});

--- a/bot/src/bridge.ts
+++ b/bot/src/bridge.ts
@@ -197,7 +197,7 @@ function isPrivateIP(ip: string): boolean {
   return true;
 }
 
-async function assertPublicUrl(rawUrl: string): Promise<void> {
+export async function assertPublicUrl(rawUrl: string): Promise<void> {
   let parsed: URL;
   try {
     parsed = new URL(rawUrl);
@@ -1516,7 +1516,9 @@ class MattermostBridge implements PlatformBridge {
 
   async proxyFile(url: string): Promise<{ contentType: string; buffer: Buffer }> {
     const fileUrl = url.startsWith("http") ? url : `${this.baseUrl}${url}`;
-    const response = await fetch(fileUrl, {
+    const decodedUrl = decodeURIComponent(fileUrl);
+    await assertPublicUrl(decodedUrl);
+    const response = await fetch(decodedUrl, {
       headers: { Authorization: `Bearer ${this.botToken}` },
     });
     if (!response.ok) {


### PR DESCRIPTION
## Summary

Closes #27.

`MattermostBridge.proxyFile()` fetched user-supplied URLs without calling `assertPublicUrl()`, enabling SSRF against cloud metadata (169.254.169.254), RFC1918 services, and loopback interfaces.

All four other platform bridges (Slack, Discord, Teams, Telegram) already had this guard. This patch adds the identical `decodeURIComponent` + `assertPublicUrl` pattern to the Mattermost bridge.

## Changes

- `bot/src/bridge.ts`:
  - Add `decodeURIComponent` + `await assertPublicUrl(decodedUrl)` before `fetch()` in `MattermostBridge.proxyFile` (3-line addition)
  - `export` `assertPublicUrl` (was module-private) so the URL-validation behavior is unit-testable
- `bot/src/bridge.mattermost-ssrf.test.ts`: 10 regression tests against `assertPublicUrl` covering IPv4 cloud metadata, loopback, RFC1918, URL-encoded bypass, public IP-literal pass, composed-baseUrl-with-private-IP, non-http scheme, IPv6 loopback, IPv6 link-local, IPv4-mapped IPv6

## Known Limitations

1. **Self-hosted Mattermost on private networks.** `assertPublicUrl` rejects URLs that resolve to private IPs. Self-hosted Mattermost on private networks (e.g. `https://mattermost.internal.corp/...`) will have file proxying blocked. The other four bridges target SaaS-only CDNs (Slack/Discord/Teams/Telegram) and never hit this case. Follow-up planned: operator-configured allowlist (`BEEVER_SSRF_ALLOW_PRIVATE`).
2. **Open-redirect bypass.** Node's `fetch` follows HTTP redirects by default. An open redirect on a public host could 302 to a private IP after `assertPublicUrl` validates the original hostname. This affects all five bridges equally (pre-existing). Follow-up: set `redirect: 'manual'` and re-validate the `Location` header.
3. **DNS-rebinding TOCTOU.** Inherent limitation of resolve-then-fetch SSRF guards. Mitigation requires a custom fetch Agent that pins the validated IP. Follow-up tracked.

## Test plan

- [x] Unit: cloud metadata (169.254.169.254) blocked
- [x] Unit: loopback (127.0.0.1) blocked
- [x] Unit: RFC1918 (10.0.0.1) blocked
- [x] Unit: URL-encoded bypass blocked
- [x] Unit: public URL (8.8.8.8 IP literal — no DNS) passes
- [x] Unit: composed-baseUrl-with-private-IP blocked
- [x] Unit: non-http scheme rejected
- [x] Unit: IPv6 loopback (`[::1]`) blocked
- [x] Unit: IPv6 link-local (`[fe80::1]`) blocked
- [x] Unit: IPv4-mapped IPv6 (`[::ffff:127.0.0.1]`) blocked
- [x] Local: `npm test` in `bot/` — 126/126 pass
- [x] Local: `npx tsc --noEmit` clean
- [ ] CI: full test suite green
- [ ] Manual: staging deploy + public-hosted Mattermost connection — verify file attachments still proxy via Beever UI; verify a crafted malicious URL returns an error response