### PR TITLE
chore(ci): bump github/codeql-action v3 -> v4

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,15 +24,15 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+        uses: github/codeql-action/autobuild@v4
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:${{ matrix.language }}"
           # TODO(res-206 Q1.1 follow-up): remove `upload: never` once Code


### PR DESCRIPTION
## Summary

Bumps `github/codeql-action` from v3 to v4 in `.github/workflows/codeql.yml`.

- `github/codeql-action/init@v3` → `@v4`
- `github/codeql-action/autobuild@v3` → `@v4`
- `github/codeql-action/analyze@v3` → `@v4`

Supersedes Dependabot PR #12.

## Test plan

- [ ] CI CodeQL workflow passes on this PR