### PR TITLE
chore(ci): bump action pins (setup-node v6, setup-python v6, setup-uv v7)

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -20,12 +20,12 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
 
@@ -36,7 +36,7 @@ jobs:
         run: uv run --with pip-audit pip-audit --requirement /tmp/requirements-audit.txt
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,12 +37,12 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
 
@@ -74,7 +74,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: "npm"
@@ -105,7 +105,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: "npm"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -44,12 +44,12 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v7
 
       - name: Install dependencies
         run: uv sync --extra dev --extra nebula


### PR DESCRIPTION
## Summary

Combines three Dependabot bumps that all touch overlapping workflow files into a single PR to avoid merge conflicts:

- `actions/setup-node` v4 → v6 (ci.yml, audit.yml)
- `actions/setup-python` v5 → v6 (ci.yml, audit.yml, nightly.yml)
- `astral-sh/setup-uv` v4 → v7 (ci.yml, audit.yml, nightly.yml)

Supersedes Dependabot PRs #58, #9, and #6.

## Test plan

- [ ] CI passes (Backend, Web, Bot, Supply Chain, Docker smoke, CodeQL, Security Audit)
- [ ] Only action pin lines changed in diff (no unrelated edits)
- [ ] All three workflow files updated: ci.yml, audit.yml, nightly.yml