### PR TITLE
chore(ci): bump docker/setup-buildx-action v3 -> v4

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Create .env from example
         run: cp .env.example .env


### PR DESCRIPTION
## Summary

Bumps `docker/setup-buildx-action` from v3 to v4 in `.github/workflows/smoke.yml`.

- `docker/setup-buildx-action@v3` → `@v4`

Supersedes Dependabot PR #5.

## Test plan

- [ ] CI smoke test (Docker Compose) passes on this PR