### PR TITLE
chore(deps-dev): bump @types/node to 25.6.0 in /bot

### DIFF
--- a/bot/package-lock.json
+++ b/bot/package-lock.json
@@ -19,7 +19,7 @@
         "ioredis": "^5.4.0"
       },
       "devDependencies": {
-        "@types/node": "^22.0.0",
+        "@types/node": "^25.6.0",
         "@typescript-eslint/eslint-plugin": "^8.59.0",
         "@typescript-eslint/parser": "^8.59.0",
         "eslint": "^8.57.1",
@@ -1223,12 +1223,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.19.15",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
-      "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.19.0"
       }
     },
     "node_modules/@types/retry": {
@@ -5224,9 +5224,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
       "license": "MIT"
     },
     "node_modules/unified": {

--- a/bot/package.json
+++ b/bot/package.json
@@ -23,7 +23,7 @@
     "ioredis": "^5.4.0"
   },
   "devDependencies": {
-    "@types/node": "^22.0.0",
+    "@types/node": "^25.6.0",
     "@typescript-eslint/eslint-plugin": "^8.59.0",
     "@typescript-eslint/parser": "^8.59.0",
     "eslint": "^8.57.1",


### PR DESCRIPTION
## Summary

- Bumps `@types/node` from `^22.0.0` to `^25.6.0` in `/bot`
- Type-defs only — no runtime impact
- Lockfile regenerated via `npm install` (not cherry-picked from Dependabot)
- `npx tsc --noEmit` exits 0 — no type errors introduced

Supersedes Dependabot PR #10.

## Test plan
- [x] `bot/package.json` version range updated to `^25.6.0`
- [x] `bot/package-lock.json` regenerated via `npm install`
- [x] `npx tsc --noEmit` exits 0
- [ ] CI passes on this PR