### PR TITLE
chore(deps-dev): bump typescript to 6.0.3 in /bot

### DIFF
--- a/bot/package-lock.json
+++ b/bot/package-lock.json
@@ -24,7 +24,7 @@
         "@typescript-eslint/parser": "^8.59.0",
         "eslint": "^8.57.1",
         "tsx": "^4.19.0",
-        "typescript": "^5.7.0"
+        "typescript": "6.0.3"
       }
     },
     "node_modules/@azure/msal-common": {
@@ -5201,9 +5201,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/bot/package.json
+++ b/bot/package.json
@@ -28,6 +28,6 @@
     "@typescript-eslint/parser": "^8.59.0",
     "eslint": "^8.57.1",
     "tsx": "^4.19.0",
-    "typescript": "^5.7.0"
+    "typescript": "6.0.3"
   }
 }


### PR DESCRIPTION
## Summary

Supersedes Dependabot PR #7.

- Bumps `typescript` devDependency from `^5.7.0` to `6.0.3` in `/bot`
- Lockfile regenerated via `npm install` (not cherry-picked from Dependabot)
- No source changes required — `tsc --noEmit` passes clean on TS 6

## Verification

- `npx tsc --noEmit` — exit 0
- `npm test` — all tests pass
- `npm run lint` — exit 0

## Notes

This is a replacement PR authored by the team. Once merged, PR #7 (Dependabot) can be closed.