### PR TITLE
chore(deps-dev): bump typescript to 6.0.3 in /web

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -49,7 +49,7 @@
         "globals": "^17.5.0",
         "jsdom": "^27.0.1",
         "tailwindcss": "^4.2.2",
-        "typescript": "~5.9.3",
+        "typescript": "~6.0.3",
         "typescript-eslint": "^8.59.1",
         "vite": "^8.0.9",
         "vitest": "^3.2.4"
@@ -11688,9 +11688,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "devOptional": true,
       "license": "Apache-2.0",
       "bin": {

--- a/web/package.json
+++ b/web/package.json
@@ -60,7 +60,7 @@
     "globals": "^17.5.0",
     "jsdom": "^27.0.1",
     "tailwindcss": "^4.2.2",
-    "typescript": "~5.9.3",
+    "typescript": "~6.0.3",
     "typescript-eslint": "^8.59.1",
     "vite": "^8.0.9",
     "vitest": "^3.2.4"

--- a/web/tsconfig.app.json
+++ b/web/tsconfig.app.json
@@ -23,6 +23,7 @@
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true,
+    "ignoreDeprecations": "6.0",
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]


### PR DESCRIPTION
## Summary
- Bumps `typescript` 5.9.3 → 6.0.3 in /web. Supersedes Dependabot #11 (which is dependabot-authored — keeping the contributor graph clean).
- Adds `ignoreDeprecations: "6.0"` to **both** `web/tsconfig.app.json` and `web/tsconfig.json` (root). TS 6 turned the long-deprecated `baseUrl` option into a hard error (TS5101); both files declare `baseUrl: "."` so both need the silencer.
- Lockfile regenerated via `npm install`, not cherry-picked.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — successful Vite build
- [x] `npm run lint` — 0 errors (59 pre-existing warnings unrelated to TS bump)
- [x] `npm test` — 47/47 passing
- [ ] CI: full suite green

## Follow-up
TS 7.0 will remove `baseUrl` entirely. The `ignoreDeprecations: "6.0"` flag is a temporary escape hatch — track a separate ticket to migrate path resolution off `baseUrl` (likely use `paths` + a Vite resolve.alias config or fully-qualified imports) before TS 7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)