### PR TITLE
chore(deps-dev): bump eslint-plugin-react-hooks to 7.1.1 in /web

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -44,7 +44,7 @@
         "@vitejs/plugin-react": "^6.0.1",
         "@vitest/coverage-v8": "^3.2.4",
         "eslint": "^9.39.4",
-        "eslint-plugin-react-hooks": "^7.0.1",
+        "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-refresh": "^0.5.2",
         "globals": "^17.5.0",
         "jsdom": "^27.0.1",
@@ -6250,9 +6250,9 @@
       }
     },
     "node_modules/eslint-plugin-react-hooks": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.0.1.tgz",
-      "integrity": "sha512-O0d0m04evaNzEPoSW+59Mezf8Qt0InfgGIBJnpC0h3NH/WjUAR7BIKUfysC6todmtiZ/A0oUVS8Gce0WhBrHsA==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz",
+      "integrity": "sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6266,7 +6266,7 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0"
       }
     },
     "node_modules/eslint-plugin-react-refresh": {

--- a/web/package.json
+++ b/web/package.json
@@ -55,7 +55,7 @@
     "@vitejs/plugin-react": "^6.0.1",
     "@vitest/coverage-v8": "^3.2.4",
     "eslint": "^9.39.4",
-    "eslint-plugin-react-hooks": "^7.0.1",
+    "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.5.0",
     "jsdom": "^27.0.1",

--- a/web/src/components/channel/ChatInputBar.tsx
+++ b/web/src/components/channel/ChatInputBar.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState, useEffect, useCallback } from "react";
+import React, { useRef, useState, useEffect } from "react";
 import { Send, Square, Paperclip, X, Sparkles, ChevronDown, SlidersHorizontal, Loader2 } from "lucide-react";
 import type { AnswerMode, AttachmentFile } from "../../types/askTypes";
 import type { ToolDescriptor, ToolCategory } from "../../types/toolTypes";
@@ -103,14 +103,10 @@ export function ChatInputBar({
     return () => window.removeEventListener("keydown", handler);
   }, [showToolsMenu]);
 
-  const adjustHeight = useCallback(() => {
-    const el = textareaRef.current;
-    if (!el) return;
+  const resizeTextarea = (el: HTMLTextAreaElement) => {
     el.style.height = "auto";
     el.style.height = Math.min(el.scrollHeight, 180) + "px";
-  }, []);
-
-  useEffect(() => adjustHeight(), [text, adjustHeight]);
+  };
 
   const handleSubmit = () => {
     const trimmed = text.trim();
@@ -120,7 +116,7 @@ export function ChatInputBar({
     if (!trimmed || isStreaming || disabled || uploading) return;
     onSubmit(trimmed, { mode, attachments });
     setText("");
-    if (textareaRef.current) textareaRef.current.style.height = "auto";
+    if (textareaRef.current) resizeTextarea(textareaRef.current);
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
@@ -247,7 +243,7 @@ export function ChatInputBar({
             <textarea
               ref={textareaRef}
               value={text}
-              onChange={(e) => setText(e.target.value)}
+              onChange={(e) => { setText(e.target.value); resizeTextarea(e.target); }}
               onKeyDown={handleKeyDown}
               onFocus={() => setFocused(true)}
               onBlur={() => setFocused(false)}

--- a/web/src/components/channel/MessagesTab.tsx
+++ b/web/src/components/channel/MessagesTab.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback, useMemo } from "react";
+import { useState, useEffect, useLayoutEffect, useRef, useCallback, useMemo } from "react";
 import { createPortal } from "react-dom";
 import { useParams, useOutletContext } from "react-router-dom";
 import { api } from "@/lib/api";
@@ -344,7 +344,9 @@ export function MessagesTab() {
 
   // Use ref for connectionId to avoid recreating fetchMessages on null→value transition
   const connectionIdRef = useRef(connectionId);
-  connectionIdRef.current = connectionId;
+  useLayoutEffect(() => {
+    connectionIdRef.current = connectionId;
+  });
 
   // Track previous channelId to only clear messages on actual channel change
   const prevChannelIdRef = useRef(channelId);

--- a/web/src/components/graph/GraphCanvas.tsx
+++ b/web/src/components/graph/GraphCanvas.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useLayoutEffect, useRef } from "react";
 import cytoscape, { type Core, type ElementDefinition } from "cytoscape";
 import type { GraphEntity, GraphRelationship } from "@/hooks/useGraph";
 import { getTypeColors } from "./GraphFilters";
@@ -28,7 +28,9 @@ export function GraphCanvas({
   // in cytoscape event handlers (the main useEffect doesn't include
   // onSelectEntity in its deps to avoid destroying cytoscape on every render).
   const onSelectRef = useRef(onSelectEntity);
-  onSelectRef.current = onSelectEntity;
+  useLayoutEffect(() => {
+    onSelectRef.current = onSelectEntity;
+  });
 
   // Build elements whenever data changes
   useEffect(() => {

--- a/web/src/hooks/useGlobalConversationHistory.ts
+++ b/web/src/hooks/useGlobalConversationHistory.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect, useRef } from "react";
+import { useState, useCallback, useEffect, useLayoutEffect, useRef } from "react";
 import { authFetch } from "../lib/api";
 
 const API_BASE = import.meta.env.VITE_API_URL || "http://localhost:8000";
@@ -91,7 +91,9 @@ export function useGlobalConversationHistory() {
   }, []);
 
   // Keep ref in sync so loadMore always reads the latest search query.
-  searchQueryRef.current = searchQuery;
+  useLayoutEffect(() => {
+    searchQueryRef.current = searchQuery;
+  });
 
   const loadMore = useCallback(async () => {
     if (loadingMoreRef.current) return;


### PR DESCRIPTION
## Summary
Replaces Dependabot #20 (alan5543-authored — keeps the contributor graph clean).

The 7.1 release adds correctness rules that surface real component/hook anti-patterns. This PR fixes the 5 hard errors that fired and keeps the 75 \`set-state-in-effect\` warnings as tolerated build output for a follow-up sweep.

## Refactors

| File | What changed | Rule fixed |
|---|---|---|
| \`web/src/components/graph/GraphCanvas.tsx\` | \`onSelectRef.current = onSelectEntity\` moved from render body into a \`useLayoutEffect\` | refs-in-render |
| \`web/src/components/channel/MessagesTab.tsx\` | \`connectionIdRef.current = connectionId\` moved into a \`useLayoutEffect\` | refs-in-render |
| \`web/src/hooks/useGlobalConversationHistory.ts\` | \`searchQueryRef.current = searchQuery\` moved into a \`useLayoutEffect\` | refs-in-render |
| \`web/src/components/channel/ChatInputBar.tsx\` | \`adjustHeight = useCallback(...)\` + chained \`useEffect\` replaced with a plain \`resizeTextarea(el)\` helper called explicitly on text change and submit | component-hook-factories |

## Test plan
- [x] \`npm run lint\` — 0 errors (75 pre-existing warnings unchanged)
- [x] \`npm test\` — 47/47 passing
- [x] \`npx tsc --noEmit\` — clean
- [x] \`npm run build\` — successful Vite build
- [ ] CI: full suite green

## Why no \`eslint-disable\` for these errors
The new rules detect actual render-phase side effects (writing refs during render, defining hook factories). Silencing them would mask the issues. The refactors above preserve the original semantics while satisfying the rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)