### PR TITLE
fix(reliability): PersisterAgent graceful degradation on Weaviate failure (#29)

### DIFF
--- a/src/beever_atlas/agents/ingestion/persister.py
+++ b/src/beever_atlas/agents/ingestion/persister.py
@@ -485,7 +485,8 @@ class PersisterAgent(BaseAgent):
                 if skip_graph:
                     break
                 all_media_urls = [
-                    (url, fact.source_media_type or "file") for url in (fact.source_media_urls or [])
+                    (url, fact.source_media_type or "file")
+                    for url in (fact.source_media_urls or [])
                 ] + [(url, "link") for url in (fact.source_link_urls or [])]
                 for url, mtype in all_media_urls:
                     title = ""

--- a/src/beever_atlas/agents/ingestion/persister.py
+++ b/src/beever_atlas/agents/ingestion/persister.py
@@ -29,6 +29,22 @@ from beever_atlas.models import AtomicFact, GraphEntity, GraphRelationship
 logger = logging.getLogger(__name__)
 
 
+# Shared between the Weaviate error-capture site and the
+# `mark_intent_complete` conditional so a future format change at one site
+# cannot silently break the other (Critic-flagged).
+WEAVIATE_ERROR_PREFIX = "weaviate:"
+
+
+def weaviate_failed(persist_errors: list[str]) -> bool:
+    """Return True if `persist_errors` contains a Weaviate-prefixed entry.
+
+    Used by `_run_async_impl` to gate `mark_intent_complete`: when Weaviate
+    failed, the intent must stay in `weaviate_done=False` state so the
+    `WriteReconciler` retries the Weaviate write automatically.
+    """
+    return any(err.startswith(WEAVIATE_ERROR_PREFIX) for err in persist_errors)
+
+
 def match_media_by_word_overlap(
     fact: dict[str, Any],
     preprocessed_messages: list[dict[str, Any]],
@@ -342,7 +358,7 @@ class PersisterAgent(BaseAgent):
                 batch_num,
                 results[0],
             )
-            persist_errors.append(f"weaviate: {results[0]}")
+            persist_errors.append(f"{WEAVIATE_ERROR_PREFIX} {results[0]}")
         else:
             weaviate_ids = results[0]
 
@@ -424,20 +440,29 @@ class PersisterAgent(BaseAgent):
 
         # --- 6. Batch episodic links ---
         episodic_links: list[dict[str, Any]] = []
-        for fact, weaviate_id in zip(facts, weaviate_ids, strict=True):
-            if skip_graph:
-                break
-            for entity_name in fact.entity_tags:
-                episodic_links.append(
-                    {
-                        "entity_name": entity_name,
-                        "weaviate_fact_id": weaviate_id,
-                        "message_ts": fact.message_ts,
-                        "channel_id": fact.channel_id,
-                        "media_urls": fact.source_media_urls or [],
-                        "link_urls": fact.source_link_urls or [],
-                    }
-                )
+        if weaviate_ids:
+            for fact, weaviate_id in zip(facts, weaviate_ids, strict=True):
+                if skip_graph:
+                    break
+                for entity_name in fact.entity_tags:
+                    episodic_links.append(
+                        {
+                            "entity_name": entity_name,
+                            "weaviate_fact_id": weaviate_id,
+                            "message_ts": fact.message_ts,
+                            "channel_id": fact.channel_id,
+                            "media_urls": fact.source_media_urls or [],
+                            "link_urls": fact.source_link_urls or [],
+                        }
+                    )
+        else:
+            logger.warning(
+                "PersisterAgent: skipping episodic-link cross-reference (weaviate_ids empty — Weaviate failed for %d facts) job_id=%s channel=%s batch=%s",
+                len(facts),
+                sync_job_id,
+                channel_id,
+                batch_num,
+            )
 
         if episodic_links and not skip_graph:
             try:
@@ -455,51 +480,60 @@ class PersisterAgent(BaseAgent):
         # --- 7. Batch media nodes and entity-media links ---
         media_items: list[dict[str, Any]] = []
         entity_media_links: list[dict[str, Any]] = []
-        for fact, weaviate_id in zip(facts, weaviate_ids, strict=True):
-            if skip_graph:
-                break
-            all_media_urls = [
-                (url, fact.source_media_type or "file") for url in (fact.source_media_urls or [])
-            ] + [(url, "link") for url in (fact.source_link_urls or [])]
-            for url, mtype in all_media_urls:
-                title = ""
-                if mtype == "link":
-                    idx = (
-                        (fact.source_link_urls or []).index(url)
-                        if url in (fact.source_link_urls or [])
-                        else -1
-                    )
-                    if idx >= 0 and idx < len(fact.source_link_titles or []):
-                        title = fact.source_link_titles[idx]
-                    if not title:
-                        try:
-                            parts = url.split("//")[-1].split("/")
-                            title = "/".join(parts[:3]) if len(parts) > 2 else parts[0]
-                        except Exception:
-                            title = url
-                else:
-                    media_urls_list = fact.source_media_urls or []
-                    media_names = fact.source_media_names or []
-                    if url in media_urls_list:
-                        idx = media_urls_list.index(url)
-                        if idx < len(media_names) and media_names[idx]:
-                            title = media_names[idx]
-                media_items.append(
-                    {
-                        "url": url,
-                        "media_type": mtype,
-                        "title": title,
-                        "channel_id": fact.channel_id,
-                        "message_ts": fact.message_ts,
-                    }
-                )
-                for entity_name in fact.entity_tags:
-                    entity_media_links.append(
+        if weaviate_ids:
+            for fact, weaviate_id in zip(facts, weaviate_ids, strict=True):
+                if skip_graph:
+                    break
+                all_media_urls = [
+                    (url, fact.source_media_type or "file") for url in (fact.source_media_urls or [])
+                ] + [(url, "link") for url in (fact.source_link_urls or [])]
+                for url, mtype in all_media_urls:
+                    title = ""
+                    if mtype == "link":
+                        idx = (
+                            (fact.source_link_urls or []).index(url)
+                            if url in (fact.source_link_urls or [])
+                            else -1
+                        )
+                        if idx >= 0 and idx < len(fact.source_link_titles or []):
+                            title = fact.source_link_titles[idx]
+                        if not title:
+                            try:
+                                parts = url.split("//")[-1].split("/")
+                                title = "/".join(parts[:3]) if len(parts) > 2 else parts[0]
+                            except Exception:
+                                title = url
+                    else:
+                        media_urls_list = fact.source_media_urls or []
+                        media_names = fact.source_media_names or []
+                        if url in media_urls_list:
+                            idx = media_urls_list.index(url)
+                            if idx < len(media_names) and media_names[idx]:
+                                title = media_names[idx]
+                    media_items.append(
                         {
-                            "entity_name": entity_name,
-                            "media_url": url,
+                            "url": url,
+                            "media_type": mtype,
+                            "title": title,
+                            "channel_id": fact.channel_id,
+                            "message_ts": fact.message_ts,
                         }
                     )
+                    for entity_name in fact.entity_tags:
+                        entity_media_links.append(
+                            {
+                                "entity_name": entity_name,
+                                "media_url": url,
+                            }
+                        )
+        else:
+            logger.warning(
+                "PersisterAgent: skipping media-node cross-reference (weaviate_ids empty — Weaviate failed for %d facts) job_id=%s channel=%s batch=%s",
+                len(facts),
+                sync_job_id,
+                channel_id,
+                batch_num,
+            )
 
         if media_items and not skip_graph:
             try:
@@ -512,16 +546,25 @@ class PersisterAgent(BaseAgent):
             except Exception:  # noqa: BLE001
                 logger.warning("PersisterAgent: batch_link_entities_to_media failed", exc_info=True)
 
-        # --- 6. Mark intent fully complete ---
-        await stores.mongodb.mark_intent_complete(intent_id)
-        logger.info(
-            "PersisterAgent: intent complete job_id=%s channel=%s batch=%s intent=%s episodic_links_facts=%d",
-            sync_job_id,
-            channel_id,
-            batch_num,
-            intent_id,
-            len(weaviate_ids),
-        )
+        # --- 6. Mark intent fully complete (skip if Weaviate failed; reconciler retries) ---
+        if not weaviate_failed(persist_errors):
+            await stores.mongodb.mark_intent_complete(intent_id)
+            logger.info(
+                "PersisterAgent: intent complete job_id=%s channel=%s batch=%s intent=%s episodic_links_facts=%d",
+                sync_job_id,
+                channel_id,
+                batch_num,
+                intent_id,
+                len(weaviate_ids),
+            )
+        else:
+            logger.warning(
+                "PersisterAgent: leaving intent %s pending for reconciler retry (Weaviate failed) job_id=%s channel=%s batch=%s",
+                intent_id,
+                sync_job_id,
+                channel_id,
+                batch_num,
+            )
 
         # --- 7. Write result summary via event state_delta ---
         # ADK's InMemorySessionService only persists state changes that come

--- a/tests/agents/ingestion/test_persister_weaviate_failure.py
+++ b/tests/agents/ingestion/test_persister_weaviate_failure.py
@@ -16,8 +16,6 @@ coverage without spinning up the full ADK invocation context.
 
 from __future__ import annotations
 
-import pytest
-
 from beever_atlas.agents.ingestion.persister import (
     WEAVIATE_ERROR_PREFIX,
     weaviate_failed,

--- a/tests/agents/ingestion/test_persister_weaviate_failure.py
+++ b/tests/agents/ingestion/test_persister_weaviate_failure.py
@@ -1,0 +1,100 @@
+"""Regression tests for PersisterAgent graceful Weaviate-failure handling (#29).
+
+The fix in persister.py:
+  1. Adds `WEAVIATE_ERROR_PREFIX` module constant.
+  2. Adds `weaviate_failed(persist_errors)` helper predicate.
+  3. Wraps both `zip(facts, weaviate_ids, strict=True)` loops with `if weaviate_ids:`.
+  4. Skips `mark_intent_complete` when `weaviate_failed(persist_errors)` is True
+     so the existing WriteReconciler retries the Weaviate write automatically.
+
+These tests target the predicate + constant directly. The `if weaviate_ids:`
+zip-loop guards and the `if not weaviate_failed(...)` conditional at the
+mark_intent_complete site are both small enough that the predicate test +
+the manual staging integration test (PR checklist) provide adequate
+coverage without spinning up the full ADK invocation context.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from beever_atlas.agents.ingestion.persister import (
+    WEAVIATE_ERROR_PREFIX,
+    weaviate_failed,
+)
+
+
+class TestWeaviateErrorPrefix:
+    def test_constant_value(self):
+        """The prefix must match the format used at the error-capture site."""
+        assert WEAVIATE_ERROR_PREFIX == "weaviate:"
+
+
+class TestWeaviateFailedPredicate:
+    def test_empty_errors_returns_false(self):
+        assert weaviate_failed([]) is False
+
+    def test_only_weaviate_error_returns_true(self):
+        errors = [f"{WEAVIATE_ERROR_PREFIX} RuntimeError('connection refused')"]
+        assert weaviate_failed(errors) is True
+
+    def test_only_neo4j_error_returns_false(self):
+        """Neo4j-prefixed errors must NOT trigger the Weaviate-failure path —
+        otherwise mark_intent_complete would be skipped on Neo4j-only failures
+        too, leaving Weaviate-success state inconsistent."""
+        errors = ["neo4j: ConnectionError('timeout')"]
+        assert weaviate_failed(errors) is False
+
+    def test_mixed_errors_with_weaviate_returns_true(self):
+        """If both stores failed, weaviate_failed must still return True so
+        mark_intent_complete is skipped (Weaviate write must remain retryable)."""
+        errors = [
+            f"{WEAVIATE_ERROR_PREFIX} RuntimeError('A')",
+            "neo4j: ConnectionError('B')",
+        ]
+        assert weaviate_failed(errors) is True
+
+    def test_mixed_errors_neo4j_first_still_returns_true(self):
+        """Order independence — Weaviate detection works regardless of
+        where the entry sits in the list."""
+        errors = [
+            "neo4j: ConnectionError('B')",
+            f"{WEAVIATE_ERROR_PREFIX} RuntimeError('A')",
+        ]
+        assert weaviate_failed(errors) is True
+
+    def test_unrelated_error_returns_false(self):
+        """Defensive: a generic error string must not be misclassified."""
+        errors = ["something_else: unrelated failure"]
+        assert weaviate_failed(errors) is False
+
+    def test_substring_weaviate_does_not_trigger(self):
+        """The prefix is checked with startswith, not substring match. An
+        error message that mentions 'weaviate:' mid-string must not trigger
+        the conditional."""
+        errors = ["something happened with weaviate: in the middle"]
+        assert weaviate_failed(errors) is False
+
+
+class TestErrorCaptureFormatStability:
+    """Lock in the invariant that the error-capture format at L345 of
+    persister.py begins with `WEAVIATE_ERROR_PREFIX` followed by a space.
+
+    If a future contributor changes the format string at the error-capture
+    site, the predicate at the conditional site silently breaks. This test
+    catches such drift by re-constructing the format directly.
+    """
+
+    def test_capture_format_is_detected_by_predicate(self):
+        """The actual format used at L345 is `f"{WEAVIATE_ERROR_PREFIX} {results[0]}"`.
+        Verify the resulting string is correctly classified by the predicate."""
+        sample_error = RuntimeError("Weaviate batch upsert failed")
+        captured = f"{WEAVIATE_ERROR_PREFIX} {sample_error}"
+        assert weaviate_failed([captured]) is True
+
+    def test_capture_format_starts_with_constant(self):
+        """The captured string must literally begin with the constant value
+        (no leading whitespace, no other prefix)."""
+        sample_error = RuntimeError("oops")
+        captured = f"{WEAVIATE_ERROR_PREFIX} {sample_error}"
+        assert captured.startswith(WEAVIATE_ERROR_PREFIX)


### PR DESCRIPTION
## Summary

Closes #29.

When Weaviate is unreachable, `WeaviateStore.batch_upsert_facts()` raises `RuntimeError`. The `asyncio.gather(..., return_exceptions=True)` block at L330 catches this and leaves `weaviate_ids = []`, but two downstream `zip(facts, weaviate_ids, strict=True)` calls then raised `ValueError`, crashing the persister mid-batch.

## Changes

- **`src/beever_atlas/agents/ingestion/persister.py`**:
  - Guard both zip loops (L427 episodic-links, L458 media-nodes) with `if weaviate_ids:`. Skip cross-reference creation + log warning on Weaviate failure.
  - Skip `mark_intent_complete` when `persist_errors` contains a `WEAVIATE_ERROR_PREFIX` entry. Intent stays in `weaviate_done=False` state; existing `WriteReconciler` retries the Weaviate write automatically.
  - Always emit `persist_result` event (callers learn the outcome).
  - Introduce module-level `WEAVIATE_ERROR_PREFIX` constant + `weaviate_failed()` helper so error-capture (L345) and conditional check (L516) cannot drift.

- **`tests/agents/ingestion/test_persister_weaviate_failure.py`** (new): 10 regression tests covering the constant, the predicate (empty/weaviate-only/neo4j-only/mixed/order-independence/substring-not-startswith/unrelated), and the error-capture format stability.

## Why we don't `mark_intent_complete` on failure

`mark_intent_complete` sets both `weaviate_done=True` and `neo4j_done=True` unconditionally. Calling it after Weaviate failure would lie to the reconciler — `get_pending_intents` (filters `weaviate_done=False OR neo4j_done=False`) would never return this intent, and the Weaviate write would be **permanently lost** on transient outages.

By keeping the intent in `weaviate_done=False`, the existing `WriteReconciler` retries `batch_upsert_facts` until Weaviate recovers. No schema change needed.

## Known Limitations

- Episodic links and media nodes are NOT recreated when Weaviate fails. The reconciler retries `batch_upsert_facts` but doesn't call back into `PersisterAgent`, so cross-references are permanently lost. Pre-existing.
- Intent stays pending forever if Weaviate never recovers. Operator intervention needed for truly dead intents. Tracked as follow-up.
- `mark_intent_complete` at L516 also masks Neo4j failures (pre-existing — only Weaviate is gated here). Tracked as follow-up.

## Test plan

- [x] Unit: predicate detects Weaviate-prefixed errors, ignores Neo4j-only / unrelated errors
- [x] Unit: prefix constant matches the format used at error-capture site
- [x] Unit: order independence in mixed-error lists
- [x] Unit: startswith (not substring) — "weaviate:" mid-string doesn't trigger
- [x] Local: `pytest tests/agents/ingestion/test_persister_weaviate_failure.py -v` — 10/10 pass
- [x] Local: `ruff check src/beever_atlas/agents/ingestion/persister.py` — clean
- [ ] CI: full suite green
- [ ] Manual: staging deploy → `docker compose stop weaviate` → trigger sync → verify no crash, intent stays pending → `docker compose start weaviate` → wait one reconciler interval → verify intent transitions to `weaviate_done=True`

## Follow-ups (separate issues)

1. Add `weaviate_error: str | None` field to `WriteIntent` + `mark_intent_weaviate_failed()` method for error-aware reconciliation
2. Cross-reference backfill (episodic links + media nodes lost on Weaviate failure)
3. Max-retry counter / retry-deadline on `WriteIntent`
4. Symmetric Neo4j-failure handling (`mark_intent_complete` masks Neo4j failures too — pre-existing)