### PR TITLE
fix(webhooks): drain buffered requests after adapter rebuild (#30)

### DIFF
--- a/bot/src/chat-manager.ts
+++ b/bot/src/chat-manager.ts
@@ -47,6 +47,7 @@ export class ChatManager {
   private redisUrl: string;
   private transitioning: boolean = false;
   private rebuildListeners: Array<() => void> = [];
+  private rebuildCompleteListeners: Array<() => void> = [];
   /** Maps workspace identifiers to connectionId for URL-based routing.
    *  e.g. Slack team_id "T0APJ2FNUKZ" → connectionId "abc-123" */
   private workspaceIdMap: Map<string, string> = new Map();
@@ -113,119 +114,134 @@ export class ChatManager {
     }
   }
 
+  /** Register a callback invoked AFTER each rebuild completes (success, no-adapters, or error).
+   *  Distinct from `onRebuild`, which fires at rebuild START (used by bridge.ts for cache
+   *  invalidation). Used by WebhookBuffer to drain buffered requests once the new bot is ready. */
+  onRebuildComplete(listener: () => void): void {
+    this.rebuildCompleteListeners.push(listener);
+  }
+
+  private notifyRebuildCompleteListeners(): void {
+    for (const fn of this.rebuildCompleteListeners) {
+      try { fn(); } catch { /* listener errors must not break rebuild */ }
+    }
+  }
+
   async rebuild(): Promise<void> {
     this.transitioning = true;
     this.notifyRebuildListeners();
 
-    if (this.currentBot) {
-      try {
-        await this.currentBot.shutdown();
-      } catch (err: unknown) {
-        console.warn("ChatManager: error during shutdown:", err);
-      }
-      this.currentBot = null;
-    }
-
-    if (this.adapters.size === 0) {
-      console.log("ChatManager: no adapters registered, bot is offline");
-      this.transitioning = false;
-      return;
-    }
-
-    // Build fresh adapter instances from stored configs.
-    // The composite key is used as the Chat SDK adapter key.
-    // Platform is extracted from the entry for factory selection.
-    // Required credential keys per platform — entries missing any of these are
-    // skipped so a single broken connection cannot take down the entire bot.
-    const REQUIRED_CREDENTIALS: Record<string, string[]> = {
-      slack: ["botToken", "signingSecret"],
-      discord: ["botToken", "publicKey", "applicationId"],
-      teams: ["appId", "appPassword"],
-      telegram: ["botToken"],
-      mattermost: ["baseUrl", "botToken"],
-    };
-
-    const adapterInstances: Record<string, unknown> = {};
-
-    for (const [key, entry] of this.adapters.entries()) {
-      const required = REQUIRED_CREDENTIALS[entry.platform];
-      if (required) {
-        const missing = required.filter((k) => !entry.config[k]);
-        if (missing.length > 0) {
-          console.warn(`ChatManager: skipping "${key}" — missing required credentials: ${missing.join(", ")}`);
-          continue;
+    try {
+      if (this.currentBot) {
+        try {
+          await this.currentBot.shutdown();
+        } catch (err: unknown) {
+          console.warn("ChatManager: error during shutdown:", err);
         }
+        this.currentBot = null;
       }
 
-      try {
-        if (entry.platform === "slack") {
-          const slackAdapter = createSlackAdapter({
-            botToken: entry.config.botToken,
-            signingSecret: entry.config.signingSecret,
-          });
-          adapterInstances[key] = slackAdapter;
-          // Cache team_id → connectionId for URL-based file routing
-          try {
-            const authResult = await (slackAdapter as any).client.auth.test();
-            if (authResult?.team_id) {
-              this.workspaceIdMap.set(authResult.team_id, entry.connectionId);
-              console.log(`ChatManager: cached Slack team_id=${authResult.team_id} → connection=${entry.connectionId}`);
+      if (this.adapters.size === 0) {
+        console.log("ChatManager: no adapters registered, bot is offline");
+        return;
+      }
+
+      // Build fresh adapter instances from stored configs.
+      // The composite key is used as the Chat SDK adapter key.
+      // Platform is extracted from the entry for factory selection.
+      // Required credential keys per platform — entries missing any of these are
+      // skipped so a single broken connection cannot take down the entire bot.
+      const REQUIRED_CREDENTIALS: Record<string, string[]> = {
+        slack: ["botToken", "signingSecret"],
+        discord: ["botToken", "publicKey", "applicationId"],
+        teams: ["appId", "appPassword"],
+        telegram: ["botToken"],
+        mattermost: ["baseUrl", "botToken"],
+      };
+
+      const adapterInstances: Record<string, unknown> = {};
+
+      for (const [key, entry] of this.adapters.entries()) {
+        const required = REQUIRED_CREDENTIALS[entry.platform];
+        if (required) {
+          const missing = required.filter((k) => !entry.config[k]);
+          if (missing.length > 0) {
+            console.warn(`ChatManager: skipping "${key}" — missing required credentials: ${missing.join(", ")}`);
+            continue;
+          }
+        }
+
+        try {
+          if (entry.platform === "slack") {
+            const slackAdapter = createSlackAdapter({
+              botToken: entry.config.botToken,
+              signingSecret: entry.config.signingSecret,
+            });
+            adapterInstances[key] = slackAdapter;
+            // Cache team_id → connectionId for URL-based file routing
+            try {
+              const authResult = await (slackAdapter as any).client.auth.test();
+              if (authResult?.team_id) {
+                this.workspaceIdMap.set(authResult.team_id, entry.connectionId);
+                console.log(`ChatManager: cached Slack team_id=${authResult.team_id} → connection=${entry.connectionId}`);
+              }
+            } catch (err) {
+              console.warn(`ChatManager: auth.test failed for "${key}", file routing may be degraded:`, err);
             }
-          } catch (err) {
-            console.warn(`ChatManager: auth.test failed for "${key}", file routing may be degraded:`, err);
+          } else if (entry.platform === "discord") {
+            const discordOpts: Record<string, unknown> = {
+              botToken: entry.config.botToken,
+              publicKey: entry.config.publicKey,
+              applicationId: entry.config.applicationId,
+            };
+            if (entry.config.mentionRoleIds) {
+              discordOpts.mentionRoleIds = String(entry.config.mentionRoleIds).split(",").map((s: string) => s.trim()).filter(Boolean);
+            }
+            adapterInstances[key] = createDiscordAdapter(discordOpts);
+          } else if (entry.platform === "teams") {
+            adapterInstances[key] = createTeamsAdapter({
+              appId: entry.config.appId,
+              appPassword: entry.config.appPassword,
+              appTenantId: entry.config.appTenantId,
+              appType: entry.config.appType as "MultiTenant" | "SingleTenant" | undefined,
+            });
+          } else if (entry.platform === "telegram") {
+            adapterInstances[key] = createTelegramAdapter({
+              botToken: entry.config.botToken,
+              secretToken: entry.config.secretToken,
+            });
+          } else if (entry.platform === "mattermost") {
+            adapterInstances[key] = createMattermostAdapter({
+              baseUrl: entry.config.baseUrl,
+              botToken: entry.config.botToken,
+            });
+          } else {
+            console.warn(`ChatManager: unknown platform "${entry.platform}", skipping`);
           }
-        } else if (entry.platform === "discord") {
-          const discordOpts: Record<string, unknown> = {
-            botToken: entry.config.botToken,
-            publicKey: entry.config.publicKey,
-            applicationId: entry.config.applicationId,
-          };
-          if (entry.config.mentionRoleIds) {
-            discordOpts.mentionRoleIds = String(entry.config.mentionRoleIds).split(",").map((s: string) => s.trim()).filter(Boolean);
-          }
-          adapterInstances[key] = createDiscordAdapter(discordOpts);
-        } else if (entry.platform === "teams") {
-          adapterInstances[key] = createTeamsAdapter({
-            appId: entry.config.appId,
-            appPassword: entry.config.appPassword,
-            appTenantId: entry.config.appTenantId,
-            appType: entry.config.appType as "MultiTenant" | "SingleTenant" | undefined,
-          });
-        } else if (entry.platform === "telegram") {
-          adapterInstances[key] = createTelegramAdapter({
-            botToken: entry.config.botToken,
-            secretToken: entry.config.secretToken,
-          });
-        } else if (entry.platform === "mattermost") {
-          adapterInstances[key] = createMattermostAdapter({
-            baseUrl: entry.config.baseUrl,
-            botToken: entry.config.botToken,
-          });
-        } else {
-          console.warn(`ChatManager: unknown platform "${entry.platform}", skipping`);
+        } catch (err) {
+          console.error(`ChatManager: failed to create adapter for "${key}":`, err);
         }
-      } catch (err) {
-        console.error(`ChatManager: failed to create adapter for "${key}":`, err);
       }
-    }
 
-    if (Object.keys(adapterInstances).length === 0) {
-      console.warn("ChatManager: no valid adapters could be created");
+      if (Object.keys(adapterInstances).length === 0) {
+        console.warn("ChatManager: no valid adapters could be created");
+        return;
+      }
+
+      const newBot = new Chat({
+        userName: "beever",
+        adapters: adapterInstances as Record<string, import("chat").Adapter>,
+        state: createRedisState({ url: this.redisUrl }),
+      });
+
+      this.registerHandlers(newBot);
+      this.currentBot = newBot;
+
+      console.log(`ChatManager: bot rebuilt with adapters: ${Object.keys(adapterInstances).join(", ")}`);
+    } finally {
       this.transitioning = false;
-      return;
+      this.notifyRebuildCompleteListeners();
     }
-
-    const newBot = new Chat({
-      userName: "beever",
-      adapters: adapterInstances as Record<string, import("chat").Adapter>,
-      state: createRedisState({ url: this.redisUrl }),
-    });
-
-    this.registerHandlers(newBot);
-    this.currentBot = newBot;
-    this.transitioning = false;
-
-    console.log(`ChatManager: bot rebuilt with adapters: ${Object.keys(adapterInstances).join(", ")}`);
   }
 
   getCurrentBot(): Chat | null {

--- a/bot/src/index.ts
+++ b/bot/src/index.ts
@@ -371,26 +371,31 @@ function startServer(chatManager: ChatManager): void {
   const handleBridge = registerBridgeRoutes(chatManager, () => lazySyncIfNeeded(chatManager));
   const webhookBuffer = new WebhookBuffer(chatManager);
 
-  const server = createServer(async (req: IncomingMessage, res: ServerResponse) => {
-    // Health check
-    if (req.method === "GET" && req.url === "/health") {
-      jsonResponse(res, 200, {
-        status: "ok",
-        adapters: chatManager.listAdapters(),
-        transitioning: chatManager.isTransitioning(),
-      });
-      return;
-    }
-
-    // Bridge endpoints (Chat SDK data fetching for Python backend)
-    if (req.url?.startsWith("/bridge/")) {
-      await handleBridge(req, res);
-      return;
-    }
-
-    // Buffer webhook requests during Chat instance transitions
-    if (webhookBuffer.shouldBuffer()) {
-      await webhookBuffer.enqueue(req, res);
+  /**
+   * Routes a webhook request to the right per-platform / per-connection handler.
+   *
+   * Used by both:
+   *   1. The HTTP server callback for live requests
+   *   2. WebhookBuffer.drain() for replayed requests after a chat-manager rebuild
+   *
+   * For replayed requests: Node's IncomingMessage stays paused after enqueue
+   * (no `data` listener was attached), so internally-buffered chunks remain
+   * available when readBody() attaches its listeners during drain. Slow / large
+   * payloads where data is still arriving when drain fires continue to stream
+   * through normally. Client disconnects during the buffer window are caught
+   * by the req.destroyed guard at the top.
+   */
+  async function handleWebhookRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    if (req.destroyed) {
+      // Client disconnected during the buffer window — short-circuit to avoid
+      // attaching listeners to a dead stream. drain() will resolve the queue
+      // entry's promise via .finally().
+      try {
+        res.writeHead(204);
+        res.end();
+      } catch {
+        // res may also be destroyed (shared socket); ignore
+      }
       return;
     }
 
@@ -421,6 +426,39 @@ function startServer(chatManager: ChatManager): void {
 
     res.writeHead(404);
     res.end("Not Found");
+  }
+
+  // Drain buffered webhooks after each rebuild completes (#30).
+  // drain() returns void; per-entry handler errors are caught internally
+  // by WebhookBuffer.drain() and reported via the entry's .finally() block.
+  chatManager.onRebuildComplete(() => {
+    webhookBuffer.drain(handleWebhookRequest);
+  });
+
+  const server = createServer(async (req: IncomingMessage, res: ServerResponse) => {
+    // Health check
+    if (req.method === "GET" && req.url === "/health") {
+      jsonResponse(res, 200, {
+        status: "ok",
+        adapters: chatManager.listAdapters(),
+        transitioning: chatManager.isTransitioning(),
+      });
+      return;
+    }
+
+    // Bridge endpoints (Chat SDK data fetching for Python backend)
+    if (req.url?.startsWith("/bridge/")) {
+      await handleBridge(req, res);
+      return;
+    }
+
+    // Buffer webhook requests during Chat instance transitions
+    if (webhookBuffer.shouldBuffer()) {
+      await webhookBuffer.enqueue(req, res);
+      return;
+    }
+
+    await handleWebhookRequest(req, res);
   });
 
   server.listen(PORT, () => {

--- a/bot/src/webhook-buffer.test.ts
+++ b/bot/src/webhook-buffer.test.ts
@@ -1,5 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "node:assert";
+import { Readable } from "node:stream";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { WebhookBuffer } from "./webhook-buffer.js";
 import type { ChatManager } from "./chat-manager.js";
@@ -209,5 +210,120 @@ describe("WebhookBuffer — maxDuration timeout", () => {
     await buf.enqueue(makeMockReq(), makeMockRes() as unknown as ServerResponse);
 
     assert.strictEqual(buf.queueSize(), 0);
+  });
+});
+
+// ── onRebuildComplete wiring (#30) ─────────────────────────────────────────────
+
+/** ChatManager stub that supports both isTransitioning() and onRebuildComplete().
+ *  Tests register listeners and trigger them via fireRebuildComplete(). */
+function makeRebuildAwareChatManager(initiallyTransitioning: boolean): {
+  manager: ChatManager;
+  setTransitioning(value: boolean): void;
+  fireRebuildComplete(): void;
+} {
+  let transitioning = initiallyTransitioning;
+  const listeners: Array<() => void> = [];
+  const manager = {
+    isTransitioning: () => transitioning,
+    onRebuildComplete: (listener: () => void) => {
+      listeners.push(listener);
+    },
+  } as unknown as ChatManager;
+  return {
+    manager,
+    setTransitioning(value) { transitioning = value; },
+    fireRebuildComplete() { for (const l of listeners) l(); },
+  };
+}
+
+describe("WebhookBuffer — onRebuildComplete wiring (#30)", () => {
+  it("drain fires when the registered onRebuildComplete listener is invoked", async () => {
+    const stub = makeRebuildAwareChatManager(true);
+    const buf = new WebhookBuffer(stub.manager);
+
+    const handledReqs: IncomingMessage[] = [];
+    const handler = async (req: IncomingMessage, _res: ServerResponse) => {
+      handledReqs.push(req);
+    };
+
+    // Production wiring: index.ts registers this once at startup.
+    stub.manager.onRebuildComplete(() => buf.drain(handler));
+
+    // Two requests arrive during the transition and get buffered.
+    const req1 = makeMockReq();
+    const req2 = makeMockReq();
+    const p1 = buf.enqueue(req1, makeMockRes() as unknown as ServerResponse);
+    const p2 = buf.enqueue(req2, makeMockRes() as unknown as ServerResponse);
+
+    assert.strictEqual(buf.queueSize(), 2);
+
+    // Rebuild completes; the listener fires and drains the queue.
+    stub.setTransitioning(false);
+    stub.fireRebuildComplete();
+
+    await Promise.all([p1, p2]);
+
+    assert.strictEqual(handledReqs.length, 2);
+    assert.strictEqual(buf.queueSize(), 0);
+  });
+
+  it("drain is a no-op with empty queue", () => {
+    const stub = makeRebuildAwareChatManager(false);
+    const buf = new WebhookBuffer(stub.manager);
+
+    let handlerCalled = false;
+    const handler = async () => { handlerCalled = true; };
+
+    stub.manager.onRebuildComplete(() => buf.drain(handler));
+    stub.fireRebuildComplete();
+
+    assert.strictEqual(handlerCalled, false);
+    assert.strictEqual(buf.queueSize(), 0);
+  });
+});
+
+// ── Body-stream replay (Architect Patch 1) ─────────────────────────────────────
+
+/** Mirror of bot/src/index.ts readBody() for testing the drain-replay path.
+ *  Verifies that a paused IncomingMessage stream still delivers buffered chunks
+ *  when a `data` listener is attached after enqueue (during drain). */
+function readBodyForTest(req: IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let data = "";
+    req.on("data", (chunk: Buffer) => { data += chunk.toString(); });
+    req.on("end", () => resolve(data));
+    req.on("error", reject);
+  });
+}
+
+describe("WebhookBuffer — body-stream replay survives enqueue (#30)", () => {
+  it("readBody can consume the body of a buffered IncomingMessage during drain", async () => {
+    const stub = makeRebuildAwareChatManager(true);
+    const buf = new WebhookBuffer(stub.manager);
+
+    const payload = JSON.stringify({ type: "url_verification", challenge: "abc123" });
+    // Readable.from() produces a paused readable stream — same model as
+    // an IncomingMessage in a createServer callback.
+    const mockReq = Readable.from([Buffer.from(payload)]) as unknown as IncomingMessage;
+    Object.assign(mockReq, { method: "POST", url: "/api/slack" });
+
+    let receivedBody: string | undefined;
+    const handler = async (req: IncomingMessage, _res: ServerResponse) => {
+      // Production handler chain calls readBody() — verify it works on a
+      // request that was enqueued (paused) before the drain.
+      receivedBody = await readBodyForTest(req);
+    };
+
+    stub.manager.onRebuildComplete(() => buf.drain(handler));
+
+    const enqueuePromise = buf.enqueue(mockReq, makeMockRes() as unknown as ServerResponse);
+
+    stub.setTransitioning(false);
+    stub.fireRebuildComplete();
+
+    await enqueuePromise;
+
+    assert.strictEqual(receivedBody, payload);
   });
 });


### PR DESCRIPTION
## Summary

Closes #30.

`WebhookBuffer.enqueue()` was called during `ChatManager` adapter rebuilds but `drain()` was never invoked. All buffered webhooks hit the 5-second safety timeout and 503'd — breaking Slack URL verification, Discord interactions, and ordinary message events on every workspace add/remove.

## Changes

- **`bot/src/chat-manager.ts`**:
  - New `onRebuildComplete(listener)` API — distinct from the existing `onRebuild` which fires at rebuild **start** (used by `bridge.ts` for cache invalidation). The new hook fires at rebuild **end** in all exit paths (success, no-adapters, error).
  - `rebuild()` body wrapped in `try { ... } finally { transitioning = false; notifyRebuildCompleteListeners(); }` so the post-rebuild callback fires even on uncaught exceptions during adapter creation.
- **`bot/src/index.ts`**:
  - Extracts the URL-based webhook routing into `handleWebhookRequest(req, res)`. Used by both the live HTTP path AND the drain replay path.
  - Adds a `req.destroyed` guard at the top of the extracted handler — Slack's ~3-second client timeout is shorter than the 5-second buffer window, so client disconnects during the buffer can leave a destroyed request in the queue.
  - Registers `chatManager.onRebuildComplete(() => webhookBuffer.drain(handleWebhookRequest))` once at startup.
- **`bot/src/webhook-buffer.test.ts`**: 3 new test cases covering the wiring (drain-fires-on-listener, empty-queue-noop) and the body-stream replay invariant (Node's paused `IncomingMessage` still delivers buffered chunks when `readBody` attaches data listeners during drain).

## Why a separate `onRebuildComplete` hook

The existing `onRebuild` listener fires at `transitioning = true` (rebuild START) and is used by `bridge.ts:2196` to clear the bridge cache before the new adapters appear. Reusing it for drain would replay requests against a null bot. Moving it post-rebuild would break the bridge cache-invalidation timing. A second hook is the minimal correct fix.

## Test plan

- [x] Unit: `drain` is called when the registered `onRebuildComplete` listener fires
- [x] Unit: `drain` is a no-op with empty queue
- [x] Unit: body-stream replay — buffered `IncomingMessage` survives drain through `readBody`
- [x] Local: `npm test` in `bot/` — 136/136 pass
- [x] Local: `npx tsc --noEmit` clean
- [ ] CI: full suite green
- [ ] Manual: staging deploy, send webhook during a rebuild (`docker compose restart bot` or trigger workspace add/remove), verify the request replays with 200 instead of timing out at 503

## Follow-ups (separate issues)

1. Rename `onRebuild` → `onRebuildStart` for symmetry with `onRebuildComplete` (touches `bridge.ts`)
2. Configurable buffer `maxDurationMs` for slow rebuilds in production (currently hardcoded 5s)
3. Persistent buffer queue (currently in-memory; lost on bot restart)