### PR TITLE
fix(stores): align NullGraphStore.delete_channel_data keys with protocol (#33)

### DIFF
--- a/src/beever_atlas/stores/null_graph.py
+++ b/src/beever_atlas/stores/null_graph.py
@@ -150,7 +150,14 @@ class NullGraphStore:
     # ------------------------------------------------------------------
 
     async def delete_channel_data(self, channel_id: str) -> dict[str, int]:
-        return {"entities": 0, "relationships": 0, "events": 0, "media": 0}
+        # Issue #33 — match the GraphStore protocol's `*_deleted` keys used
+        # by Neo4jStore / NebulaStore / MockGraphStore. The previous
+        # `{entities, relationships, events, media}` shape caused KeyError
+        # in any caller that read `result["entities_deleted"]` (e.g.
+        # api/channels.py:552 spreads the dict into a response). Neo4j
+        # uses DETACH DELETE so it has no separate `relationships_deleted`
+        # key — the null shape mirrors that.
+        return {"entities_deleted": 0, "events_deleted": 0, "media_deleted": 0}
 
     # ------------------------------------------------------------------
     # Entity-registry support

--- a/tests/stores/test_null_graph_delete_keys.py
+++ b/tests/stores/test_null_graph_delete_keys.py
@@ -1,0 +1,43 @@
+"""Regression test for issue #33 — NullGraphStore.delete_channel_data
+must return the canonical `*_deleted` key shape used by the GraphStore
+protocol and the real implementations (Neo4j, Nebula).
+
+The pre-fix shape `{entities, relationships, events, media}` caused
+KeyError in callers that read `result["entities_deleted"]` (e.g.
+api/channels.py spreads the dict into the response payload).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from beever_atlas.stores.null_graph import NullGraphStore
+
+
+@pytest.mark.asyncio
+async def test_null_graph_delete_returns_canonical_keys() -> None:
+    """delete_channel_data must return exactly the protocol's `*_deleted`
+    keys with int zero values — no `entities`, no `relationships`."""
+    store = NullGraphStore()
+    result = await store.delete_channel_data("any-channel")
+
+    expected_keys = {"entities_deleted", "events_deleted", "media_deleted"}
+    assert set(result.keys()) == expected_keys, (
+        f"NullGraphStore returned {set(result.keys())}, "
+        f"expected {expected_keys} to match Neo4j/Nebula protocol"
+    )
+    assert all(isinstance(v, int) and v == 0 for v in result.values())
+
+
+@pytest.mark.asyncio
+async def test_null_graph_delete_no_keyerror_on_canonical_lookup() -> None:
+    """The originally-reported failure mode: callers do
+    `result["entities_deleted"]` and KeyError when the key is just
+    `entities`. After the fix, that lookup succeeds."""
+    store = NullGraphStore()
+    result = await store.delete_channel_data("any-channel")
+
+    # These must NOT raise.
+    assert result["entities_deleted"] == 0
+    assert result["events_deleted"] == 0
+    assert result["media_deleted"] == 0


### PR DESCRIPTION
## Summary

Closes #33.

\`NullGraphStore.delete_channel_data\` returned \`{"entities", "relationships", "events", "media"}\` while \`Neo4jStore\`, \`NebulaStore\`, and \`MockGraphStore\` all return \`{"entities_deleted", "events_deleted", "media_deleted"}\`. Any caller that read \`result["entities_deleted"]\` got a \`KeyError\` when \`GRAPH_BACKEND=none\`.

\`api/channels.py:552\` spreads the dict into the response payload, so the inconsistency also leaks into the public API shape — clients see different field names depending on backend.

## Changes

- \`src/beever_atlas/stores/null_graph.py\`: drop \`relationships\` (Neo4j uses DETACH DELETE — no separate count); match the canonical 3-key \`*_deleted\` shape used by Neo4j/Nebula/MockGraphStore.
- \`tests/stores/test_null_graph_delete_keys.py\` (new): 2 regression tests
  - Keyset equals the canonical \`{entities_deleted, events_deleted, media_deleted}\`
  - \`result["entities_deleted"]\` etc. no longer \`KeyError\`

## Verified consumer

\`api/channels.py:552\` does \`results.update(neo4j_results)\` — keys flow through unchanged. After this fix, the response shape is uniform across all 3 backends.

## Test plan

- [x] \`uv run ruff format --check src/ tests/\` — clean (377 files)
- [x] \`uv run ruff check src/ tests/\` — clean
- [x] \`uv run python -m pytest tests/stores/test_null_graph_delete_keys.py -v\` — 2/2 pass
- [ ] CI: full suite green