### PR TITLE
fix(security): bind bot bridge to localhost + gate BRIDGE_ALLOW_UNAUTH on dev only (#34)

### DIFF
--- a/bot/src/bridge.auth.test.ts
+++ b/bot/src/bridge.auth.test.ts
@@ -7,7 +7,8 @@
  * - Wrong token → 401
  * - Correct token → 200 (proceeds to handler)
  * - BRIDGE_API_KEY unset AND BRIDGE_ALLOW_UNAUTH unset → 401
- * - BRIDGE_API_KEY unset AND BRIDGE_ALLOW_UNAUTH="true" → allowed + loud warn
+ * - BRIDGE_API_KEY unset AND BRIDGE_ALLOW_UNAUTH="true" AND BEEVER_ENV="development" → allowed + loud warn
+ * - BRIDGE_API_KEY unset AND BRIDGE_ALLOW_UNAUTH="true" AND BEEVER_ENV unset/staging → STILL 401 (issue #34)
  * - Non-"true" strings for BRIDGE_ALLOW_UNAUTH ("TRUE", "1", "yes") → still closed
  * - BRIDGE_API_KEY set AND BRIDGE_ALLOW_UNAUTH="true" → key wins (opt-in ignored)
  */
@@ -97,11 +98,44 @@ describe("checkAuth — bridge auth enforcement (M1)", () => {
     assert.equal(res.statusCode, 401);
   });
 
-  it("allows request when BRIDGE_API_KEY unset and BRIDGE_ALLOW_UNAUTH=\"true\"", () => {
+  it("allows request when BRIDGE_API_KEY unset, BRIDGE_ALLOW_UNAUTH=\"true\", AND BEEVER_ENV=\"development\"", () => {
     process.env.BRIDGE_ALLOW_UNAUTH = "true";
+    process.env.BEEVER_ENV = "development";
     const res = makeRes();
     const ok = checkAuth(makeReq() as IncomingMessage, res as unknown as ServerResponse);
     assert.equal(ok, true);
+  });
+
+  // Issue #34 — BRIDGE_ALLOW_UNAUTH must require an explicit BEEVER_ENV=development
+  // marker. Without it, an operator who set the flag on staging or in their CI
+  // pipeline would have run the bridge wide-open. The flag is now silently
+  // ignored unless dev is the explicit env.
+  it("issue #34: BRIDGE_ALLOW_UNAUTH=\"true\" with no BEEVER_ENV → still 401", () => {
+    process.env.BRIDGE_ALLOW_UNAUTH = "true";
+    // BEEVER_ENV intentionally not set
+    const res = makeRes();
+    const ok = checkAuth(makeReq() as IncomingMessage, res as unknown as ServerResponse);
+    assert.equal(ok, false, "without BEEVER_ENV=development the unauth flag must be ignored");
+    assert.equal(res.statusCode, 401);
+  });
+
+  it("issue #34: BRIDGE_ALLOW_UNAUTH=\"true\" with BEEVER_ENV=\"staging\" → still 401", () => {
+    process.env.BRIDGE_ALLOW_UNAUTH = "true";
+    process.env.BEEVER_ENV = "staging";
+    const res = makeRes();
+    const ok = checkAuth(makeReq() as IncomingMessage, res as unknown as ServerResponse);
+    assert.equal(ok, false, "non-development envs must not honor the unauth flag");
+    assert.equal(res.statusCode, 401);
+  });
+
+  it("issue #34: BRIDGE_ALLOW_UNAUTH=\"true\" with NODE_ENV=\"development\" only → still 401", () => {
+    // The gate is BEEVER_ENV specifically, not the generic NODE_ENV.
+    process.env.BRIDGE_ALLOW_UNAUTH = "true";
+    process.env.NODE_ENV = "development";
+    const res = makeRes();
+    const ok = checkAuth(makeReq() as IncomingMessage, res as unknown as ServerResponse);
+    assert.equal(ok, false, "BEEVER_ENV is the explicit dev marker, NODE_ENV is not");
+    assert.equal(res.statusCode, 401);
   });
 
   for (const variant of ["TRUE", "True", "1", "yes", " true"]) {
@@ -164,8 +198,9 @@ describe("assertBridgeAuthReady — startup warning for explicit opt-in", () => 
     resetEnv();
   });
 
-  it("emits a loud warning when running unauthenticated via opt-in", () => {
+  it("emits a loud warning when running unauthenticated via opt-in (with BEEVER_ENV=development)", () => {
     process.env.BRIDGE_ALLOW_UNAUTH = "true";
+    process.env.BEEVER_ENV = "development";
     const captured: string[] = [];
     const originalWarn = console.warn;
     console.warn = (...args: unknown[]) => {
@@ -181,8 +216,35 @@ describe("assertBridgeAuthReady — startup warning for explicit opt-in", () => 
       "expected warning to contain BRIDGE_ALLOW_UNAUTH=true",
     );
     assert.ok(
-      captured.some((m) => m.includes("Do NOT use in production")),
-      "expected warning to contain a production-use caution",
+      captured.some((m) => m.includes("Do NOT use in staging or production")),
+      "expected warning to contain a staging/production-use caution",
+    );
+  });
+
+  // Issue #34 — when the operator sets BRIDGE_ALLOW_UNAUTH=true but
+  // doesn't explicitly mark the env as development, the flag is ignored
+  // at request time. Surface that loudly at startup so they don't think
+  // they've bypassed auth when in fact every request will 401.
+  it("issue #34: warns that flag is IGNORED when BEEVER_ENV is not development", () => {
+    process.env.BRIDGE_ALLOW_UNAUTH = "true";
+    // BEEVER_ENV intentionally not set
+    const captured: string[] = [];
+    const originalWarn = console.warn;
+    console.warn = (...args: unknown[]) => {
+      captured.push(args.map((a) => String(a)).join(" "));
+    };
+    try {
+      assertBridgeAuthReady();
+    } finally {
+      console.warn = originalWarn;
+    }
+    assert.ok(
+      captured.some((m) => m.includes("IGNORED")),
+      "expected warning to clearly state the flag is being ignored",
+    );
+    assert.ok(
+      captured.some((m) => m.includes("BEEVER_ENV=development")),
+      "expected warning to point at the BEEVER_ENV gate",
     );
   });
 

--- a/bot/src/bridge.ts
+++ b/bot/src/bridge.ts
@@ -105,11 +105,17 @@ export function checkAuth(
   // and operators can swap keys without restarting (cost is negligible —
   // process.env lookup is a hash hit).
   const bridgeKey = process.env.BRIDGE_API_KEY || "";
-  const allowUnauth = process.env.BRIDGE_ALLOW_UNAUTH === "true";
+  // Issue #34 — BRIDGE_ALLOW_UNAUTH is a no-op outside dev. Previously any
+  // non-production environment honored the flag, which let operators
+  // accidentally run the bridge wide-open on staging. The flag now requires
+  // BEEVER_ENV === "development" (the explicit dev marker), not "anything
+  // but production".
+  const isDev = process.env.BEEVER_ENV === "development";
+  const allowUnauth = isDev && process.env.BRIDGE_ALLOW_UNAUTH === "true";
   const hmacDual = process.env.BEEVER_BRIDGE_HMAC_DUAL === "true";
 
   if (!bridgeKey) {
-    if (allowUnauth) return true; // explicit local-dev opt-in
+    if (allowUnauth) return true; // explicit local-dev opt-in (BEEVER_ENV=development gate)
     return unauthorized(res);
   }
 
@@ -135,7 +141,12 @@ export function checkAuth(
  */
 export function assertBridgeAuthReady(): void {
   const bridgeKey = process.env.BRIDGE_API_KEY || "";
-  const allowUnauth = process.env.BRIDGE_ALLOW_UNAUTH === "true";
+  // Issue #34 — match the new dev-only gate from `checkAuth`. The startup
+  // warning only fires for the *effective* unauth state, not the literal
+  // env value; setting BRIDGE_ALLOW_UNAUTH=true outside dev is silently
+  // ignored at request time (the bridge stays locked).
+  const isDev = process.env.BEEVER_ENV === "development";
+  const allowUnauth = isDev && process.env.BRIDGE_ALLOW_UNAUTH === "true";
   const isProd =
     process.env.BEEVER_ENV === "production" ||
     process.env.NODE_ENV === "production";
@@ -149,7 +160,18 @@ export function assertBridgeAuthReady(): void {
 
   if (!bridgeKey && allowUnauth) {
     console.warn(
-      "⚠️  BRIDGE_ALLOW_UNAUTH=true — running without bridge authentication. Do NOT use in production.",
+      "⚠️  BRIDGE_ALLOW_UNAUTH=true (with BEEVER_ENV=development) — running without bridge authentication. Do NOT use in staging or production.",
+    );
+  } else if (
+    !bridgeKey &&
+    process.env.BRIDGE_ALLOW_UNAUTH === "true" &&
+    !isDev
+  ) {
+    // Operator set the flag but BEEVER_ENV is not 'development' — surface
+    // a loud warning so they know the flag is being ignored and the bridge
+    // will return 401 on every call.
+    console.warn(
+      "⚠️  BRIDGE_ALLOW_UNAUTH=true is IGNORED unless BEEVER_ENV=development. The bridge will return 401 until BRIDGE_API_KEY is set or BEEVER_ENV is explicitly 'development'.",
     );
   }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,7 +89,12 @@ services:
 
   bot:
     build: ./bot
-    ports: ["3001:3001"]
+    # Bind bot bridge to localhost only — it's an internal management
+    # surface (adapter registration, sync triggers, credential lookup),
+    # not user-facing. Datastores already bind to 127.0.0.1; the bot
+    # bridge was the outlier (issue #34). Backend (8000) and web (3000)
+    # remain on 0.0.0.0 since they're behind a reverse proxy in prod.
+    ports: ["127.0.0.1:3001:3001"]
     depends_on:
       redis:
         condition: service_healthy


### PR DESCRIPTION
## Summary

Closes #34. Two related hardening changes for the bot bridge:

### 1. Bind bot port to 127.0.0.1 in docker-compose

\`docker-compose.yml\`: \`3001:3001\` → \`127.0.0.1:3001:3001\`. The bridge is an internal management surface (adapter registration, sync triggers, credential lookup), not user-facing. Datastores already bound to 127.0.0.1; the bot bridge was the outlier. Backend (8000) and web (3000) stay on 0.0.0.0 since they're behind a reverse proxy in production.

### 2. Gate \`BRIDGE_ALLOW_UNAUTH\` on \`BEEVER_ENV=development\`

Previously any non-production environment honored the flag, which let operators accidentally run the bridge wide-open on staging or in CI pipelines. The flag now requires the explicit dev marker; in any other env it's silently ignored at request time **and** surfaces a loud startup warning so the operator knows the flag is having no effect.

The startup warning (\`assertBridgeAuthReady\`) was updated to:
- Differentiate the dev-allowed message ("Do NOT use in **staging or** production")
- Add a new "IGNORED unless BEEVER_ENV=development" warning when the flag is set but the env doesn't qualify

## New test cases

3 cases lock in the dev gate:
- \`BRIDGE_ALLOW_UNAUTH=true\` with no \`BEEVER_ENV\` → 401
- \`BRIDGE_ALLOW_UNAUTH=true\` with \`BEEVER_ENV=staging\` → 401
- \`BRIDGE_ALLOW_UNAUTH=true\` with \`NODE_ENV=development\` only → 401 (\`BEEVER_ENV\` is the explicit marker)

Plus 1 case for the new ignored-flag warning behavior.

## Out of scope

The issue's third suggestion ("consider also binding backend (8000) and web (3000) to 127.0.0.1") is left for a separate decision — those are user-facing services and deployments may legitimately want them on 0.0.0.0 behind a proxy. Defer.

## Breaking change for staging

Staging environments that relied on \`BRIDGE_ALLOW_UNAUTH=true\` without \`BEEVER_ENV=development\` will start returning 401. This is the correct behavior — the whole point is to surface the misconfiguration. Operators should either set \`BRIDGE_API_KEY\` (recommended) or, for genuine local dev, set \`BEEVER_ENV=development\`.

## Test plan

- [x] \`bot/\` 140/140 tests pass (4 new cases for issue #34, 1 updated existing case)
- [x] \`npx tsc --noEmit\` clean in bot/
- [ ] CI: full suite green
- [ ] Manual: \`docker compose up -d bot\` → \`curl localhost:3001/health\` works (loopback) but \`curl <docker-host-ip>:3001/health\` fails (binding to 127.0.0.1 only)