### PR TITLE
fix(security): harden responses for URLs carrying ?access_token= (#35 partial)

### DIFF
--- a/src/beever_atlas/infra/loader_url_headers.py
+++ b/src/beever_atlas/infra/loader_url_headers.py
@@ -1,0 +1,50 @@
+"""Middleware that hardens responses to URLs carrying ``?access_token=``.
+
+Issue #35 — the frontend's ``buildLoaderUrl`` appends ``?access_token=<key>``
+to URLs consumed by browser-native loaders (``<img src>``, ``<a href>``)
+that cannot set custom Authorization headers. This is intentional, but it
+means the API key can leak into:
+
+  * server access logs (uvicorn, load balancers, CDNs)
+  * browser history (the URL is bookmarkable)
+  * the ``Referer`` header sent on outbound navigation
+
+The Referer leak is the most serious of the three. This middleware adds
+``Referrer-Policy: no-referrer`` and ``Cache-Control: no-store`` to every
+response whose request carried ``?access_token=`` in the query string.
+Endpoints that already set these headers explicitly (e.g. the public share
+GET) are unaffected — we use ``setdefault`` to avoid overriding intentional
+``Cache-Control: private, no-store`` overrides.
+"""
+
+from __future__ import annotations
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+
+
+class LoaderUrlSecurityHeadersMiddleware(BaseHTTPMiddleware):
+    """Add ``Referrer-Policy`` + ``Cache-Control`` when ``?access_token=``
+    appears on the request URL.
+
+    Implementation note: the middleware checks ``request.query_params``
+    rather than scanning ``request.url.query`` so URL-encoded variants
+    like ``%61ccess_token`` are not matched (they wouldn't be parsed
+    by FastAPI's ``Query`` dependency either, so they wouldn't have
+    authenticated; protecting them would be defense-in-depth but is not
+    required for the fix).
+    """
+
+    async def dispatch(  # type: ignore[override]
+        self,
+        request: Request,
+        call_next,
+    ) -> Response:
+        response = await call_next(request)
+        if "access_token" in request.query_params:
+            # `setdefault` preserves explicit overrides like the public
+            # share endpoint's `Cache-Control: private, no-store`.
+            response.headers.setdefault("Referrer-Policy", "no-referrer")
+            response.headers.setdefault("Cache-Control", "no-store")
+        return response

--- a/src/beever_atlas/server/app.py
+++ b/src/beever_atlas/server/app.py
@@ -19,6 +19,7 @@ from slowapi import _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
 
 from beever_atlas.infra.auth import require_bridge, require_user
+from beever_atlas.infra.loader_url_headers import LoaderUrlSecurityHeadersMiddleware
 
 from beever_atlas.adapters import close_adapter
 from beever_atlas.infra.rate_limit import limiter
@@ -220,6 +221,12 @@ app.add_middleware(
     allow_methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
     allow_headers=["Authorization", "Content-Type", "X-Requested-With", "X-Admin-Token"],
 )
+# Issue #35 — harden responses to URLs carrying ?access_token= so a leaked
+# loader URL doesn't leak the embedded API key via the Referer header
+# (outbound navigation) or browser disk cache. Endpoints that set their
+# own Cache-Control / Referrer-Policy (e.g. the public share GET) are
+# preserved via setdefault.
+app.add_middleware(LoaderUrlSecurityHeadersMiddleware)
 
 # All routers require Bearer auth except /api/health (declared below) and MCP mount.
 _auth = [Depends(require_user)]

--- a/tests/infra/test_loader_url_headers.py
+++ b/tests/infra/test_loader_url_headers.py
@@ -1,0 +1,82 @@
+"""Regression tests for issue #35 — LoaderUrlSecurityHeadersMiddleware.
+
+Verifies:
+  * Requests carrying ``?access_token=`` get ``Referrer-Policy: no-referrer``
+    and ``Cache-Control: no-store`` on the response.
+  * Requests WITHOUT ``?access_token=`` are unaffected.
+  * Endpoints that set their own ``Cache-Control`` / ``Referrer-Policy``
+    keep their values (we use ``setdefault``, not overwrite).
+"""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.responses import Response
+from fastapi.testclient import TestClient
+
+from beever_atlas.infra.loader_url_headers import LoaderUrlSecurityHeadersMiddleware
+
+
+def _make_app() -> FastAPI:
+    app = FastAPI()
+    app.add_middleware(LoaderUrlSecurityHeadersMiddleware)
+
+    @app.get("/plain")
+    async def plain() -> dict:
+        return {"ok": True}
+
+    @app.get("/preset-headers")
+    async def preset() -> Response:
+        return Response(
+            content="{}",
+            media_type="application/json",
+            headers={
+                "Cache-Control": "private, no-store",
+                "Referrer-Policy": "strict-origin-when-cross-origin",
+            },
+        )
+
+    return app
+
+
+def test_query_string_access_token_adds_security_headers() -> None:
+    client = TestClient(_make_app())
+    resp = client.get("/plain?access_token=secret123")
+
+    assert resp.status_code == 200
+    assert resp.headers["referrer-policy"] == "no-referrer"
+    assert resp.headers["cache-control"] == "no-store"
+
+
+def test_no_access_token_means_no_added_headers() -> None:
+    client = TestClient(_make_app())
+    resp = client.get("/plain")
+
+    assert resp.status_code == 200
+    # The middleware must not touch headers when access_token isn't on the URL.
+    assert "referrer-policy" not in resp.headers
+    # FastAPI's default JSON responses have no Cache-Control header.
+    assert "cache-control" not in resp.headers
+
+
+def test_endpoint_explicit_headers_are_preserved() -> None:
+    """Endpoints that set their own Cache-Control / Referrer-Policy retain
+    them — the middleware's setdefault must not override."""
+    client = TestClient(_make_app())
+    resp = client.get("/preset-headers?access_token=secret123")
+
+    assert resp.status_code == 200
+    # Endpoint-set values win.
+    assert resp.headers["cache-control"] == "private, no-store"
+    assert resp.headers["referrer-policy"] == "strict-origin-when-cross-origin"
+
+
+def test_unrelated_query_param_does_not_trigger() -> None:
+    """Only the literal ``access_token`` query param triggers the middleware,
+    not partial matches or other names."""
+    client = TestClient(_make_app())
+    resp = client.get("/plain?token=secret&page=1")
+
+    assert resp.status_code == 200
+    assert "referrer-policy" not in resp.headers
+    assert "cache-control" not in resp.headers


### PR DESCRIPTION
## Summary

Partial fix for #35 — implements **mitigation #2** from the issue's suggested-fix list (response headers). Defers mitigation #1 (HMAC-signed scoped tokens) and mitigation #3 (refactor 54 endpoints to a dedicated dependency) to follow-ups.

## What this changes

Adds a Starlette middleware (\`LoaderUrlSecurityHeadersMiddleware\`) that sets two headers on every response whose request URL carried \`?access_token=\` in the query string:

- \`Referrer-Policy: no-referrer\` — prevents the API key from leaking to external sites via the \`Referer\` header on outbound navigation
- \`Cache-Control: no-store\` — prevents browser disk cache from persisting the URL with the embedded key

## Why this matters

The frontend's \`buildLoaderUrl\` deliberately appends \`?access_token=\` for browser-native loaders (\`<img src>\`, \`<a href>\`) that can't set custom \`Authorization\` headers — an intentional design choice. But it means the API key leaks into:

| Leak vector | Mitigated by this PR |
|---|---|
| \`Referer\` on outbound navigation | ✅ \`Referrer-Policy: no-referrer\` |
| Browser history / disk cache | ✅ \`Cache-Control: no-store\` |
| Server access logs (uvicorn, LBs, CDNs) | ❌ requires HMAC tokens (follow-up) |

The \`Referer\` leak is the highest-impact: a user clicking an external link from an authenticated page would have leaked their key to the destination site.

## Implementation

- \`src/beever_atlas/infra/loader_url_headers.py\` (new): the middleware. Uses \`setdefault\` so endpoints that explicitly set their own \`Cache-Control\` / \`Referrer-Policy\` (e.g. the public share GET) keep their values.
- \`src/beever_atlas/server/app.py\`: registered after \`CORSMiddleware\` so it runs LAST on the response (Starlette middleware order is reverse-of-registration on response).
- \`tests/infra/test_loader_url_headers.py\`: 4 cases — with access_token, without, explicit-headers preserved, unrelated query param does not trigger.

## Out of scope

- **Mitigation #1**: HMAC-signed scoped tokens replacing raw API keys in URLs — substantial scope (token issuance, validation, expiry, key rotation). Right thing to do; needs its own design + PR.
- **Mitigation #3**: Refactor 54 endpoints to use a dedicated \`require_user_loader\` dependency — would let us flip the default to "no query string" for everything else, closing the surface globally. Medium scope; the middleware closes the highest-impact leak vector without touching all 54 endpoints today.

Both should be filed as follow-up issues if not already.

## Test plan

- [x] \`uv run ruff format --check src/ tests/\` — clean
- [x] \`uv run ruff check src/ tests/\` — clean
- [x] \`uv run python -m pytest tests/infra/test_loader_url_headers.py -v\` — 4/4 pass
- [ ] CI: full suite green
- [ ] Manual: hit \`/api/ask/files/{id}?access_token=foo\` from a browser, view DevTools → Network → Response Headers; confirm \`Referrer-Policy: no-referrer\` and \`Cache-Control: no-store\` are both present