### PR TITLE
refactor(stores): symmetrize Weaviate schema migration between sync + async paths (#38)

### DIFF
--- a/src/beever_atlas/stores/weaviate_store.py
+++ b/src/beever_atlas/stores/weaviate_store.py
@@ -151,6 +151,31 @@ class WeaviateStore:
         ("last_mentioned_at", DataType.TEXT),
     ]
 
+    def _apply_schema_migration(self, collection) -> None:  # type: ignore[no-untyped-def]
+        """Add any missing ``_EXPECTED_PROPERTIES`` to ``collection`` in-place.
+
+        Single source of truth for the schema-migration loop, shared by
+        the async ``ensure_schema()`` and the sync ``_ensure_schema_sync()``
+        paths so the two cannot drift if a future contributor adds a new
+        property to ``_EXPECTED_PROPERTIES`` (issue #38).
+
+        Limitation: handles property ADDITIONS only. Property type
+        changes are not migrated — Weaviate does not support in-place
+        property type changes anyway (it would require dropping and
+        recreating the collection). A type change in
+        ``_EXPECTED_PROPERTIES`` for an existing property silently
+        no-ops here.
+        """
+        existing_names = {p.name for p in collection.config.get().properties}
+        for prop_name, prop_type in self._EXPECTED_PROPERTIES:
+            if prop_name not in existing_names:
+                collection.config.add_property(Property(name=prop_name, data_type=prop_type))
+                logger.info(
+                    "WeaviateStore: added missing property '%s' to %s",
+                    prop_name,
+                    COLLECTION_NAME,
+                )
+
     async def ensure_schema(self) -> None:
         """Create or migrate the MemoryFact collection."""
 
@@ -159,17 +184,7 @@ class WeaviateStore:
             if self._client.collections.exists(COLLECTION_NAME):
                 # Auto-migrate: add any missing properties to existing collections.
                 collection = self._client.collections.get(COLLECTION_NAME)
-                existing_names = {p.name for p in collection.config.get().properties}
-                for prop_name, prop_type in self._EXPECTED_PROPERTIES:
-                    if prop_name not in existing_names:
-                        collection.config.add_property(
-                            Property(name=prop_name, data_type=prop_type)
-                        )
-                        logger.info(
-                            "WeaviateStore: added missing property '%s' to %s",
-                            prop_name,
-                            COLLECTION_NAME,
-                        )
+                self._apply_schema_migration(collection)
                 return
             self._client.collections.create(
                 name=COLLECTION_NAME,
@@ -198,9 +213,19 @@ class WeaviateStore:
         return self._client.collections.get(COLLECTION_NAME)
 
     def _ensure_schema_sync(self) -> None:
-        """Synchronous version of ensure_schema for use within _collection()."""
+        """Synchronous version of ensure_schema for use within _collection().
+
+        Issue #38 — symmetric with the async ``ensure_schema()``: when
+        the collection already exists, run the same migration helper to
+        add any missing properties. The branch is rarely hit in normal
+        operation (`_collection()` only calls this on missing-collection
+        path), but is defense-in-depth for edge cases like manual
+        collection creation by ops or partial startup.
+        """
         assert self._client is not None
         if self._client.collections.exists(COLLECTION_NAME):
+            collection = self._client.collections.get(COLLECTION_NAME)
+            self._apply_schema_migration(collection)
             return
         self._client.collections.create(
             name=COLLECTION_NAME,

--- a/tests/stores/test_weaviate_schema_migration.py
+++ b/tests/stores/test_weaviate_schema_migration.py
@@ -1,0 +1,154 @@
+"""Tests for `WeaviateStore` schema-migration symmetry (issue #38).
+
+Covers `_apply_schema_migration` helper + symmetric behavior between
+`ensure_schema` (async) and `_ensure_schema_sync` (sync) when called
+against an existing collection. All tests use `unittest.mock` — no
+live Weaviate.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, call
+
+from weaviate.classes.config import Property
+
+from beever_atlas.stores.weaviate_store import COLLECTION_NAME, WeaviateStore
+
+
+def _store_with_mock_client(mock_client) -> WeaviateStore:
+    """Construct a WeaviateStore without going through the real connect path."""
+    store = WeaviateStore.__new__(WeaviateStore)
+    store._client = mock_client  # bypass async connect
+    store._url = "http://test"
+    store._api_key = ""
+    return store
+
+
+def _mock_collection_with_existing(prop_names: list[str]) -> MagicMock:
+    """Build a mock collection whose `config.get().properties` returns
+    SimpleNamespace objects matching the given names."""
+    collection = MagicMock()
+    config = MagicMock()
+    config.get.return_value = SimpleNamespace(
+        properties=[SimpleNamespace(name=n) for n in prop_names],
+    )
+    collection.config = config
+    return collection
+
+
+# ── Helper unit tests ───────────────────────────────────────────────────
+
+
+def test_apply_schema_migration_adds_missing_properties() -> None:
+    """The helper adds each missing property with explicit `name=` and
+    `data_type=` kwargs (Architect Patch 1 — assert kwargs, not just
+    that the call happened, so a regression that swaps name/type is
+    caught)."""
+    store = _store_with_mock_client(MagicMock())
+    # Existing collection has only the FIRST property of _EXPECTED_PROPERTIES.
+    first_name, _first_dtype = store._EXPECTED_PROPERTIES[0]
+    collection = _mock_collection_with_existing([first_name])
+
+    store._apply_schema_migration(collection)
+
+    # Every property AFTER the first should have been added with kwargs.
+    expected_calls = [
+        call(Property(name=name, data_type=dtype)) for name, dtype in store._EXPECTED_PROPERTIES[1:]
+    ]
+    assert collection.config.add_property.call_args_list == expected_calls
+    # First property was already present — must NOT have been re-added.
+    assert all(
+        c != call(Property(name=first_name, data_type=_first_dtype))
+        for c in collection.config.add_property.call_args_list
+    )
+
+
+def test_apply_schema_migration_noop_when_up_to_date() -> None:
+    store = _store_with_mock_client(MagicMock())
+    all_names = [n for n, _ in store._EXPECTED_PROPERTIES]
+    collection = _mock_collection_with_existing(all_names)
+
+    store._apply_schema_migration(collection)
+
+    collection.config.add_property.assert_not_called()
+
+
+# ── Sync path tests ─────────────────────────────────────────────────────
+
+
+def test_ensure_schema_sync_creates_collection_when_missing() -> None:
+    client = MagicMock()
+    client.collections.exists.return_value = False
+    store = _store_with_mock_client(client)
+
+    store._ensure_schema_sync()
+
+    client.collections.create.assert_called_once()
+    # Verify the create call sets the full property list (defense-in-depth).
+    create_kwargs = client.collections.create.call_args.kwargs
+    assert create_kwargs["name"] == COLLECTION_NAME
+    assert len(create_kwargs["properties"]) == len(store._EXPECTED_PROPERTIES)
+
+
+def test_ensure_schema_sync_migrates_existing_collection() -> None:
+    """Sync path now migrates when collection already exists (issue #38).
+    Verify each `add_property` call uses explicit `name=` AND `data_type=`
+    kwargs (Architect Patch 1)."""
+    client = MagicMock()
+    client.collections.exists.return_value = True
+    # Existing collection has half the expected properties.
+    half_idx = len(WeaviateStore._EXPECTED_PROPERTIES) // 2
+    existing_names = [n for n, _ in WeaviateStore._EXPECTED_PROPERTIES[:half_idx]]
+    collection = _mock_collection_with_existing(existing_names)
+    client.collections.get.return_value = collection
+    store = _store_with_mock_client(client)
+
+    store._ensure_schema_sync()
+
+    # Migration helper must have been called via the new branch.
+    expected_calls = [
+        call(Property(name=name, data_type=dtype))
+        for name, dtype in WeaviateStore._EXPECTED_PROPERTIES[half_idx:]
+    ]
+    assert collection.config.add_property.call_args_list == expected_calls
+    # Must NOT have called `collections.create` (collection already exists).
+    client.collections.create.assert_not_called()
+
+
+def test_ensure_schema_sync_noop_when_collection_up_to_date() -> None:
+    client = MagicMock()
+    client.collections.exists.return_value = True
+    all_names = [n for n, _ in WeaviateStore._EXPECTED_PROPERTIES]
+    collection = _mock_collection_with_existing(all_names)
+    client.collections.get.return_value = collection
+    store = _store_with_mock_client(client)
+
+    store._ensure_schema_sync()
+
+    collection.config.add_property.assert_not_called()
+    client.collections.create.assert_not_called()
+
+
+# ── Async path delegates to helper ──────────────────────────────────────
+
+
+async def test_ensure_schema_delegates_to_helper_when_collection_exists() -> None:
+    """After the refactor, `ensure_schema()` calls the same helper as
+    the sync path — so future schema additions update both paths."""
+    client = MagicMock()
+    client.collections.exists.return_value = True
+    half_idx = len(WeaviateStore._EXPECTED_PROPERTIES) // 2
+    existing_names = [n for n, _ in WeaviateStore._EXPECTED_PROPERTIES[:half_idx]]
+    collection = _mock_collection_with_existing(existing_names)
+    client.collections.get.return_value = collection
+    store = _store_with_mock_client(client)
+
+    await store.ensure_schema()
+
+    expected_calls = [
+        call(Property(name=name, data_type=dtype))
+        for name, dtype in WeaviateStore._EXPECTED_PROPERTIES[half_idx:]
+    ]
+    assert collection.config.add_property.call_args_list == expected_calls
+    client.collections.create.assert_not_called()


### PR DESCRIPTION
## Summary

Issue #38 reports that `WeaviateStore._ensure_schema_sync()` returns early when the collection exists, while the async `ensure_schema()` runs a migration loop that adds any missing `_EXPECTED_PROPERTIES`. The two methods can drift if a contributor adds a new property and only updates one path.

## Honest framing

This is a **refactor**, not a fix for an actively-firing bug. `_collection()` only calls `_ensure_schema_sync()` when the collection is MISSING (in which case full schema is created fresh), so the migration branch added here is **defense-in-depth** for edge cases: manual collection creation by ops, future refactors that move callers, partial startup that skips `ensure_schema()`. Architect explicitly flagged this framing during planning. The PR's value is preventing future drift, not patching a runtime bug.

## Changes

| File | Change |
|---|---|
| `stores/weaviate_store.py` | Extract `_apply_schema_migration(self, collection) -> None` helper. Docstring documents the property-type-change limitation. `ensure_schema()` and `_ensure_schema_sync()` both delegate to the helper. `_ensure_schema_sync()`'s "collection exists" branch no longer returns early — it migrates first. |
| `tests/stores/test_weaviate_schema_migration.py` (new) | 6 tests with mocked Weaviate clients — helper adds missing props, helper no-op when up-to-date, sync creates full schema when missing, sync migrates existing collection (asserts each `add_property` call uses explicit `name=` AND `data_type=` kwargs per Architect Patch 1), sync no-op when up-to-date, async delegates to helper. |

## Test plan

- [x] `pytest tests/stores/test_weaviate_schema_migration.py -v`: 6/6 PASS
- [x] `pytest tests/ --ignore=tests/integration`: 1473 PASS, 0 FAIL, 23 SKIP
- [x] `ruff check` + `ruff format --check`: clean

## Process

Full ralplan consensus: Planner (Option A+D — extract helper + add to sync path) → Architect APPROVE-WITH-PATCHES (3 observations: this is a refactor not a fix, helper docstring needs type-change limitation note, tests must assert kwargs not just call count). Plan: `.omc/plans/fix-weaviate-schema-sync.md` (rev2). Openspec: `openspec/changes/weaviate-schema-sync/`.

Critic was skipped because Architect's review was thorough and the change is mechanical.

## Follow-ups

- If stale-schema issues recur in production, file an issue to widen `_collection()` to always migrate on first access (Option B from the plan, deferred per Architect tradeoff analysis).
- Apply the same symmetrization pattern to `QAHistoryStore` (its `_collection()` has the identical asymmetry; separate scope).

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)