### PR TITLE
fix(security): drop root in all three Dockerfiles (#39)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,13 +16,27 @@ FROM python:3.12-slim@sha256:804ddf3251a60bbf9c92e73b7566c40428d54d0e79d3428194e
 
 WORKDIR /app
 
-# Copy the built venv and source from builder
-COPY --from=builder /app/.venv /app/.venv
-COPY --from=builder /app/src /app/src
-COPY --from=builder /app/pyproject.toml /app/pyproject.toml
+# Issue #39 — drop root. UID 10001 is fixed (not `--system`'s arbitrary 100-999)
+# for k8s `runAsNonRoot` SCC compatibility — survives base-image upgrades unchanged.
+# `chown app:app /app` ensures the WORKDIR itself is `app`-owned so the file-import
+# staging feature (`/app/.omc/imports`, see infra/config.py:61, api/imports.py:148)
+# can `mkdir -p` at runtime under non-root.
+RUN addgroup --system --gid 10001 app && \
+    adduser --system --uid 10001 --ingroup app --no-create-home app && \
+    chown app:app /app
+
+# Copy the built venv and source from builder, owned by `app`.
+COPY --chown=app:app --from=builder /app/.venv /app/.venv
+COPY --chown=app:app --from=builder /app/src /app/src
+COPY --chown=app:app --from=builder /app/pyproject.toml /app/pyproject.toml
 
 # Ensure the venv is on PATH
 ENV PATH="/app/.venv/bin:$PATH"
+
+# All RUN commands below execute as 'app'. New writable dirs MUST be created
+# here, before USER, OR with explicit `chown app:app` after USER (otherwise the
+# directory is root-owned and the runtime user can't write to it).
+USER app
 
 EXPOSE 8000
 

--- a/bot/Dockerfile
+++ b/bot/Dockerfile
@@ -9,10 +9,15 @@ RUN npm run build
 
 FROM node:22-alpine@sha256:8ea2348b068a9544dae7317b4f3aafcdc032df1647bb7d768a05a5cad1a7683f
 
+# Issue #39 — drop root. node:22-alpine ships a built-in `node` user (UID 1000).
+# Keep WORKDIR /app for path stability — anything hard-coding /app/dist/index.js
+# (volume mounts, log/process monitoring) continues to work.
+RUN mkdir -p /app && chown node:node /app
 WORKDIR /app
-COPY package*.json ./
+USER node
+COPY --chown=node:node package*.json ./
 RUN npm ci --audit-signatures --omit=dev
-COPY --from=build /app/dist dist/
+COPY --chown=node:node --from=build /app/dist dist/
 
 EXPOSE 3001
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,10 @@ services:
       args:
         VITE_API_URL: ${VITE_API_URL:-http://localhost:8000}
         VITE_BEEVER_API_KEY: ${VITE_BEEVER_API_KEY:-}
-    ports: ["3000:80"]
+    # Issue #39 — web container now runs as nginx-unprivileged listening on
+    # 8080 (CIS Docker Benchmark — non-root). Host port 3000 unchanged so
+    # existing dev URLs (http://localhost:3000/) keep working.
+    ports: ["3000:8080"]
     depends_on:
       - beever-atlas
 

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -13,11 +13,16 @@ ENV VITE_BEEVER_API_KEY=${VITE_BEEVER_API_KEY}
 
 RUN npm run build
 
-FROM nginx:alpine@sha256:5616878291a2eed594aee8db4dade5878cf7edcb475e59193904b198d9b830de
+FROM nginxinc/nginx-unprivileged:alpine@sha256:f35982400455b4f359083ba9d1ef573fbbe4221a6a8a194dc7a14beb4e2cd3dc
+# Issue #39 — drop root. The `nginxinc/nginx-unprivileged` image is the official
+# upstream nginx variant configured to run as the `nginx` user (UID 101) and
+# listen on port 8080 by default. Avoids fragile manual chown of /var/cache/nginx,
+# /var/run, /etc/nginx/conf.d that breaks across nginx version bumps. The host-side
+# port mapping in docker-compose is updated atomically (3000:80 → 3000:8080).
 COPY --from=build /app/dist /usr/share/nginx/html
 COPY <<'EOF' /etc/nginx/conf.d/default.conf
 server {
-    listen 80;
+    listen 8080;
     root /usr/share/nginx/html;
     location / {
         try_files $uri $uri/ /index.html;
@@ -30,5 +35,5 @@ server {
     }
 }
 EOF
-EXPOSE 80
+EXPOSE 8080
 CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
## Summary

CIS Docker Benchmark 4.1: none of the three Dockerfiles had a `USER` directive. All containers ran as root. This PR introduces non-root users for backend, bot, and web — each with the idiomatic pattern for that runtime.

## Changes

| File | Change |
|---|---|
| `Dockerfile` (backend) | Create `app:10001` system user. **`chown /app` to `app:app`** so the file-import staging feature can `mkdir -p /app/.omc/imports` at runtime (Architect-caught: this was a real bug in the original plan). `COPY --chown=app:app` on builder→runtime copies. `USER app` before `EXPOSE 8000`. Inline comment above `USER` warns future contributors. UID 10001 chosen for k8s `runAsNonRoot` SCC compatibility. |
| `bot/Dockerfile` | Use built-in `node` user (UID 1000). **Keep `WORKDIR /app`** (path stability — anything hard-coding `/app/dist/index.js` continues to work). `chown node:node /app` before `WORKDIR + USER`. `COPY --chown=node:node`. |
| `web/Dockerfile` | Switch base from `nginx:alpine` to `nginxinc/nginx-unprivileged:alpine` (officially maintained by the nginx team, listens on 8080 by default, runs as `nginx` UID 101). Pinned to digest `sha256:f35982400…` per supply-chain CI gate. `listen 80;` → `listen 8080;`, `EXPOSE 80` → `EXPOSE 8080`. |
| `docker-compose.yml` | Atomically update web port mapping `3000:80` → `3000:8080`. Host port 3000 unchanged. |

## Local verification

```
$ docker run --rm backend-test id        # uid=10001(app)
$ docker run --rm backend-test python -c "import os; os.makedirs('/app/.omc/imports', exist_ok=True); print('ok')"  # ok
$ docker run --rm bot-test id            # uid=1000(node)
$ docker run --rm bot-test pwd           # /app
$ docker run --rm web-test id            # uid=101(nginx)
```

## Breaking change

Anyone running `docker run -p XXXX:80 web-image` after this PR will get connection refused — they need `-p XXXX:8080`. **Compose users with the project's official compose file are auto-fixed** (the PR updates `3000:80` → `3000:8080` atomically). Only external consumers (custom deployment manifests, reverse-proxy configs, monitoring tools) hard-coding the container's port 80 need to update — out of scope for this PR but documented here.

## Process

Full ralplan: Planner → Architect APPROVE-WITH-PATCHES (3 patches: backend `/app` chown caught the file-import staging bug, bot `WORKDIR /app` stability preserved, UID 10001 explanation comment). Critic skipped (mechanical change, Architect was thorough). Plan: `.omc/plans/fix-dockerfile-nonroot.md`. Openspec: `openspec/changes/dockerfile-nonroot/`.

## Follow-ups

- Optional: `cap_drop: [ALL]` on compose services
- Optional: read-only root filesystem with `tmpfs` for `/tmp`
- Optional: distroless / Chainguard base images

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)