### PR TITLE
chore(gitignore): ignore .claude/, openspec/, future/ tooling dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,13 +77,14 @@ web/dist/
 /package-lock.json
 
 # Claude Code runtime state
-.claude/scheduled_tasks.lock
+.claude/
 
 # QA harness output artifacts
 scripts/_qa_harness_out/
 
 # Local scratch notes
 daily_update.md
+future/
 
 # hypothesis cache
 .hypothesis/
@@ -95,8 +96,7 @@ htmlcov/
 coverage.xml
 
 # OpenSpec scratch artifacts — commit specific change dirs explicitly with `git add -f`
-openspec/changes/
-openspec/specs/
+openspec/
 web/openspec/
 
 # Local env backups created by ./atlas on re-runs


### PR DESCRIPTION
## Summary
- Replace narrow `.claude/scheduled_tasks.lock` entry with full `.claude/` to cover all Claude Code runtime artifacts
- Broaden `openspec/` ignore from `changes/` + `specs/` subdirs to the entire top-level dir
- Add `future/` for local scratch work

## Test plan
- [ ] CI passes (8 required status checks)
- [ ] `git status` no longer surfaces `.claude/`, `openspec/`, or `future/` as untracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)