### PR TITLE
fix(security): reject CREDENTIAL_MASTER_KEY placeholder + bash fallback in atlas (#41)

### DIFF
--- a/atlas
+++ b/atlas
@@ -190,10 +190,25 @@ replace_env_value() {
 }
 
 # Generate a random hex token of N bytes (2N hex chars). Echoes the
-# token on stdout. Requires $PY_CMD; callers must check that first.
+# token on stdout. Issue #41 — falls back to POSIX `od /dev/urandom`
+# when Python is missing, so minimal hosts no longer leave the public
+# .env.example placeholder in place. Returns non-zero only when both
+# Python and /dev/urandom are unavailable.
 gen_hex() {
   local bytes="${1:-24}"
-  "$PY_CMD" -c "import secrets; print(secrets.token_hex(${bytes}))"
+  if [ -n "$PY_CMD" ]; then
+    "$PY_CMD" -c "import secrets; print(secrets.token_hex(${bytes}))"
+    return $?
+  fi
+  if [ -r /dev/urandom ]; then
+    # POSIX `od` (BSD + GNU + busybox); strip spaces and newlines from
+    # the output. Produces 2N hex chars matching `secrets.token_hex(N)`.
+    od -An -tx1 -N"${bytes}" /dev/urandom | tr -d ' \n'
+    echo
+    return 0
+  fi
+  error "gen_hex: neither Python nor /dev/urandom available — cannot generate secret"
+  return 1
 }
 
 # Confirm prompt. Args: default(Y|N), prompt text. Returns 0 for yes, 1 for no.
@@ -261,12 +276,14 @@ prompt_internal_secret() {
   local value=""
   read -r value || true
   if [ -z "$value" ]; then
-    if [ -n "$PY_CMD" ]; then
-      value=$(gen_hex "$bytes")
+    # Issue #41 — gen_hex now falls back to /dev/urandom if Python is
+    # missing. Only warn-and-skip when both paths fail.
+    value=$(gen_hex "$bytes")
+    if [ -n "$value" ]; then
       replace_env_value "$key" "$value"
       ok "auto-generated"
     else
-      warn "Python not found — leaving ${key} unchanged, set manually later"
+      warn "Cannot auto-generate ${key} (no Python and no /dev/urandom) — set manually later"
     fi
   else
     replace_env_value "$key" "$value"
@@ -314,12 +331,14 @@ if [ "$NON_INTERACTIVE" != "true" ]; then
     # MCP server
     if confirm "N" "Enable the MCP server for Claude Code / Cursor?"; then
       replace_env_value "BEEVER_MCP_ENABLED" "true"
-      if [ -n "$PY_CMD" ]; then
-        mcp_key="mcp-$(gen_hex 24)"
-        replace_env_value "BEEVER_MCP_API_KEYS" "$mcp_key"
+      # Issue #41 — gen_hex now falls back to /dev/urandom; only warn-and-skip
+      # when both paths fail.
+      mcp_random=$(gen_hex 24)
+      if [ -n "$mcp_random" ]; then
+        replace_env_value "BEEVER_MCP_API_KEYS" "mcp-${mcp_random}"
         ok "BEEVER_MCP_ENABLED=true · auto-generated BEEVER_MCP_API_KEYS"
       else
-        warn "BEEVER_MCP_ENABLED=true but python missing — set BEEVER_MCP_API_KEYS manually"
+        warn "BEEVER_MCP_ENABLED=true but cannot auto-generate (no Python and no /dev/urandom) — set BEEVER_MCP_API_KEYS manually"
       fi
     else
       ok "skipped MCP server"
@@ -361,12 +380,14 @@ if [ "$NON_INTERACTIVE" != "true" ]; then
   hint "Rotate them to random secrets for any deploy."
 
   if confirm "N" "Rotate auth tokens to fresh random secrets?"; then
-    if [ -z "$PY_CMD" ]; then
-      warn "Python not found — can't auto-generate, skipping rotation"
+    # Issue #41 — gen_hex now falls back to /dev/urandom; only skip
+    # rotation when BOTH Python and /dev/urandom are unavailable.
+    new_api=$(gen_hex 24)
+    new_admin=$(gen_hex 24)
+    new_bridge=$(gen_hex 24)
+    if [ -z "$new_api" ] || [ -z "$new_admin" ] || [ -z "$new_bridge" ]; then
+      warn "Cannot auto-generate (no Python and no /dev/urandom) — skipping rotation"
     else
-      new_api=$(gen_hex 24)
-      new_admin=$(gen_hex 24)
-      new_bridge=$(gen_hex 24)
       replace_env_value "BEEVER_API_KEYS"        "$new_api"
       replace_env_value "BEEVER_ADMIN_TOKEN"     "$new_admin"
       replace_env_value "BRIDGE_API_KEY"         "$new_bridge"
@@ -406,25 +427,30 @@ secrets_changed=false
 MASTER_KEY_PLACEHOLDER="00000000000000000000000000000000000000000000000000000000deadbeef"
 
 if grep -qF "CREDENTIAL_MASTER_KEY=${MASTER_KEY_PLACEHOLDER}" .env; then
-  if [ -n "$PY_CMD" ]; then
-    replace_env_value "CREDENTIAL_MASTER_KEY" "$(gen_hex 32)"
-    ok "Generated a fresh CREDENTIAL_MASTER_KEY"
-    secrets_changed=true
-  else
-    warn "Python not found — set CREDENTIAL_MASTER_KEY manually in .env:"
-    hint "python -c \"import secrets; print(secrets.token_hex(32))\""
+  # Issue #41 — `gen_hex` now falls back to /dev/urandom if Python is
+  # missing. Exit fail-loud if BOTH paths fail rather than ship the
+  # public placeholder, which would leave AES-256-GCM encryption
+  # effectively plaintext.
+  new_master_key="$(gen_hex 32)"
+  if [ -z "$new_master_key" ]; then
+    error "Cannot generate CREDENTIAL_MASTER_KEY — neither Python nor /dev/urandom available."
+    error "Set it manually in .env (64 hex chars) and re-run atlas."
+    exit 1
   fi
+  replace_env_value "CREDENTIAL_MASTER_KEY" "$new_master_key"
+  ok "Generated a fresh CREDENTIAL_MASTER_KEY"
+  secrets_changed=true
 fi
 
 if grep -qE "^WEAVIATE_API_KEY=$" .env; then
-  if [ -n "$PY_CMD" ]; then
-    replace_env_value "WEAVIATE_API_KEY" "$(gen_hex 16)"
-    ok "Generated a fresh WEAVIATE_API_KEY"
-    secrets_changed=true
-  else
-    warn "Python not found — set WEAVIATE_API_KEY manually in .env:"
-    hint "python -c \"import secrets; print(secrets.token_hex(16))\""
+  new_weaviate_key="$(gen_hex 16)"
+  if [ -z "$new_weaviate_key" ]; then
+    error "Cannot generate WEAVIATE_API_KEY — neither Python nor /dev/urandom available."
+    exit 1
   fi
+  replace_env_value "WEAVIATE_API_KEY" "$new_weaviate_key"
+  ok "Generated a fresh WEAVIATE_API_KEY"
+  secrets_changed=true
 fi
 
 if ! $secrets_changed; then

--- a/src/beever_atlas/infra/config.py
+++ b/src/beever_atlas/infra/config.py
@@ -57,6 +57,18 @@ class ConfigurationError(RuntimeError):
     """Raised when feature-flag coupling or settings are invalid."""
 
 
+# Issue #41 — the well-known development placeholder shipped in `.env.example`
+# (and seeded by the `atlas` installer when Python is missing without this fix).
+# It IS valid 64-char hex so the bare hex_ok check would pass it, but using it
+# as the AES-256-GCM master key makes "encrypted" credentials effectively
+# plaintext to anyone who reads the public `.env.example`. The validator
+# rejects this exact value: hard error in production, loud warning in dev.
+# The `tests/infra/test_credential_master_key_validation.py` regression test
+# asserts this constant matches the value in `.env.example` so the two
+# sources cannot drift.
+_INSECURE_PLACEHOLDER_KEY = "00000000000000000000000000000000000000000000000000000000deadbeef"
+
+
 class Settings(BaseSettings):
     """Beever Atlas configuration — all values from env vars."""
 
@@ -428,6 +440,21 @@ class Settings(BaseSettings):
         hex_ok = len(key) == 64 and all(c in "0123456789abcdefABCDEF" for c in key)
         if not hex_ok:
             problems.append("CREDENTIAL_MASTER_KEY must be 64 hex chars (AES-256-GCM)")
+        elif key.lower() == _INSECURE_PLACEHOLDER_KEY:
+            # Issue #41 — reject the well-known dev placeholder. It IS valid
+            # 64-char hex but it's published in `.env.example`, so any
+            # encrypted credential under this key is effectively plaintext to
+            # anyone who reads the repo. Production raises (existing logic at
+            # L442-445); dev/test logs the same problem string at WARNING
+            # severity — the INSECURE/PLAINTEXT keywords carry the loudness;
+            # do NOT escalate to logger.critical/error to keep severity
+            # consistent with the rest of `_validate_production`.
+            problems.append(
+                "CREDENTIAL_MASTER_KEY is the INSECURE well-known placeholder "
+                "from .env.example — encryption is effectively PLAINTEXT. "
+                'Regenerate with: python -c "import secrets; '
+                'print(secrets.token_hex(32))"'
+            )
         if self.neo4j_password in {"beever_atlas_dev", ""}:
             problems.append("NEO4J_AUTH password is a dev default or empty")
         if self.nebula_password == "nebula":

--- a/tests/infra/test_credential_master_key_validation.py
+++ b/tests/infra/test_credential_master_key_validation.py
@@ -1,0 +1,104 @@
+"""Tests for `_validate_production` rejection of the well-known
+`CREDENTIAL_MASTER_KEY` placeholder (issue #41).
+
+The placeholder `00...deadbeef` is shipped publicly in `.env.example`
+and is valid 64-char hex, so the bare `hex_ok` check accepts it. Using
+it as the AES-256-GCM master key makes "encrypted" credentials
+effectively plaintext to anyone who reads the repo.
+
+The validator now rejects it explicitly: hard error in production,
+loud warning (problem string contains INSECURE / PLAINTEXT) in dev.
+A regression test asserts the constant matches `.env.example` so the
+two sources cannot drift.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import secrets
+
+import pytest
+
+from beever_atlas.infra import config as config_mod
+from beever_atlas.infra.config import Settings, _INSECURE_PLACEHOLDER_KEY
+
+
+# ── Fixtures ────────────────────────────────────────────────────────────
+
+
+def _prod_kwargs(**overrides) -> dict:
+    """Return a kwargs dict that satisfies every other production check
+    so we isolate the placeholder check under test."""
+    base = dict(
+        beever_env="production",
+        credential_master_key=secrets.token_hex(32),
+        neo4j_auth="neo4j/this-is-a-strong-password-not-the-dev-default",
+        nebula_password="nebula-strong-pw",
+        bridge_api_key="bridge-real-key-aaaaaaaa",
+        api_keys="user-real-key-bbbbbbbb",
+        admin_token="admin-real-token-cccccccc",
+    )
+    base.update(overrides)
+    return base
+
+
+# ── Tests ───────────────────────────────────────────────────────────────
+
+
+def test_placeholder_rejected_in_production() -> None:
+    """Production raises ValueError when the master key is the public placeholder."""
+    with pytest.raises(ValueError) as exc_info:
+        Settings(**_prod_kwargs(credential_master_key=_INSECURE_PLACEHOLDER_KEY))
+    msg = str(exc_info.value)
+    assert "INSECURE" in msg, f"expected INSECURE in error; got: {msg}"
+    assert "PLAINTEXT" in msg, f"expected PLAINTEXT in error; got: {msg}"
+
+
+def test_placeholder_warns_loud_in_dev(monkeypatch) -> None:
+    """Dev/test mode emits a WARNING containing INSECURE / PLAINTEXT.
+
+    The autouse `_auth_bypass` fixture imports `beever_atlas.server.app`
+    which sets `propagate=False` on the `beever_atlas` logger, so
+    caplog (root) doesn't see records from `beever_atlas.infra.config`.
+    Capture via direct monkeypatch on the module logger instead.
+    """
+    captured: list[str] = []
+    monkeypatch.setattr(
+        config_mod.logger,
+        "warning",
+        lambda msg, *a, **kw: captured.append(msg % a if a else msg),
+    )
+    Settings(
+        beever_env="development",
+        credential_master_key=_INSECURE_PLACEHOLDER_KEY,
+    )
+    matched = [m for m in captured if "INSECURE" in m and "PLAINTEXT" in m]
+    assert matched, f"expected a WARNING containing INSECURE/PLAINTEXT keywords; got: {captured}"
+
+
+def test_valid_random_key_passes_in_production() -> None:
+    """A freshly-generated 64-char hex key satisfies the validator."""
+    fresh = secrets.token_hex(32)
+    assert fresh != _INSECURE_PLACEHOLDER_KEY
+    # No exception raised.
+    Settings(**_prod_kwargs(credential_master_key=fresh))
+
+
+def test_placeholder_matches_env_example() -> None:
+    """Drift guard: the constant in config.py and `.env.example` MUST agree.
+    Use grep-based extraction (NOT line-number indexing) so cosmetic edits
+    to `.env.example` don't break this test."""
+    # Two parents up from this test file (tests/infra/) → repo root.
+    repo_root = pathlib.Path(__file__).resolve().parents[2]
+    env_example = (repo_root / ".env.example").read_text()
+    match = re.search(
+        r"^CREDENTIAL_MASTER_KEY=(\S+)$",
+        env_example,
+        re.MULTILINE,
+    )
+    assert match, ".env.example must contain CREDENTIAL_MASTER_KEY=..."
+    assert match.group(1) == _INSECURE_PLACEHOLDER_KEY, (
+        "drift between .env.example and config._INSECURE_PLACEHOLDER_KEY — "
+        "either both updated together or neither"
+    )


### PR DESCRIPTION
## Summary

When Python is missing on the host, the `atlas` installer silently leaves the public well-known placeholder `00...deadbeef` (visible in `.env.example`) as `CREDENTIAL_MASTER_KEY` in `.env`. The backend validator only checks 64 hex chars (which the placeholder satisfies), so all "encrypted" credentials become effectively plaintext to anyone who reads `.env.example`. Plausible scenario on minimal Docker hosts and NAS devices.

Two layers of defense:

1. **`atlas` installer** gets a pure-bash fallback for hex generation when Python is missing
2. **Backend validator** rejects the well-known placeholder explicitly (production hard-error, dev loud warning)

## Changes

| File | Change |
|---|---|
| `atlas` | `gen_hex()` now has a fallback chain: Python → `od -An -tx1 -N${bytes} /dev/urandom \| tr -d ' \n'` → fail-loud (exit 1). Removed redundant `[ -n "$PY_CMD" ]` guards from ALL 5 callers (`prompt_internal_secret`, MCP block, auth-token rotation, CREDENTIAL_MASTER_KEY block, WEAVIATE_API_KEY block). The placeholder block + WEAVIATE block now `exit 1` rather than ship the placeholder when both Python and /dev/urandom are unavailable. |
| `infra/config.py` | New `_INSECURE_PLACEHOLDER_KEY` module constant (single source of truth). `_validate_production` rejects it explicitly: production raises `ValueError` with `INSECURE`/`PLAINTEXT` keywords; dev/test logs the same message at WARNING severity (consistent with the rest of the validator — no escalation to logger.critical). |
| `tests/infra/test_credential_master_key_validation.py` (new) | 4 tests: production rejection, dev WARNING, valid random key passes, drift guard against `.env.example`. |

## Why "reject prod + warn dev" instead of "always reject"

A developer running `cp .env.example .env && docker compose up` for a quick spin-up should not be blocked. The combination of:
- `atlas` installer fails-loud (placeholder cannot escape)
- Validator rejects in prod (which has stricter checks anyway)
- Validator emits LOUD WARNING in dev (specific INSECURE/PLAINTEXT keywords in problem string)

…is sufficient defense without breaking the quickstart. Architect explored the antithesis (always reject + escape hatch env var) and found the maintenance overhead not worth the marginal security gain.

## Test plan

- [x] `pytest tests/infra/test_credential_master_key_validation.py -v`: 4/4 PASS
- [x] `pytest tests/ --ignore=tests/integration`: 1471 PASS, 0 FAIL
- [x] `bash -n atlas`: clean
- [x] Bash fallback verified locally — `od -An -tx1 -N32 /dev/urandom | tr -d ' \n'` produces 64-char hex matching `secrets.token_hex(32)`

## Process

Full ralplan: Planner → Architect APPROVE-WITH-PATCHES (3 patches, **1 critical**: original plan only fixed CREDENTIAL_MASTER_KEY + WEAVIATE_API_KEY paths but left 5 other gen_hex callers — `prompt_internal_secret`, MCP, rotation — still broken without Python). Critic skipped (mechanical change, Architect was thorough). Plan: `.omc/plans/fix-credential-master-key-placeholder.md` (rev2).

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)