### PR TITLE
fix(ci): pin nightly service images by digest + extend supply-chain lint to workflows (#42)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,8 +171,17 @@ jobs:
               esac
             done < "$f"
           done
-          # Compose files: reject `image:` lines without @sha256:.
-          for f in docker-compose.yml docker-compose.nebula.yml; do
+          # Compose files + GitHub Actions workflow service images: reject
+          # `image:` lines without @sha256:. Issue #42 added the workflows
+          # scan after the nightly job's `services:` images were caught
+          # running unpinned. The existing
+          # `^[[:space:]]*image:[[:space:]]+` regex matches both
+          # compose-level and `services:` block image references.
+          targets="docker-compose.yml docker-compose.nebula.yml"
+          for wf in .github/workflows/*.yml; do
+            [ -f "$wf" ] && targets="$targets $wf"
+          done
+          for f in $targets; do
             [ -f "$f" ] || continue
             while IFS= read -r line; do
               ref="$(echo "$line" | awk '/^[[:space:]]*image:[[:space:]]+/{print $2}')"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -11,8 +11,13 @@ jobs:
     runs-on: ubuntu-latest
 
     services:
+      # Issue #42 — service images pinned by digest. Tag-only references
+      # (e.g. `neo4j:5.26`) are vulnerable to a compromised-tag supply-chain
+      # attack: a malicious push to the same tag would silently affect this
+      # CI run. The `supply-chain-lint` job in `ci.yml` now scans this file
+      # so any future `image:` reference without `@sha256:` fails CI.
       neo4j:
-        image: neo4j:5.26
+        image: neo4j:5.26@sha256:b357872da95a164c5243ca8d9060601130717ff43cee3c829402fab46209a412
         env:
           NEO4J_AUTH: neo4j/beever_atlas_dev
           NEO4J_PLUGINS: '["apoc"]'
@@ -26,17 +31,17 @@ jobs:
           --health-retries 20
 
       nebula-metad:
-        image: vesoft/nebula-metad:v3.8.0
+        image: vesoft/nebula-metad:v3.8.0@sha256:ab687bd32d3e441d436842b41427ba0961a5e169c46997ef03fa4dcfd5388b35
         ports:
           - 9559:9559
 
       nebula-storaged:
-        image: vesoft/nebula-storaged:v3.8.0
+        image: vesoft/nebula-storaged:v3.8.0@sha256:7142642ee69001a5b5c50520196538d58bb2ec3930707c067cb4c4e2be3890f9
         ports:
           - 9779:9779
 
       nebula-graphd:
-        image: vesoft/nebula-graphd:v3.8.0
+        image: vesoft/nebula-graphd:v3.8.0@sha256:1040573cc684ea6cc5e673b667422e9abab607c9d553c2c17c7bac6ad8a74e05
         ports:
           - 9669:9669
 


### PR DESCRIPTION
## Summary

`nightly.yml` used unpinned tag-only references for its `services:` images (4 of them: `neo4j:5.26`, plus 3 nebula images). The existing `supply-chain-lint` job only scanned Dockerfiles + docker-compose files, leaving a blind spot for GitHub Actions workflow service images. A compromised tag pushed to any of those upstream registries would silently affect CI.

## Changes

| File | Change |
|---|---|
| `.github/workflows/nightly.yml` | Pin all 4 service images by `@sha256:` digest. Digests captured from current upstream tags via `docker pull <ref> && docker inspect --format='{{index .RepoDigests 0}}' <ref>`. |
| `.github/workflows/ci.yml` | Extend the `supply-chain-lint` job to iterate over `.github/workflows/*.yml` in addition to the existing compose files. The same `^[[:space:]]*image:[[:space:]]+` regex matches both compose-level and `services:` block image references — only the file-list needed expansion. |

## Pinned digests

| Image | Digest |
|---|---|
| `neo4j:5.26` | `b357872da95a164c5243ca8d9060601130717ff43cee3c829402fab46209a412` |
| `vesoft/nebula-metad:v3.8.0` | `ab687bd32d3e441d436842b41427ba0961a5e169c46997ef03fa4dcfd5388b35` |
| `vesoft/nebula-storaged:v3.8.0` | `7142642ee69001a5b5c50520196538d58bb2ec3930707c067cb4c4e2be3890f9` |
| `vesoft/nebula-graphd:v3.8.0` | `1040573cc684ea6cc5e673b667422e9abab607c9d553c2c17c7bac6ad8a74e05` |

## Verification

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` on both workflow files: clean
- [x] Local lint dry-run with the extended file set: **0 violations** (all 6 workflow `image:` refs now pinned: `mongo+redis` in `ci.yml`, `neo4j+nebula×3` in `nightly.yml`)
- [x] **Negative test**: stub workflow with `image: redis:7` (unpinned) triggers a violation under the new lint, confirming the scan reaches workflow files

## Maintenance note

When bumping a pinned tag, regenerate the digest via:
```sh
docker pull <ref>
docker inspect --format='{{index .RepoDigests 0}}' <ref>
```
…and update both the tag and the digest atomically. The tag is retained alongside the digest as a human-readable hint.

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)