### PR TITLE
fix(web): show all 5 platforms on onboarding welcome screen

### DIFF
--- a/web/src/components/onboarding/WelcomeScreen.tsx
+++ b/web/src/components/onboarding/WelcomeScreen.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect } from "react";
-import { MessageSquare, Monitor, Building2, ChevronRight, Sparkles } from "lucide-react";
+import { MessageSquare, Monitor, Building2, MessagesSquare, FileText, ChevronRight, Sparkles } from "lucide-react";
 import EmojiPicker, { Theme } from "emoji-picker-react";
 import type { EmojiClickData } from "emoji-picker-react";
 import { cn } from "@/lib/utils";
@@ -13,6 +13,8 @@ const PLATFORMS: { key: string; label: string; icon: React.ComponentType<{ class
   { key: "slack", label: "Slack", icon: MessageSquare, desc: "Connect a Slack workspace" },
   { key: "discord", label: "Discord", icon: Monitor, desc: "Connect a Discord server" },
   { key: "teams", label: "Teams", icon: Building2, desc: "Connect a Teams tenant" },
+  { key: "mattermost", label: "Mattermost", icon: MessagesSquare, desc: "Connect a Mattermost server" },
+  { key: "file", label: "File Import", icon: FileText, desc: "Upload a CSV / TSV / JSONL chat export" },
 ];
 
 export function WelcomeScreen({ onConnect }: WelcomeScreenProps) {

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -10,10 +10,11 @@ import { ActivityFeed } from "@/components/dashboard/ActivityFeed";
 import { useStats, useActivity } from "@/hooks/useStats";
 import { WelcomeScreen } from "@/components/onboarding/WelcomeScreen";
 import { ConnectionWizard } from "@/components/settings/ConnectionWizard";
+import { FileImportWizard } from "@/components/settings/FileImportWizard";
 import { useUserProfile } from "@/hooks/useUserProfile";
 import type { PlatformConnection } from "@/lib/types";
 
-type Platform = "slack" | "discord" | "teams" | "telegram";
+type Platform = "slack" | "discord" | "teams" | "telegram" | "mattermost";
 
 interface Channel {
   channel_id: string;
@@ -33,6 +34,7 @@ export function Dashboard() {
   const [connectionsLoading, setConnectionsLoading] = useState(true);
   const [showWizard, setShowWizard] = useState(false);
   const [wizardPlatform, setWizardPlatform] = useState<Platform>("slack");
+  const [showFileImport, setShowFileImport] = useState(false);
   const { resolvedTheme } = useTheme();
   const isDark = resolvedTheme === "dark";
   const { stats, loading: statsLoading } = useStats();
@@ -67,8 +69,12 @@ export function Dashboard() {
       <>
         <WelcomeScreen
           onConnect={(platform) => {
-            setWizardPlatform(platform as Platform);
-            setShowWizard(true);
+            if (platform === "file") {
+              setShowFileImport(true);
+            } else {
+              setWizardPlatform(platform as Platform);
+              setShowWizard(true);
+            }
           }}
         />
         {showWizard && (
@@ -77,6 +83,16 @@ export function Dashboard() {
             onClose={() => setShowWizard(false)}
             onComplete={() => {
               setShowWizard(false);
+              fetchConnections();
+              window.dispatchEvent(new Event("connections-changed"));
+            }}
+          />
+        )}
+        {showFileImport && (
+          <FileImportWizard
+            onClose={() => setShowFileImport(false)}
+            onComplete={() => {
+              setShowFileImport(false);
               fetchConnections();
               window.dispatchEvent(new Event("connections-changed"));
             }}


### PR DESCRIPTION
## Summary
- The Settings page lets users connect Slack, Discord, Microsoft Teams, Mattermost, and File Import, but the onboarding **Welcome → Connect a platform** screen only exposed Slack/Discord/Teams. New users with a Mattermost workspace or a chat export had no entry point.
- Adds the missing **Mattermost** and **File Import** tiles to `WelcomeScreen.tsx` so the onboarding grid matches Settings.
- Extends `Dashboard.tsx` to handle the new choices: `Platform` union now includes `"mattermost"` (already supported by `ConnectionWizard`), and the `"file"` key is routed to `FileImportWizard` instead of `ConnectionWizard` (mirroring how `SettingsPage` does it).

## Test plan
- [ ] Hard-reload `http://localhost:3000/` against a fresh DB (no connections) and confirm the onboarding screen shows 5 tiles in the 2-column grid: Slack, Discord, Teams, Mattermost, File Import.
- [ ] Click **Mattermost** → `ConnectionWizard` opens with Mattermost steps (no console errors).
- [ ] Click **File Import** → `FileImportWizard` opens (not `ConnectionWizard`).
- [ ] Cancel each wizard and confirm the onboarding view is restored.
- [ ] Complete a Slack/Discord/Teams connection and confirm the post-onboarding dashboard still loads (no regression on existing platforms).

🤖 Generated with [Claude Code](https://claude.com/claude-code)