### PR TITLE
fix(preprocessor): remove broken cross-batch Weaviate fallback (#44)

### DIFF
--- a/src/beever_atlas/agents/ingestion/preprocessor.py
+++ b/src/beever_atlas/agents/ingestion/preprocessor.py
@@ -257,23 +257,21 @@ async def _resolve_cross_batch_parent(
                 text = text[: max_len - 3] + "..."
             return f"[Reply to {author}: {text}]"
 
-        # Fallback: search Weaviate for a fact from this message
-        weaviate_facts = await stores.weaviate.list_facts(
-            channel_id=msg.get("channel_id", ""),
-            filters=type(
-                "F",
-                (),
-                {"topic": None, "entity": None, "importance": None, "since": None, "until": None},
-            )(),
-            page=1,
-            limit=1,
-        )
-        if weaviate_facts:
-            first = weaviate_facts[0] if isinstance(weaviate_facts, list) else None
-            if first:
-                text = (first.get("text") or first.get("statement") or "")[:max_len]
-                if text:
-                    return f"[Reply to thread: {text}]"
+        # Issue #44 — there used to be a Weaviate fallback here that called
+        # `list_facts(filters=<all-None>, limit=1)` to fetch "some" fact from
+        # the channel. Two problems:
+        #   1. SEMANTICALLY WRONG: the returned fact has no relation to
+        #      `thread_ts` — `list_facts` with all-None filters yields an
+        #      arbitrary channel fact (whichever Weaviate returns first).
+        #      Feeding that into the LLM prompt as `[Reply to thread: ...]`
+        #      misled the preprocessor with authoritative-looking garbage.
+        #   2. FULL-CHANNEL SCAN: `list_facts` computes `total_count` via
+        #      `aggregate.over_all(total_count=True)` — O(channel size) per
+        #      cross-batch parent lookup. Combined with (1) the cost was
+        #      paid for a wrong answer.
+        # Removed entirely. If the MongoDB lookup at L252 misses, we now
+        # return None — no cross-batch context for that message — which is
+        # the correct contract: silent absence > silent garbage.
 
     except Exception:
         logger.warning(

--- a/tests/agents/ingestion/test_cross_batch_no_weaviate_fallback.py
+++ b/tests/agents/ingestion/test_cross_batch_no_weaviate_fallback.py
@@ -1,0 +1,134 @@
+"""Regression tests for `_resolve_cross_batch_parent` — issue #44.
+
+Asserts the corrected contract:
+  * MongoDB hit → returns `[Reply to <author>: <text>]`
+  * MongoDB miss → returns None (NOT the previous Weaviate fallback that
+    yielded an unrelated fact from the channel)
+  * Disabled flag → returns None
+  * In-batch resolution → returns None (parent already in `messages_by_ts`)
+
+Uses AsyncMock for the MongoDB collection so the test runs without a
+live MongoDB.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+from beever_atlas.agents.ingestion import preprocessor as pre_mod
+from beever_atlas.agents.ingestion.preprocessor import _resolve_cross_batch_parent
+
+
+def _stores_with(mongodb_record: dict | None) -> MagicMock:
+    """Build a fake `stores` whose `mongodb.db['raw_messages'].find_one`
+    returns the supplied record (or None for a miss)."""
+    stores = MagicMock()
+    stores.mongodb.db = {"raw_messages": MagicMock()}
+    stores.mongodb.db["raw_messages"].find_one = AsyncMock(return_value=mongodb_record)
+    # Issue #44 verification: weaviate must NOT be touched. Wire up a
+    # MagicMock and assert no calls were made on it after the function
+    # returns.
+    stores.weaviate.list_facts = AsyncMock(
+        side_effect=AssertionError(
+            "weaviate.list_facts must NOT be called — issue #44 removed the fallback"
+        ),
+    )
+    return stores
+
+
+def _settings_with(thread_context_enabled: bool = True) -> MagicMock:
+    s = MagicMock()
+    s.cross_batch_thread_context_enabled = thread_context_enabled
+    s.thread_context_max_length = 200
+    return s
+
+
+# ── Tests ───────────────────────────────────────────────────────────────
+
+
+async def test_mongodb_hit_returns_reply_context(monkeypatch) -> None:
+    """When MongoDB has the parent message, format and return the
+    [Reply to <author>: <text>] context string."""
+    record = {
+        "message_ts": "1700000000.000100",
+        "author_name": "alice",
+        "text": "Original parent message",
+    }
+    stores = _stores_with(record)
+    monkeypatch.setattr(pre_mod, "get_settings", lambda: _settings_with())
+    monkeypatch.setattr("beever_atlas.stores.get_stores", lambda: stores)
+
+    result = await _resolve_cross_batch_parent(
+        msg={
+            "thread_ts": "1700000000.000100",
+            "message_ts": "1700000001.000200",
+            "channel_id": "C_TEST",
+        },
+        messages_by_ts={},
+    )
+
+    assert result == "[Reply to alice: Original parent message]"
+
+
+async def test_mongodb_miss_returns_none_not_fallback(monkeypatch) -> None:
+    """Issue #44 — when MongoDB has no record, return None instead of
+    falling back to an unrelated Weaviate fact. The fake `stores.weaviate.list_facts`
+    raises AssertionError if called, so this test fails loudly if the
+    fallback ever returns."""
+    stores = _stores_with(None)
+    monkeypatch.setattr(pre_mod, "get_settings", lambda: _settings_with())
+    monkeypatch.setattr("beever_atlas.stores.get_stores", lambda: stores)
+
+    result = await _resolve_cross_batch_parent(
+        msg={
+            "thread_ts": "1700000000.000100",
+            "message_ts": "1700000001.000200",
+            "channel_id": "C_TEST",
+        },
+        messages_by_ts={},
+    )
+
+    assert result is None
+    # Assert the broken fallback was NOT exercised.
+    stores.weaviate.list_facts.assert_not_called()
+
+
+async def test_disabled_flag_returns_none(monkeypatch) -> None:
+    """Feature-flag disabled → short-circuit None before any store call."""
+    stores = _stores_with(None)
+    monkeypatch.setattr(
+        pre_mod, "get_settings", lambda: _settings_with(thread_context_enabled=False)
+    )
+    monkeypatch.setattr("beever_atlas.stores.get_stores", lambda: stores)
+
+    result = await _resolve_cross_batch_parent(
+        msg={
+            "thread_ts": "1700000000.000100",
+            "message_ts": "1700000001.000200",
+            "channel_id": "C_TEST",
+        },
+        messages_by_ts={},
+    )
+
+    assert result is None
+    stores.mongodb.db["raw_messages"].find_one.assert_not_called()
+
+
+async def test_in_batch_resolution_returns_none(monkeypatch) -> None:
+    """If `thread_ts` is already in `messages_by_ts`, no cross-batch
+    lookup is needed — return None."""
+    stores = _stores_with(None)
+    monkeypatch.setattr(pre_mod, "get_settings", lambda: _settings_with())
+    monkeypatch.setattr("beever_atlas.stores.get_stores", lambda: stores)
+
+    result = await _resolve_cross_batch_parent(
+        msg={
+            "thread_ts": "1700000000.000100",
+            "message_ts": "1700000001.000200",
+            "channel_id": "C_TEST",
+        },
+        messages_by_ts={"1700000000.000100": {"text": "in-batch parent"}},
+    )
+
+    assert result is None
+    stores.mongodb.db["raw_messages"].find_one.assert_not_called()


### PR DESCRIPTION
## Summary

`_resolve_cross_batch_parent` (preprocessor.py L261-270) had a Weaviate fallback that called `list_facts(filters=<all-None>, limit=1)` when the MongoDB lookup missed. Two problems:

1. **Semantically wrong**: `list_facts` with all-None filters returns an arbitrary fact from the channel — no relation to the `thread_ts` we're resolving. That fact was then formatted as `[Reply to thread: <text>]` and fed to the LLM as authoritative cross-batch context, generating coreferences against unrelated facts.
2. **Full-channel scan**: `list_facts` computes `total_count` via `aggregate.over_all(total_count=True)` — O(channel size) per parent lookup, paid for a wrong answer.

## Decision

Of the three fixes the issue suggested:
- **Option 1** (`since`/`until` window from `thread_ts`): narrows but doesn't fix correctness — a 1-second window can still match unrelated channel facts at scale.
- **Option 2** (remove the fallback) — chosen. MongoDB lookup is the only correct path; if it misses, returning None is the correct contract: **silent absence > silent garbage**.
- **Option 3** (skip `total_count`): addresses perf, not correctness — you'd still feed garbage to the LLM, just faster.

## Changes

| File | Change |
|---|---|
| `agents/ingestion/preprocessor.py` | Delete the broken Weaviate fallback (15 lines). Replace with a comment block explaining both failure modes so a future contributor doesn't reintroduce the same shape. |
| `tests/agents/ingestion/test_cross_batch_no_weaviate_fallback.py` (new) | 4 regression tests asserting: MongoDB hit returns reply context, MongoDB miss returns None, feature flag disabled short-circuits, in-batch parent returns None. Each test wires an `AsyncMock` Weaviate `list_facts` that raises `AssertionError` if called — the negative invariant is enforced. |

## Test plan

- [x] `pytest tests/agents/ingestion/test_cross_batch_no_weaviate_fallback.py -v`: 4/4 PASS
- [x] `pytest tests/agents/ingestion/ -q`: 14 PASS (10 existing + 4 new)
- [x] `pytest tests/ --ignore=tests/integration`: 1550 PASS, 0 FAIL
- [x] `ruff check + format --check`: clean

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)