### PR TITLE
fix(security): verify session ownership in v1 feedback + ask endpoints (#45)

### DIFF
--- a/src/beever_atlas/api/ask.py
+++ b/src/beever_atlas/api/ask.py
@@ -1066,6 +1066,12 @@ async def ask_channel(
     await assert_channel_access(principal, channel_id)
     user_id = principal.id
     session_id = body.session_id or str(uuid.uuid4())
+    # Issue #45 — when the client supplies a session_id, verify it isn't
+    # someone else's session before persisting Q&A messages or feedback to
+    # it. New session_ids (those not yet in chat_history) pass through
+    # silently as legitimate first-message sessions.
+    if body.session_id:
+        await _assert_session_ownership_or_new(session_id, user_id)
 
     return StreamingResponse(
         _run_agent_stream(
@@ -1153,10 +1159,15 @@ async def submit_feedback(
 ) -> dict:
     """Submit thumbs up/down feedback on an assistant response."""
     await assert_channel_access(principal, channel_id)
+    user_id = principal.id
+    # Issue #45 — verify the session belongs to the caller before upserting
+    # feedback. Without this, any authenticated user could submit feedback
+    # against another user's session_id (the v2 endpoint already had this
+    # check via _verify_session_ownership; v1 was missed).
+    await _verify_session_ownership(body.session_id, user_id)
     # Phase 2 of #31 — use the shared MongoDB client from StoreClients.
     from beever_atlas.stores import get_stores
 
-    user_id = principal.id
     db = get_stores().mongodb.db
 
     doc = {
@@ -1312,6 +1323,9 @@ async def ask_v2(
     await assert_channel_access(principal, body.channel_id)
     user_id = principal.id
     session_id = body.session_id or str(uuid.uuid4())
+    # Issue #45 — verify ownership when the client supplies a session_id.
+    if body.session_id:
+        await _assert_session_ownership_or_new(session_id, user_id)
 
     return StreamingResponse(
         _run_agent_stream(
@@ -1498,6 +1512,29 @@ async def _verify_session_ownership(session_id: str, user_id: str) -> dict:
     if session.get("user_id") != user_id:
         raise HTTPException(status_code=403, detail="Forbidden")
     return session
+
+
+async def _assert_session_ownership_or_new(session_id: str, user_id: str) -> bool:
+    """Issue #45 — variant of `_verify_session_ownership` for endpoints
+    where a NEW session_id is legitimate (the ask endpoints accept
+    client-generated UUIDs for first-message sessions).
+
+    Returns True if the session exists and belongs to ``user_id``.
+    Returns False if the session doesn't exist (caller should treat as a
+    new session).
+    Raises 403 if the session exists but belongs to a different user —
+    this is the bug class issue #45 closes: client-supplied session_ids
+    being used to inject Q&A messages and feedback into another user's
+    session document.
+    """
+    from beever_atlas.stores import get_stores
+
+    session = await get_stores().chat_history.load_session(session_id=session_id)
+    if not session:
+        return False
+    if session.get("user_id") != user_id:
+        raise HTTPException(status_code=403, detail="Forbidden")
+    return True
 
 
 @router.post("/api/ask/sessions/{session_id}/share")

--- a/tests/api/test_ask_v1_feedback_ownership.py
+++ b/tests/api/test_ask_v1_feedback_ownership.py
@@ -1,0 +1,146 @@
+"""Issue #45: the v1 `POST /api/channels/{channel_id}/ask/feedback`
+endpoint must reject sessions not owned by the caller — same fix as
+RES-202 / `test_ask_feedback_ownership.py` for the v2 endpoint.
+
+Before this fix, any authenticated user could upsert ``qa_feedback``
+keyed by `(session_id, message_id)` against another user's session_id
+and overwrite their feedback.
+
+Mirrors `test_ask_feedback_ownership.py` (v2) so the test shapes stay
+in sync.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from beever_atlas.infra.auth import Principal, require_user
+from beever_atlas.infra.config import get_settings
+from beever_atlas.server.app import app
+from beever_atlas.stores.chat_history_store import ChatHistoryStore
+
+OWNER = Principal("user:owner-v1fb", kind="user")
+STRANGER = Principal("user:stranger-v1fb", kind="user")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture
+async def client():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+def _install_principal(p: Principal):
+    saved = app.dependency_overrides.get(require_user)
+    app.dependency_overrides[require_user] = lambda: p
+
+    def _restore() -> None:
+        if saved is None:
+            app.dependency_overrides.pop(require_user, None)
+        else:
+            app.dependency_overrides[require_user] = saved
+
+    return _restore
+
+
+@pytest.fixture
+def as_owner(_auth_bypass):
+    restore = _install_principal(OWNER)
+    try:
+        yield OWNER
+    finally:
+        restore()
+
+
+@pytest.fixture
+def as_stranger(_auth_bypass):
+    restore = _install_principal(STRANGER)
+    try:
+        yield STRANGER
+    finally:
+        restore()
+
+
+@pytest.fixture
+async def owned_session():
+    """Seed a chat_history session owned by OWNER and clean up after."""
+    session_id = f"test-v1fb-{uuid.uuid4()}"
+    settings = get_settings()
+    store = ChatHistoryStore(settings.mongodb_uri)
+    await store.startup()
+    try:
+        await store._collection.insert_one(
+            {
+                "session_id": session_id,
+                "user_id": str(OWNER),
+                "channel_id": "C_MOCK_GENERAL",
+                "title": "v1-fb-test",
+                "messages": [],
+                "created_at": datetime.now(UTC),
+                "updated_at": datetime.now(UTC),
+            }
+        )
+        yield session_id
+    finally:
+        await store._collection.delete_many({"session_id": session_id})
+        store.close()
+        from motor.motor_asyncio import AsyncIOMotorClient
+
+        fb_client = AsyncIOMotorClient(settings.mongodb_uri)
+        try:
+            await fb_client["beever_atlas"].qa_feedback.delete_many({"session_id": session_id})
+        finally:
+            fb_client.close()
+
+
+@pytest.mark.anyio
+async def test_stranger_cannot_submit_feedback_on_owners_session(
+    client: AsyncClient, as_stranger, owned_session: str
+):
+    """Issue #45 — v1 endpoint must 403 the stranger, matching v2 behaviour."""
+    r = await client.post(
+        "/api/channels/C_MOCK_GENERAL/ask/feedback",
+        json={"session_id": owned_session, "message_id": "m1", "rating": "up"},
+    )
+    assert r.status_code == 403, r.text
+
+
+@pytest.mark.anyio
+async def test_unknown_session_returns_404(client: AsyncClient, as_owner):
+    """A session_id that doesn't exist in chat_history must 404."""
+    r = await client.post(
+        "/api/channels/C_MOCK_GENERAL/ask/feedback",
+        json={
+            "session_id": f"does-not-exist-v1-{uuid.uuid4()}",
+            "message_id": "m1",
+            "rating": "down",
+        },
+    )
+    assert r.status_code == 404, r.text
+
+
+@pytest.mark.anyio
+async def test_owner_happy_path_still_works(client: AsyncClient, as_owner, owned_session: str):
+    """Owner must still be able to submit feedback on their own session."""
+    r = await client.post(
+        "/api/channels/C_MOCK_GENERAL/ask/feedback",
+        json={
+            "session_id": owned_session,
+            "message_id": "m1",
+            "rating": "up",
+            "comment": "v1 fix works",
+        },
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["feedback"]["user_id"] == str(OWNER)
+    assert body["feedback"]["rating"] == "up"


### PR DESCRIPTION
## Summary

Two distinct instances of the same bug class — client-supplied `session_id` used without ownership verification:

1. **v1 `POST /api/channels/{id}/ask/feedback`** — accepted any `body.session_id` and upserted `qa_feedback` keyed by `(session_id, message_id)`. Malicious authenticated user could overwrite another user's feedback or inject channel_id attribution into analytics. The v2 endpoint was fixed in RES-202; v1 was missed.
2. **`ask_channel` / `ask_v2`** — accepted client-generated `body.session_id` and passed it through to `_persist_qa_history`, which writes Q&A messages to the chat_history session document keyed by that session_id. Malicious client could supply another user's session_id and inject Q&A messages into their session document.

## Changes

| File | Change |
|---|---|
| `api/ask.py` | New helper `_assert_session_ownership_or_new` (variant of `_verify_session_ownership` for endpoints where a new session_id is legitimate). `ask_channel` + `ask_v2` call it when `body.session_id` is provided. v1 `submit_feedback` calls the strict `_verify_session_ownership` before upsert (matching the v2 fix). |
| `tests/api/test_ask_v1_feedback_ownership.py` (new) | Mirrors `test_ask_feedback_ownership.py` (v2): stranger 403, unknown session 404, owner happy path. |

## Why two helpers, not one

`_verify_session_ownership` is strict: 404 on missing session. Correct for `get_session`, `update_session`, `delete_session`, `share`, v1+v2 `feedback` — all of which operate on existing sessions.

`_assert_session_ownership_or_new` is ask-friendly: returns False (proceed as new session) on missing, raises 403 only if exists-and-owned-by-someone-else. Correct for `ask_channel`/`ask_v2` where client-generated UUIDs for first-message sessions are legitimate.

A single function with a `must_exist: bool` flag would obscure the contract at call sites. Two named functions make each call site's intent explicit.

## Test plan

- [x] `pytest tests/api/test_ask_v1_feedback_ownership.py tests/api/test_ask_feedback_ownership.py -v`: 6/6 PASS (3 v1 + 3 v2)
- [x] `pytest tests/ --ignore=tests/integration`: 1550 PASS, 0 FAIL
- [x] `ruff check + format --check`: clean

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)