### PR TITLE
fix(make): trap-based cleanup for dev target + stop helper (#46)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install test lint dev docker-up docker-down clean demo demo-regenerate-fixtures
+.PHONY: install test lint dev stop docker-up docker-down clean demo demo-regenerate-fixtures
 
 install:
 	uv sync --extra dev
@@ -15,10 +15,26 @@ lint:
 	cd web && npm run lint && npm run typecheck
 	cd bot && npm run lint
 
+# Issue #46 — run all 3 dev servers in ONE shell so they share a process
+# group; `trap 'kill 0' EXIT` reaps the group when Ctrl-C lands. Without
+# this, each `&`-backgrounded process was orphaned in its own subshell
+# and held its port (8000 / 5173 / 3001), forcing the next `make dev` to
+# error with "address already in use".
 dev:
-	uv run uvicorn beever_atlas.server.app:app --reload &
-	cd web && npm run dev &
-	cd bot && npm run dev
+	@trap 'kill 0' EXIT INT TERM; \
+	uv run uvicorn beever_atlas.server.app:app --reload & \
+	(cd web && npm run dev) & \
+	(cd bot && npm run dev) & \
+	wait
+
+# Force-kill any orphans from a previous `make dev` that didn't tear down
+# cleanly (process killed with -9, container restart, etc.). Idempotent
+# (`|| true` on each pkill so missing processes don't fail the recipe).
+stop:
+	@pkill -f "uvicorn beever_atlas" || true
+	@pkill -f "vite" || true
+	@pkill -f "npm run dev" || true
+	@echo "stopped any orphan dev servers (uvicorn / vite / npm)"
 
 docker-up:
 	docker compose up -d


### PR DESCRIPTION
## Summary

The `dev` target backgrounded uvicorn and the web Vite server with `&` in separate Makefile recipe lines. Make runs each line in a separate shell, so each `&` orphaned its process when the parent shell exited. Ctrl-C on the bot (foreground) killed only the bot — uvicorn + Vite continued running and held ports 8000 / 5173. Next `make dev` failed with "address already in use" until the developer manually `lsof | kill`-ed the orphans.

## Changes

| Target | Change |
|---|---|
| `dev` | Run all three servers in a SINGLE shell invocation (line continuations). Install `trap 'kill 0' EXIT INT TERM` + `wait`. Ctrl-C reaps the entire process group. |
| `stop` (new) | Force-kill backstop using `pkill -f` for cases where the trap didn't fire (kill -9, container restart). Each guarded with `|| true` so missing processes don't fail the recipe. |

## Why bash trap, not `concurrently`/`foreman`

- **Zero new dependencies** — the project hasn't installed any process manager and doesn't need one for 3 servers.
- The bash trap pattern is a 30-year-old idiom that works on macOS, Linux, and WSL.
- Adding `concurrently` to either `web/` or `bot/` package.json for a 5-line Makefile fix is disproportionate.

## Verification

- `make -n dev` and `make -n stop`: both parse and produce expected shell.
- **Local smoke** of the trap pattern: spawned 3 background `sleep 100` processes, sent SIGTERM to the parent shell, all 3 children immediately reaped via the EXIT trap.

## Maintenance note

When adding a new dev server, add it as `(cd <dir> && <cmd>) & \` between existing backgrounded lines and BEFORE the `wait`. The trap automatically reaps it.

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)