### PR TITLE
fix(bridge): remove dead Telegram workspace-ID extraction (#47)

### DIFF
--- a/bot/src/bridge.ts
+++ b/bot/src/bridge.ts
@@ -1635,17 +1635,22 @@ function detectPlatformFromUrl(url: string): string | null {
  * Returns null if no identifier can be extracted.
  *
  * - Slack: files-pri/{TEAM_ID}-{FILE_ID}/ → TEAM_ID (e.g. "T0APJ2FNUKZ")
- * - Telegram: api.telegram.org/file/bot{TOKEN}/... → bot token prefix
- * - Discord/Teams: not reliably extractable from URL
+ * - Discord/Teams/Telegram: not reliably extractable from URL — fall through
+ *   to the try-all-adapters path in the proxy handler.
+ *
+ * Issue #47 — the Telegram regex used to extract the bot token from
+ * `api.telegram.org/file/bot{TOKEN}/` and return it as a "workspace id"
+ * lookup key. But `chatManager.workspaceIdMap` is only populated for
+ * Slack (`team_id → connectionId`); Telegram never inserts. The lookup
+ * always missed and we fell through to try-all-adapters anyway. Removed
+ * to delete the dead routing path. If multi-Telegram-bot routing is
+ * needed later, populate the map in `chat-manager.ts` first (with a
+ * stable hash of the bot token, not the token itself).
  */
 function extractWorkspaceIdFromUrl(url: string): string | null {
   // Slack: extract team ID from files-pri/TEAM_ID-FILE_ID/
   const slackMatch = url.match(/files-pri\/([A-Z0-9]+)-[A-Z0-9]+\//);
   if (slackMatch) return slackMatch[1];
-
-  // Telegram: extract bot token from api.telegram.org/file/bot{TOKEN}/
-  const telegramMatch = url.match(/api\.telegram\.org\/file\/bot([^/]+)\//);
-  if (telegramMatch) return telegramMatch[1];
 
   return null;
 }


### PR DESCRIPTION
## Summary

`extractWorkspaceIdFromUrl` had a Telegram regex that pulled the bot token from `api.telegram.org/file/bot{TOKEN}/` URLs and used it as a `workspaceIdMap` lookup key. That map is only populated for Slack (`team_id → connectionId`); the Telegram registration path never inserts anything. The lookup always missed and proxying fell through to the try-all-adapters path. Dead-code routing.

## Why option (b) — remove — over option (a) — populate map

The issue gives two options:
- (a) Hash the bot token and populate `workspaceIdMap` so per-bot routing works
- (b) Remove the regex (it's dead code)

**Chosen (b)**: option (a) adds plumbing to support a multi-Telegram-bot deployment that may not exist. If that need arises, file a separate issue and design the hash strategy + key-collision story properly. Removing dead code now is a strict win; the try-all-adapters fallback already handles Telegram correctly.

## Changes

| File | Change |
|---|---|
| `bot/src/bridge.ts` | Remove the Telegram match arm in `extractWorkspaceIdFromUrl`. Update the docstring to document why it's gone and what's needed for future per-bot routing (populate the map with a HASH of the token, not the token itself). |

## Test plan

- [x] `npm test` (bot): 140/140 PASS — no test referenced the Telegram regex
- [x] `npm run lint` (bot): 0 errors, pre-existing warnings unchanged
- [x] `grep` confirms the single caller (`extractWorkspaceIdFromUrl` at L1855) still receives `null` for Telegram URLs and falls through to the same try-all-adapters path as before

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)