### PR TITLE
fix(ci): remove `upload: never` now that Code Scanning is enabled (#48)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -35,11 +35,7 @@ jobs:
         uses: github/codeql-action/analyze@v4
         with:
           category: "/language:${{ matrix.language }}"
-          # TODO(res-206 Q1.1 follow-up): remove `upload: never` once Code
-          # Scanning is enabled on this repo (free on public repos after
-          # OSS launch; requires GitHub Advanced Security on private repos).
-          # Until then, the SARIF upload fails with "Code Security must be
-          # enabled for this repository" and blocks CI. The CodeQL queries
-          # still run — any crash during analysis will still fail the job —
-          # but findings don't surface as Code Scanning alerts.
-          upload: never
+          # Issue #48 — Code Scanning is now enabled on this repo, so the
+          # SARIF upload (default) succeeds and findings surface in the
+          # GitHub Security tab. The previous `upload: never` workaround
+          # is removed; analysis crashes still fail the job (unchanged).


### PR DESCRIPTION
## Summary

The CodeQL workflow had `upload: never` as a deliberate workaround tracked in res-206 Q1.1: until GitHub Code Scanning was enabled on the repo, the SARIF upload would fail with "Code Security must be enabled for this repository" and block CI. The repo admin enabled Code Scanning today.

## Verification

```
$ gh api repos/Beever-AI/beever-atlas/code-scanning/alerts | head -3
[{"number":43,"created_at":"2026-04-29T17:56:55Z", ...
 "rule":{"id":"py/weak-sensitive-data-hashing", ...
```

Alerts are already populating from yesterday's scheduled CodeQL run, confirming Code Scanning is reachable.

## Changes

`.github/workflows/codeql.yml`: remove `upload: never` and the TODO block that explained why it was there. Replace with a 4-line comment marking the resolution.

## Effect on next CodeQL run

| Aspect | Before | After |
|---|---|---|
| Workflow runs (push/PR/cron) | ✅ | ✅ |
| Analysis crashes fail the job | ✅ | ✅ |
| SARIF upload | ❌ (gated) | ✅ (default) |
| Findings in GitHub Security tab | ❌ | ✅ (NEW) |

## Rollback

If the upload fails on this PR for an unexpected reason (GHAS policy mismatch, Actions permissions), revert immediately to restore the gate. The analysis path is unaffected by the gate, so reverting only re-suppresses uploads, not analysis.

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)