### PR TITLE
fix(bridge): use constantTimeEqual on hmacDual fallback path (#49)

### DIFF
--- a/bot/src/bridge.ts
+++ b/bot/src/bridge.ts
@@ -122,7 +122,18 @@ export function checkAuth(
   const authHeader = req.headers.authorization || "";
   const expected = `Bearer ${bridgeKey}`;
   if (!constantTimeEqual(authHeader, expected)) {
-    if (hmacDual && authHeader === expected) {
+    // Issue #49 — keep the comparison constant-time on every path.
+    // Previously this used `authHeader === expected`, which leaks
+    // string-comparison timing information about the bearer token
+    // (only exploitable when BEEVER_BRIDGE_HMAC_DUAL=true is set; the
+    // path is opt-in and slated for removal next release per the
+    // existing deprecation note). The branch is logically equivalent
+    // to the outer check (same inputs → same equality outcome), so
+    // it can never accept where the outer rejected — but using
+    // `constantTimeEqual` here makes the contract explicit and
+    // survives any future change to `expected` (e.g. multi-key
+    // rotation) that would make the branch reachable.
+    if (hmacDual && constantTimeEqual(authHeader, expected)) {
       console.warn(
         "Bridge auth: accepted via legacy == path (BEEVER_BRIDGE_HMAC_DUAL). Retire flag next release.",
       );


### PR DESCRIPTION
## Summary

The primary bridge auth path correctly used `constantTimeEqual` for the bearer-token comparison, but the legacy `BEEVER_BRIDGE_HMAC_DUAL` fallback used `authHeader === expected` — vulnerable to timing side-channel. JS string `===` short-circuits at the first mismatched byte, leaking partial information about the bearer token. The path is opt-in and the existing comment already plans flag removal next release; while the path is still in code, the comparison must be constant-time.

## Reachability note

The branch is logically dead code today: `constantTimeEqual` already returns false for any input pair where `===` returns false. No input reaches this branch via the outer `!constantTimeEqual` gate AND satisfies the `===` check. The fix is defense-in-depth: if `expected` later becomes a list (multi-key rotation), the branch becomes reachable, and the constant-time comparison must already be in place.

## Changes

| File | Change |
|---|---|
| `bot/src/bridge.ts` | Replace `authHeader === expected` with `constantTimeEqual(authHeader, expected)` inside the hmacDual fallback. Add a comment block explaining the reachability note + "retire next release" plan. |

## Test plan

- [x] `npm test` (bot): 140/140 PASS
- [x] `npm run lint`: 0 errors, 221 pre-existing warnings unchanged

Next release will remove the `BEEVER_BRIDGE_HMAC_DUAL` flag and this whole branch entirely (per the existing deprecation comment).

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)