### PR TITLE
fix(security): optional Mongo + Redis auth overlay (#50)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,6 +45,14 @@ MONGODB_URI=mongodb://localhost:27017/beever_atlas
 REDIS_URL=redis://localhost:6379
 WEAVIATE_URL=http://localhost:8080
 WEAVIATE_API_KEY=
+# Optional Mongo + Redis auth (issue #50). Empty by default = no auth, fine
+# for local dev where 127.0.0.1 host bindings already block external access.
+# Set these and apply the docker-compose.auth.yml overlay for shared-host or
+# pre-prod environments:
+#   docker compose -f docker-compose.yml -f docker-compose.auth.yml up
+# MONGODB_USERNAME=
+# MONGODB_PASSWORD=
+# REDIS_PASSWORD=
 
 # --- 1.7 Graph backend ("neo4j" | "none") ------
 GRAPH_BACKEND=neo4j

--- a/docker-compose.auth.yml
+++ b/docker-compose.auth.yml
@@ -59,3 +59,15 @@ services:
     environment:
       MONGODB_URI: mongodb://${MONGODB_USERNAME}:${MONGODB_PASSWORD}@mongodb:27017/beever_atlas?authSource=admin
       REDIS_URL: redis://:${REDIS_PASSWORD}@redis:6379
+
+  bot:
+    # The bot service in docker-compose.yml has its own hard-coded
+    # `REDIS_URL: redis://redis:6379` under `environment:`, which takes
+    # precedence over the `env_file: .env` value. We re-override it here
+    # so the bot can authenticate against the password-protected Redis.
+    # Without this, the bot crash-loops on its
+    # `redis: { condition: service_healthy }` startup gate (NOAUTH from
+    # rate-limit / queue clients), breaking the whole stack when the
+    # overlay is applied.
+    environment:
+      REDIS_URL: redis://:${REDIS_PASSWORD}@redis:6379

--- a/docker-compose.auth.yml
+++ b/docker-compose.auth.yml
@@ -1,0 +1,61 @@
+# Optional auth overlay for MongoDB + Redis (issue #50).
+#
+# The default `docker-compose.yml` runs MongoDB and Redis without
+# authentication — fine for single-developer local dev where only the
+# trusted backend container shares the network. This overlay enables
+# password auth for both services, useful when:
+#   * Running on a shared dev box where another local user could connect
+#   * Running with custom compose overrides that add untrusted containers
+#   * Running in any pre-production environment that mimics prod hardening
+#
+# Usage:
+#   docker compose -f docker-compose.yml -f docker-compose.auth.yml up
+#
+# Required env vars (set in .env or shell):
+#   MONGODB_USERNAME=<root user>           e.g. "beever_atlas_root"
+#   MONGODB_PASSWORD=<strong password>     gen with: $(openssl rand -hex 16)
+#   REDIS_PASSWORD=<strong password>       gen with: $(openssl rand -hex 16)
+#
+# The backend's MONGODB_URI is rewritten here to include credentials and
+# `?authSource=admin`, so callers don't need to change. Other compose
+# files (e.g. `demo/docker-compose.demo.yml`) that hard-code the URI
+# would need a parallel override; out of scope here.
+
+services:
+  mongodb:
+    # Setting MONGO_INITDB_ROOT_* on the official mongo image causes the
+    # entrypoint to start mongod with --auth and create the root user
+    # on first boot. Existing volumes are NOT migrated — destroy
+    # `mongo_data` volume before applying this overlay if you want to
+    # convert an existing no-auth deployment.
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: ${MONGODB_USERNAME:?MONGODB_USERNAME must be set when using docker-compose.auth.yml}
+      MONGO_INITDB_ROOT_PASSWORD: ${MONGODB_PASSWORD:?MONGODB_PASSWORD must be set when using docker-compose.auth.yml}
+    healthcheck:
+      # Healthcheck must authenticate too once auth is enabled.
+      test: ["CMD", "mongosh", "--quiet", "-u", "${MONGODB_USERNAME}", "-p", "${MONGODB_PASSWORD}", "--authenticationDatabase", "admin", "--eval", "db.adminCommand('ping')"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  redis:
+    # `--requirepass` enables AUTH on Redis. The default image's CMD
+    # (`redis-server`) is replaced here so we can pass the flag.
+    command: ["redis-server", "--requirepass", "${REDIS_PASSWORD:?REDIS_PASSWORD must be set when using docker-compose.auth.yml}"]
+    healthcheck:
+      # `redis-cli ping` over an auth-enabled instance needs `-a <pw>`
+      # (the unauthenticated client receives NOAUTH and the healthcheck
+      # would fail).
+      test: ["CMD", "redis-cli", "-a", "${REDIS_PASSWORD}", "--no-auth-warning", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  beever-atlas:
+    # Rewrite MONGODB_URI + REDIS_URL with credentials so the backend
+    # connects through the new auth gates. The base file's
+    # `MONGODB_URI: mongodb://mongodb:27017/beever_atlas` is overridden
+    # here in full — compose merges environment maps key-by-key.
+    environment:
+      MONGODB_URI: mongodb://${MONGODB_USERNAME}:${MONGODB_PASSWORD}@mongodb:27017/beever_atlas?authSource=admin
+      REDIS_URL: redis://:${REDIS_PASSWORD}@redis:6379

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,6 +71,12 @@ services:
       timeout: 5s
       retries: 5
 
+  # Issue #50 — MongoDB and Redis run without auth by default. The
+  # 127.0.0.1 host bindings prevent external access, but any container
+  # added to this compose network can read/write freely. Apply the
+  # `docker-compose.auth.yml` overlay for password auth in shared-host
+  # or pre-prod environments:
+  #   docker compose -f docker-compose.yml -f docker-compose.auth.yml up
   mongodb:
     image: mongo:7.0@sha256:43fddee7e532a920f3dfdee9e8f4834398c155c26bcb92d790cc1cd3c630fc40
     ports: ["127.0.0.1:27017:27017"]


### PR DESCRIPTION
## Summary
- Closes #50 — MongoDB and Redis previously ran without authentication in the default compose stack. Co-located containers on the compose network could read/write either store freely (host bindings already protect external access).
- Fix is an **opt-in overlay** (`docker-compose.auth.yml`) rather than a default, so the documented `cp .env.example .env && docker compose up` local-dev quickstart keeps working unchanged.
- Operators on shared-host / pre-prod environments now have a one-flag-away path to credentialed Mongo + Redis.

## Changes
- **`docker-compose.auth.yml`** (NEW)
  - mongo: adds `MONGO_INITDB_ROOT_USERNAME`/`_PASSWORD`, healthcheck authenticates with the same creds.
  - redis: replaces command with `redis-server --requirepass`, healthcheck uses `redis-cli -a`.
  - beever-atlas: rewrites `MONGODB_URI` → `mongodb://\$user:\$pass@mongodb:27017/beever_atlas?authSource=admin` and `REDIS_URL` → `redis://:\$pass@redis:6379`.
  - All required env vars fail-fast via `\${VAR:?...}` — typo or missing var blocks startup before any unauthed cluster can boot.

- **`docker-compose.yml`**
  - Comment block above the mongodb service explaining the surface and pointing at the overlay. No behavior change.

- **`.env.example` §1.6 Datastores**
  - Three commented-out optional vars: `MONGODB_USERNAME`, `MONGODB_PASSWORD`, `REDIS_PASSWORD` with a short preamble.

## Usage
\`\`\`bash
# Set the three optional vars in .env, then:
docker compose -f docker-compose.yml -f docker-compose.auth.yml up
\`\`\`

## Why opt-in (not default)
- The local-dev quickstart documented in `.env.example` §1 is `cp .env.example .env && docker compose up`. Enabling auth by default would break it (operators would have to set `MONGODB_URI` / `REDIS_URL` by hand or regenerate fixtures every clone).
- Baking credentials into the base file with defaults is worse than no auth — anyone forgetting to override ships a public default password.
- 127.0.0.1 host bindings already block external access; the residual risk is intra-compose-network, which is opt-in territory.

## Verification
\`\`\`bash
MONGODB_USERNAME=u MONGODB_PASSWORD=p REDIS_PASSWORD=r WEAVIATE_API_KEY=k NEO4J_PASSWORD=n \
  docker compose -f docker-compose.yml -f docker-compose.auth.yml config
\`\`\`
Merged config inspected via `python yaml.safe_load`:
- `services.mongodb.environment` → `MONGO_INITDB_ROOT_{USERNAME,PASSWORD}`
- `services.mongodb.healthcheck.test` → mongosh authenticates with `--authenticationDatabase admin`
- `services.redis.command` → `['redis-server', '--requirepass', 'r']`
- `services.redis.healthcheck.test` → `redis-cli -a r --no-auth-warning ping`
- `services.beever-atlas.environment.MONGODB_URI` → `mongodb://u:p@mongodb:27017/beever_atlas?authSource=admin`
- `services.beever-atlas.environment.REDIS_URL` → `redis://:r@redis:6379`

## Test plan
- [x] `docker compose ... config` validates without errors
- [x] mongodb / redis service blocks merge as expected (healthchecks updated, command set, env injected)
- [x] beever-atlas connection string env vars rewritten with credentials
- [ ] Smoke `docker compose -f docker-compose.yml -f docker-compose.auth.yml up` end-to-end (not run in this worktree — would require pulling Mongo + Redis images)
- [x] Base stack (`docker compose up` without overlay) unchanged — only added a comment to `docker-compose.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)