### PR TITLE
fix(security): proxy_media SSRF — DNS validation + disable redirects (CodeQL alerts #37, #38)

### DIFF
--- a/src/beever_atlas/api/loaders.py
+++ b/src/beever_atlas/api/loaders.py
@@ -33,7 +33,7 @@ from beever_atlas.api.media import (
     slack_bot_tokens,
 )
 from beever_atlas.infra.config import get_settings
-from beever_atlas.infra.http_safe import validate_proxy_url
+from beever_atlas.infra.http_safe import resolve_and_validate, validate_proxy_url
 
 logger = logging.getLogger(__name__)
 
@@ -96,6 +96,25 @@ async def proxy_media(url: str = Query(..., min_length=10, max_length=2048)) -> 
     host = (parsed.hostname or "").lower()
     if host not in ALLOWED_HOSTS:
         raise HTTPException(status_code=400, detail=f"Host not allowed: {host}")
+
+    # SSRF defense (CodeQL alerts #37, #38): re-validate via DNS resolution +
+    # private-IP rejection before sending the bot token (Slack path) or
+    # making any outbound request. Without this, an allowlisted host whose
+    # DNS resolves to a private IP (DNS poisoning, misconfiguration, IMDS
+    # at 169.254.169.254) would let the proxy reach internal targets — the
+    # static `host in ALLOWED_HOSTS` check above does not catch that.
+    # The pinned URL is intentionally discarded; we use the original URL
+    # for the fetch so TLS hostname verification (SNI vs. cert SANs) works
+    # normally. The shared client has `follow_redirects=False` so the
+    # validated host cannot 302-pivot the request post-validation.
+    try:
+        resolve_and_validate(url, ALLOWED_HOSTS)
+    except (PermissionError, ValueError) as exc:
+        # Generic message — don't echo attacker-controlled URL or expose
+        # whether the failure was DNS-rebinding vs. allowlist-miss vs.
+        # private-IP. Operators see the host + reason class in the log.
+        logger.warning("media_proxy rejected url: host=%s reason=%s", host, type(exc).__name__)
+        raise HTTPException(status_code=400, detail="Invalid media URL") from None
 
     client = get_proxy_client()
     headers: dict[str, str] = {

--- a/src/beever_atlas/api/media.py
+++ b/src/beever_atlas/api/media.py
@@ -40,7 +40,12 @@ def get_proxy_client() -> httpx.AsyncClient:
     if _client is None:
         _client = httpx.AsyncClient(
             timeout=httpx.Timeout(15.0, connect=5.0),
-            follow_redirects=True,
+            # SSRF defense (CodeQL alerts #37, #38): refuse to follow redirects
+            # so an allowlisted host cannot 302 the request to a private IP or
+            # off-allowlist target after our pre-fetch validation passes.
+            # Slack files.slack.com and Discord CDN signed URLs serve content
+            # directly with 200 — they do not redirect in normal operation.
+            follow_redirects=False,
             limits=httpx.Limits(max_connections=20, max_keepalive_connections=10),
         )
     return _client

--- a/src/beever_atlas/infra/http_safe.py
+++ b/src/beever_atlas/infra/http_safe.py
@@ -109,7 +109,15 @@ def resolve_and_validate(url: str, allowlist: Iterable[str] | None = None) -> tu
             raise PermissionError(f"host {host} not in allowlist")
     port = parsed.port or (443 if parsed.scheme == "https" else 80)
 
-    infos = socket.getaddrinfo(host, port, type=socket.SOCK_STREAM)
+    try:
+        infos = socket.getaddrinfo(host, port, type=socket.SOCK_STREAM)
+    except OSError as exc:
+        # Honour the docstring contract: NXDOMAIN / DNS errors surface as
+        # ValueError("no DNS result"), not as a leaked socket.gaierror /
+        # OSError. Callers (proxy_media, validate_proxy_url) already handle
+        # ValueError; wrapping here keeps the helper's exception surface
+        # consistent across all call sites.
+        raise ValueError(f"DNS resolution failed: {exc}") from exc
     ips: set[str] = set()
     for info in infos:
         addr = info[4][0]

--- a/tests/api/test_proxy_media_ssrf.py
+++ b/tests/api/test_proxy_media_ssrf.py
@@ -1,0 +1,256 @@
+"""SSRF regression tests for ``/api/media/proxy`` (CodeQL alerts #37 + #38).
+
+The endpoint accepts a fully attacker-controlled `url` query param. Before
+this fix, the only defense was a static `host in ALLOWED_HOSTS` check, which
+does not protect against:
+
+  - DNS poisoning / misconfiguration where an allowlisted host (e.g.
+    ``files.slack.com``) resolves to ``169.254.169.254`` (cloud metadata)
+    or a private RFC1918 address.
+  - Post-validation redirect pivot — an allowlisted host returning ``302
+    Location: http://127.0.0.1/...`` would have been silently followed
+    when the shared httpx client had ``follow_redirects=True``.
+
+The fix:
+  1. ``api/media.py:get_proxy_client()`` now sets ``follow_redirects=False``.
+  2. ``proxy_media`` runs ``resolve_and_validate(url, ALLOWED_HOSTS)`` before
+     fetching, layering DNS + IP-class rejection on top of the static
+     allowlist check. The pinned URL is discarded; the original URL is used
+     for the fetch so TLS/SNI works normally.
+
+These tests verify those properties without requiring a live network — DNS
+resolution is monkeypatched.
+"""
+
+from __future__ import annotations
+
+import socket
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+# ── Fixtures ────────────────────────────────────────────────────────────────
+
+
+def _fake_getaddrinfo(ip: str):
+    """Return a getaddrinfo stub that always resolves to ``ip``."""
+
+    def _inner(host, port, *args, **kwargs):  # noqa: ARG001
+        return [(socket.AF_INET, socket.SOCK_STREAM, 0, "", (ip, port))]
+
+    return _inner
+
+
+@pytest.fixture
+def client_with_loaders(monkeypatch):
+    """FastAPI test client with the loaders router mounted, no auth required.
+
+    ``proxy_media`` checks ``adapter`` etc. via FastAPI dependencies. We mount
+    the router onto a bare app so a TestClient can call it directly.
+    """
+    from beever_atlas.api import loaders
+
+    app = FastAPI()
+    app.include_router(loaders.router)
+    return TestClient(app)
+
+
+@pytest.fixture
+def fake_proxy_client(monkeypatch):
+    """Stub ``get_proxy_client`` so no real httpx connection is opened.
+
+    Captures the GET URL and returned 200 with empty bytes by default.
+    """
+    captured: dict[str, Any] = {"calls": []}
+
+    class _FakeResp:
+        def __init__(self, status_code: int = 200, content: bytes = b"x", ctype: str = "image/png"):
+            self.status_code = status_code
+            self._content = content
+            self.headers = {"content-type": ctype}
+
+        async def aiter_bytes(self):
+            yield self._content
+
+        async def aclose(self):
+            return None
+
+    class _FakeClient:
+        async def get(self, url, headers=None):
+            captured["calls"].append({"url": url, "headers": dict(headers or {})})
+            return _FakeResp()
+
+    fake = _FakeClient()
+    from beever_atlas.api import loaders
+
+    monkeypatch.setattr(loaders, "get_proxy_client", lambda: fake)
+    return captured
+
+
+# ── Static allowlist (already in place pre-fix) ────────────────────────────
+
+
+def test_off_allowlist_host_rejected_400(client_with_loaders, monkeypatch):
+    """Pre-existing behavior: unrelated public host returns 400."""
+    monkeypatch.setattr(socket, "getaddrinfo", _fake_getaddrinfo("8.8.8.8"))
+    resp = client_with_loaders.get(
+        "/api/media/proxy", params={"url": "https://attacker.example/secret.png"}
+    )
+    assert resp.status_code == 400
+    assert "Host not allowed" in resp.json()["detail"]
+
+
+def test_unsupported_scheme_rejected_400(client_with_loaders):
+    resp = client_with_loaders.get("/api/media/proxy", params={"url": "ftp://files.slack.com/x"})
+    assert resp.status_code == 400
+    assert "http(s)" in resp.json()["detail"]
+
+
+def test_substring_bypass_rejected_400(client_with_loaders):
+    """`host in ALLOWED_HOSTS` is exact-match (parsed.hostname), so
+    `files.slack.com.evil.com` does not pass."""
+    resp = client_with_loaders.get(
+        "/api/media/proxy", params={"url": "https://files.slack.com.evil.com/x"}
+    )
+    assert resp.status_code == 400
+    assert "Host not allowed" in resp.json()["detail"]
+
+
+# ── New behavior: DNS + private-IP rejection (#37, #38) ────────────────────
+
+
+def test_allowlisted_host_resolving_to_imds_rejected(client_with_loaders, monkeypatch):
+    """`files.slack.com` resolving to 169.254.169.254 (cloud metadata) must
+    be rejected with the generic 'Invalid media URL' message."""
+    monkeypatch.setattr(socket, "getaddrinfo", _fake_getaddrinfo("169.254.169.254"))
+    resp = client_with_loaders.get(
+        "/api/media/proxy",
+        params={"url": "https://files.slack.com/files-pri/T1-F2/x.png"},
+    )
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == "Invalid media URL"
+
+
+def test_allowlisted_host_resolving_to_loopback_rejected(client_with_loaders, monkeypatch):
+    monkeypatch.setattr(socket, "getaddrinfo", _fake_getaddrinfo("127.0.0.1"))
+    resp = client_with_loaders.get(
+        "/api/media/proxy",
+        params={"url": "https://cdn.discordapp.com/attachments/1/2/x.png"},
+    )
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == "Invalid media URL"
+
+
+def test_allowlisted_host_resolving_to_rfc1918_rejected(client_with_loaders, monkeypatch):
+    monkeypatch.setattr(socket, "getaddrinfo", _fake_getaddrinfo("10.0.0.5"))
+    resp = client_with_loaders.get(
+        "/api/media/proxy",
+        params={"url": "https://media.discordapp.net/x.mp4"},
+    )
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == "Invalid media URL"
+
+
+def test_dns_failure_is_rejected_as_invalid(client_with_loaders, monkeypatch):
+    """getaddrinfo raises (no result) → reject with 400."""
+
+    def _boom(host, port, *args, **kwargs):  # noqa: ARG001
+        raise socket.gaierror(socket.EAI_NONAME, "no such host")
+
+    monkeypatch.setattr(socket, "getaddrinfo", _boom)
+    resp = client_with_loaders.get(
+        "/api/media/proxy",
+        params={"url": "https://files.slack.com/files-pri/T1-F2/x.png"},
+    )
+    assert resp.status_code == 400
+
+
+# ── New behavior: redirect-following disabled ──────────────────────────────
+
+
+def test_proxy_client_disables_follow_redirects():
+    """Direct check on the shared httpx client config — `follow_redirects`
+    must be False so an allowlisted host cannot 302-pivot the request to a
+    private IP or off-allowlist target after our pre-fetch validation."""
+    from beever_atlas.api import media
+
+    # Reset the singleton so the test sees the fresh config.
+    media._client = None
+    client = media.get_proxy_client()
+    try:
+        assert client.follow_redirects is False
+    finally:
+        media._client = None  # avoid leaking the test client into other tests
+
+
+# ── Happy path: validation passes, request reaches the fetch ───────────────
+
+
+@pytest.mark.asyncio
+async def test_allowlisted_host_with_public_ip_proceeds_to_fetch(
+    client_with_loaders, fake_proxy_client, monkeypatch
+):
+    """Discord CDN URL resolving to a public IP passes validation and reaches
+    the (stubbed) fetch — no auth header, no token leakage."""
+    monkeypatch.setattr(socket, "getaddrinfo", _fake_getaddrinfo("162.159.130.232"))
+
+    resp = client_with_loaders.get(
+        "/api/media/proxy",
+        params={"url": "https://cdn.discordapp.com/attachments/1/2/x.png"},
+    )
+    assert resp.status_code == 200
+    # Original URL should reach the fetch (NOT an IP-pinned variant) so TLS/SNI
+    # works normally.
+    assert len(fake_proxy_client["calls"]) == 1
+    call = fake_proxy_client["calls"][0]
+    assert call["url"] == "https://cdn.discordapp.com/attachments/1/2/x.png"
+    assert "Authorization" not in call["headers"]
+
+
+def test_slack_host_with_public_ip_attaches_bearer_token(
+    client_with_loaders, fake_proxy_client, monkeypatch
+):
+    """`files.slack.com` resolving to public IP gets the Slack bot token in
+    the Authorization header. Validates token attachment didn't regress."""
+    monkeypatch.setattr(socket, "getaddrinfo", _fake_getaddrinfo("3.5.30.71"))
+
+    async def _fake_tokens():
+        return ["xoxb-fake-test-token"]
+
+    from beever_atlas.api import loaders
+
+    monkeypatch.setattr(loaders, "slack_bot_tokens", _fake_tokens)
+
+    resp = client_with_loaders.get(
+        "/api/media/proxy",
+        params={"url": "https://files.slack.com/files-pri/T1-F2/x.png"},
+    )
+    assert resp.status_code == 200
+    call = fake_proxy_client["calls"][0]
+    assert call["headers"].get("Authorization") == "Bearer xoxb-fake-test-token"
+    # Original URL preserved — we do NOT pin to IP, so TLS works.
+    assert call["url"] == "https://files.slack.com/files-pri/T1-F2/x.png"
+
+
+def test_slack_host_with_no_tokens_returns_502(client_with_loaders, fake_proxy_client, monkeypatch):
+    """Pre-existing behavior preserved: if no Slack workspace is connected,
+    proxy_media returns 502 instead of attempting the fetch."""
+    monkeypatch.setattr(socket, "getaddrinfo", _fake_getaddrinfo("3.5.30.71"))
+
+    async def _no_tokens():
+        return []
+
+    from beever_atlas.api import loaders
+
+    monkeypatch.setattr(loaders, "slack_bot_tokens", _no_tokens)
+
+    resp = client_with_loaders.get(
+        "/api/media/proxy",
+        params={"url": "https://files.slack.com/files-pri/T1-F2/x.png"},
+    )
+    assert resp.status_code == 502
+    # No fetch should have happened.
+    assert fake_proxy_client["calls"] == []


### PR DESCRIPTION
## Summary

Fixes both critical CodeQL `py/full-ssrf` alerts on `/api/media/proxy`:

| Alert | Line | Risk |
|---|---|---|
| [#37](https://github.com/Beever-AI/beever-atlas/security/code-scanning/37) | 115 | Slack-token-bearing fetch — DNS poisoning could leak the workspace bot token to IMDS / private IPs |
| [#38](https://github.com/Beever-AI/beever-atlas/security/code-scanning/38) | 133 | Generic fetch — server-side SSRF to internal targets |

Pre-fix, the only defense was a static `host in ALLOWED_HOSTS` exact-match. Two gaps:
1. **No DNS-layer check** — an allowlisted host (e.g. `files.slack.com`) resolving to `169.254.169.254` (IMDS) or RFC1918 would have reached internal targets.
2. **`follow_redirects=True`** on the shared httpx client — an allowlisted host's `302 Location: http://127.0.0.1/secret` would have been silently followed.

Sibling endpoint `proxy_file` already uses `validate_proxy_url` → `resolve_and_validate` for both layers; this PR brings `proxy_media` to feature-parity.

## Changes

- **`api/media.py`**: `get_proxy_client()` now sets `follow_redirects=False`. Verified safe — this client is used only by `proxy_media`.
- **`api/loaders.py`**: `proxy_media` calls `resolve_and_validate(url, ALLOWED_HOSTS)` after the static host check. The pinned URL is **discarded**; the original URL is used for the fetch so TLS/SNI works against the cert's SANs as before.
- **`infra/http_safe.py`**: `resolve_and_validate` now wraps `socket.getaddrinfo` and converts `OSError` (incl. `socket.gaierror`) to `ValueError`. Pre-fix NXDOMAIN leaked as a raw `gaierror`, violating the helper's documented contract. Honours the contract for **all** existing callers (`safe_get`, `safe_post`, `validate_proxy_url`).
- **`tests/api/test_proxy_media_ssrf.py`** (new, 11 cases): static-allowlist preservation, DNS-layer rejection (IMDS / loopback / RFC1918 / NXDOMAIN), redirect-follow assertion, happy paths (Discord CDN no-auth, Slack with bot token), zero-token Slack 502.

## Why we don't pin to IP

The `safe_get`-style approach replaces the URL host with the resolved IP and forwards `Host: <original>`. This works for production callers like Jina embeddings, but breaks TLS hostname verification for hosts whose certs don't have IP SANs. Slack and Discord CDN certs are issued for hostnames. Approach used here:
- Validate DNS resolution + private-IP rejection at request time (closes the static-allowlist gap CodeQL flags).
- Disable redirects (closes the post-validation pivot).
- Use the original URL for fetch (TLS works as it always has).

The trade-off is a sub-second TOCTOU window between our `getaddrinfo` and httpx's connection-time resolution. The bot-side bridge `assertPublicUrl` accepts the same window for the same reason. Documented as `Not-tested:` in the commit body.

## Test plan

- [x] `pytest tests/api/test_proxy_media_ssrf.py` — **11/11 PASS**
- [x] `pytest tests/api/ tests/infra/ tests/test_http_safe.py tests/services/test_media_processor_ssrf.py` — **306/306 PASS**, no adjacent regressions
- [x] `ruff check` + `ruff format --check` — clean
- [x] `pyright` — 0 errors, 0 warnings on changed files
- [ ] After merge: confirm CodeQL re-scan auto-closes alerts #37 + #38

## Independent of bot bridge SSRF PRs

This PR is off `main`, NOT stacked on PR #108 / #109. Different file, different language, different primitives — independently mergeable in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)