### PR TITLE
fix(security): split static format string from tainted args (CodeQL alerts #21–#26)

### DIFF
--- a/bot/src/bridge.ts
+++ b/bot/src/bridge.ts
@@ -2080,7 +2080,9 @@ async function handleValidateAdapter(
       jsonResponse(res, 400, { valid: false, error: `Unknown platform: ${platform}` });
     }
   } catch (err) {
-    console.error(`Bridge: validateAdapter(${platform}) error:`, err);
+    // CodeQL js/tainted-format-string (alert #22): static format string +
+    // arguments so user-tainted `platform` cannot influence format specifiers.
+    console.error("Bridge: validateAdapter(%s) error:", platform, err);
     jsonResponse(res, 200, { valid: false, error: String(err) });
   }
 }
@@ -2107,7 +2109,8 @@ async function handleConnectionRoute(
     if (classified.status === 404) {
       console.warn(`Bridge: connection route (${connectionId}): ${(err as any)?.data?.error || err}`);
     } else {
-      console.error(`Bridge: connection route error (${connectionId}):`, err);
+      // CodeQL js/tainted-format-string (alert #23).
+      console.error("Bridge: connection route error (%s):", connectionId, err);
     }
     jsonResponse(res, classified.status, { error: String(err), code: classified.code });
   }
@@ -2128,7 +2131,8 @@ async function handleConnectionChannels(
     const channels = await result.bridge.listChannels();
     jsonResponse(res, 200, { channels });
   } catch (err) {
-    console.error(`Bridge: listChannels error (connection ${connectionId}):`, err);
+    // CodeQL js/tainted-format-string (alert #24).
+    console.error("Bridge: listChannels error (connection %s):", connectionId, err);
     const classified = classifyPlatformError(err);
     jsonResponse(res, classified.status, { error: String(err), code: classified.code });
   }
@@ -2157,12 +2161,14 @@ async function handlePlatformChannelsAggregated(
           allChannels.push({ ...ch, connection_id: connectionId });
         }
       } catch (err) {
-        console.error(`Bridge: listChannels error for ${platform}:${connectionId}:`, err);
+        // CodeQL js/tainted-format-string (alert #25).
+        console.error("Bridge: listChannels error for %s:%s:", platform, connectionId, err);
       }
     }
     jsonResponse(res, 200, { channels: allChannels });
   } catch (err) {
-    console.error(`Bridge: aggregated listChannels error for ${platform}:`, err);
+    // CodeQL js/tainted-format-string (alert #26).
+    console.error("Bridge: aggregated listChannels error for %s:", platform, err);
     const classified = classifyPlatformError(err);
     jsonResponse(res, classified.status, { error: String(err), code: classified.code });
   }

--- a/bot/src/index.ts
+++ b/bot/src/index.ts
@@ -560,7 +560,10 @@ async function handleConnectionWebhook(
       jsonResponse(res, 404, { error: `No webhook handler for connection ${connectionId}` });
     }
   } catch (err) {
-    console.error(`Connection webhook error (${connectionId}):`, err);
+    // CodeQL js/tainted-format-string (alert #21): pass the format string
+    // as a static literal and the user-tainted value as an argument so it
+    // cannot influence format-specifier interpretation downstream.
+    console.error("Connection webhook error (%s):", connectionId, err);
     res.writeHead(500);
     res.end("Internal Server Error");
   }


### PR DESCRIPTION
## Summary

Fixes 6 high-severity CodeQL `js/tainted-format-string` alerts:

| Alert | File | Line |
|---|---|---|
| [#21](https://github.com/Beever-AI/beever-atlas/security/code-scanning/21) | `bot/src/index.ts` | 563 |
| [#22](https://github.com/Beever-AI/beever-atlas/security/code-scanning/22) | `bot/src/bridge.ts` | 2083 |
| [#23](https://github.com/Beever-AI/beever-atlas/security/code-scanning/23) | `bot/src/bridge.ts` | 2110 |
| [#24](https://github.com/Beever-AI/beever-atlas/security/code-scanning/24) | `bot/src/bridge.ts` | 2131 |
| [#25](https://github.com/Beever-AI/beever-atlas/security/code-scanning/25) | `bot/src/bridge.ts` | 2160 |
| [#26](https://github.com/Beever-AI/beever-atlas/security/code-scanning/26) | `bot/src/bridge.ts` | 2165 |

Each is a `console.error/warn` whose format string is built by template-literal interpolation of a user-tainted value (`platform`, `connectionId` from webhook payloads). When a tainted substring contains a `%s` specifier, Node's `util.format` consumes the next argument into that slot — silently swallowing the `err` that was meant to be logged separately.

## Fix

Convert each site to a static literal format string + arguments:

```ts
// Before
console.error(`Bridge: connection route error (${connectionId}):`, err);

// After
console.error("Bridge: connection route error (%s):", connectionId, err);
```

Node's `util.format` only interprets format specifiers in the first arg; values substituted into specifier slots are NOT re-scanned, so a `%s` inside `connectionId` survives literally and `err` is no longer at risk of being consumed.

## Behavioral verification

Ran `util.format` empirically on both forms:

| Input | BEFORE === AFTER? |
|---|---|
| `id = "conn-123"` (normal ID) | ✅ byte-identical |
| `id = "weird-%s-id"` (contains literal `%s`) | ❌ — BEFORE consumes `err` into the substitution; AFTER preserves `%s` literally and logs `err` separately |

For production data (UUIDs, Slack/Discord/Telegram IDs — no `%s` chars): output is byte-identical. For the edge case CodeQL is warning about: the fix strictly improves logging robustness.

## Scope

- 6 sites in 2 files. Mechanical edit: template-literal-as-format-string → static-format-string + args.
- Adjacent `console.warn` at `bridge.ts:2108` follows the same pattern but is NOT in the alert list — **left unchanged** to keep this PR scoped to what CodeQL flagged. If it gets flagged later, follow-up PR.
- This PR is **independent** of the bot SSRF PRs (#108, #109). No overlap with their bridge.ts edits (those are in per-bridge class methods at lines 595–1646; these edits are in route handlers at lines 2083–2165).

## Test plan

- [x] `cd bot && npm run build` — `tsc` clean
- [x] `cd bot && npm test` — **140/140 PASS** (full bot suite)
- [x] `cd bot && npx eslint src/bridge.ts src/index.ts` — 0 errors
- [x] Empirical behavior diff verified with `util.format` (see above)
- [ ] After merge: confirm CodeQL re-scan auto-closes alerts #21–#26

🤖 Generated with [Claude Code](https://claude.com/claude-code)