### PR TITLE
fix(scripts): NEBULA_USER/PASSWORD env override in nebula_setup helper (#51)

### DIFF
--- a/scripts/nebula_setup.py
+++ b/scripts/nebula_setup.py
@@ -4,11 +4,17 @@ Usage:
     python scripts/nebula_setup.py
 
 Requires nebula3-python: pip install nebula3-python
+
+Reads NEBULA_USER / NEBULA_PASSWORD from the environment (same names the
+runtime uses); falls back to NebulaGraph's factory defaults so a fresh
+local cluster works out of the box. Override both for any non-local
+deployment — the factory defaults are widely known.
 """
 from __future__ import annotations
 
-import time
+import os
 import sys
+import time
 
 
 def main() -> None:
@@ -21,8 +27,13 @@ def main() -> None:
 
     host = "127.0.0.1"
     port = 9669
-    user = "root"
-    password = "nebula"
+    user = os.environ.get("NEBULA_USER", "root")
+    password = os.environ.get("NEBULA_PASSWORD", "nebula")
+    if password == "nebula":
+        print(
+            "WARNING: using NebulaGraph factory-default password ('nebula'). "
+            "Set NEBULA_PASSWORD for any non-local deployment."
+        )
 
     print(f"Connecting to NebulaGraph at {host}:{port}...")
 


### PR DESCRIPTION
## Summary
- Closes #51 — `scripts/nebula_setup.py` hardcoded NebulaGraph's factory-default credentials with no override path. Operators pointing the helper at a hardened cluster had to edit the file.
- Now reads `NEBULA_USER` / `NEBULA_PASSWORD` from the environment (same names the runtime config validator uses) with the factory defaults as fallback, so a fresh local cluster still works without extra setup.
- Adds a WARNING when the factory-default password is in use so a misconfigured override (typo, missing export) doesn't silently re-fall-back.

## Diff
```python
-    user = "root"
-    password = "nebula"
+    user = os.environ.get("NEBULA_USER", "root")
+    password = os.environ.get("NEBULA_PASSWORD", "nebula")
+    if password == "nebula":
+        print(
+            "WARNING: using NebulaGraph factory-default password ('nebula'). "
+            "Set NEBULA_PASSWORD for any non-local deployment."
+        )
```

## Why these env-var names
- `.env.example` §1.7 already lists `NEBULA_USER=root` / `NEBULA_PASSWORD=nebula`.
- `infra/config.py` reads them as `nebula_user` / `nebula_password` and rejects `nebula_password == "nebula"` in production mode.
- Aligning the setup helper with the same env vars means there's exactly one place an operator needs to set the secret.

## Why a WARNING (not a hard fail)
- Helper's primary job is bootstrapping a fresh local cluster — that cluster *ships* with exactly these defaults, so a hard fail would block the documented quickstart.
- Production hardening is the runtime's job (`infra/config.py:213+` already rejects the default at startup when `BEEVER_ENV=production`); the helper stays advisory.

## Verification
- `py_compile scripts/nebula_setup.py` ✓
- Module-imports cleanly with stubbed `nebula3` ✓
- `pytest tests/test_config_validator.py tests/test_graph_protocol.py -k 'nebula or graph_backend'` → 5 passed, 1 skipped, 0 failed ✓
- `scripts/` is not in the CI ruff target (`uv run ruff check src/ tests/`), so the pre-existing F541 in this file is untouched (out of scope).

## Test plan
- [x] Compile + import smoke test
- [x] Existing nebula test suite green
- [ ] Live `python scripts/nebula_setup.py` against a NebulaGraph instance with non-default credentials (requires a live cluster — not run in this worktree)

🤖 Generated with [Claude Code](https://claude.com/claude-code)