### PR TITLE
fix(installer): mask all but last 4 chars of existing API keys (#52)

### DIFF
--- a/atlas
+++ b/atlas
@@ -240,7 +240,18 @@ prompt_external_key() {
 
   ask "${C_BOLD}${label}${C_RESET} ${C_DIM}· ${url}${C_RESET}"
   if [ -n "$current" ]; then
-    hint "Current: ${current:0:8}… (Enter = keep)"
+    # Issue #52 — show only the last 4 chars (not the first 8). The
+    # leading bytes of provider keys are structured (`AIzaSy…` for
+    # Google, `jina_…` for Jina) and revealing them aids targeted
+    # brute-force if the terminal is logged. The trailing 4 are
+    # enough for the operator to recognize their own key, and we
+    # fall back to length-only for keys too short to mask safely.
+    local len=${#current}
+    if [ "$len" -ge 12 ]; then
+      hint "Current: …${current: -4} (Enter = keep)"
+    else
+      hint "Current: ${len}-char value set (Enter = keep)"
+    fi
   else
     hint "Paste the key, or press Enter to skip"
   fi

--- a/tests/test_setup_script.sh
+++ b/tests/test_setup_script.sh
@@ -400,6 +400,36 @@ assert "exited with status 0 despite slow backend"     "[ $status -eq 0 ]"
 assert "health poll warning emitted"                   "grep -qF 'backend not yet responding' '$WS/stdout'"
 
 # ────────────────────────────────────────────────────────────────────
+# Test 16: existing-key prompt masks all but the last 4 chars (#52)
+# ────────────────────────────────────────────────────────────────────
+echo ""
+echo "Test 16: prompt for existing key masks prefix"
+WS="$TMP_ROOT/t16"
+mk_workspace "$WS"
+# Seed .env: a long Google key (full mask) + a short Jina key (length-only).
+# Both contain unmistakable substrings the test asserts must NOT leak.
+sed -i.bak 's/^GOOGLE_API_KEY=.*/GOOGLE_API_KEY=AIzaSyB-fake-prefix-LONG-SUFFIX-WXYZ/' "$WS/.env.example"
+sed -i.bak 's/^JINA_API_KEY=.*/JINA_API_KEY=jina_S3CR/' "$WS/.env.example"
+rm -f "$WS/.env.example.bak"
+# Use --non-interactive once to materialise .env (preserves seeded values),
+# then drive interactive mode pressing Enter through every prompt.
+run_in_workspace "$WS" --non-interactive > /dev/null 2> /dev/null
+: > "$WS/stubs/.calls"
+printf '\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n' | (
+  cd "$WS"
+  ATLAS_HEALTH_POLL_TIMEOUT=0 PATH="${WS}/stubs:${MINBIN}" bash ./atlas
+) > "$WS/stdout" 2> "$WS/stderr"
+status=$?
+assert "long key shows last 4 chars (…WXYZ)"          "grep -qF '…WXYZ' '$WS/stdout'"
+assert "long key prefix NOT leaked"                   "! grep -qF 'AIzaSyB-' '$WS/stdout'"
+assert "long key middle NOT leaked"                   "! grep -qF 'fake-prefix' '$WS/stdout'"
+assert "short key shows length-only marker"           "grep -qF '9-char value set' '$WS/stdout'"
+assert "short key value NOT leaked"                   "! grep -qF 'jina_S3CR' '$WS/stdout'"
+assert "GOOGLE_API_KEY unchanged on Enter"            "grep -qF 'GOOGLE_API_KEY=AIzaSyB-fake-prefix-LONG-SUFFIX-WXYZ' '$WS/.env'"
+assert "JINA_API_KEY unchanged on Enter"              "grep -qF 'JINA_API_KEY=jina_S3CR' '$WS/.env'"
+assert "exited with status 0"                         "[ $status -eq 0 ]"
+
+# ────────────────────────────────────────────────────────────────────
 # Results
 # ────────────────────────────────────────────────────────────────────
 echo ""


### PR DESCRIPTION
## Summary
- Closes #52 — `./atlas` prompt for an already-configured external API key was printing the **first 8 chars** of the value (`Current: AIzaSyB7… (Enter = keep)`). For provider keys the leading bytes are structured (`AIzaSy…` for Google, `jina_…` for Jina), so 8 prefix chars leak the provider, encode-version, and ~25% of the key body — usable to aid a targeted brute-force if the terminal output is logged or pasted.
- Switches to a **trailing-4-char mask** (`…WXYZ`) for keys ≥ 12 chars, with a **length-only fallback** (`9-char value set`) for shorter values that wouldn't be safe even with 4 trailing chars exposed.
- Mirrors `prompt_internal_secret`, which already showed nothing about the current value.

## Diff
```bash
-    hint "Current: ${current:0:8}… (Enter = keep)"
+    local len=${#current}
+    if [ "$len" -ge 12 ]; then
+      hint "Current: …${current: -4} (Enter = keep)"
+    else
+      hint "Current: ${len}-char value set (Enter = keep)"
+    fi
```

## Why trailing-4 (not length-only / hash-prefix)
- **Hash-prefix** (sha256 of the value, first 8 chars): survives logging, but the operator can't recognize their own key — defeats the purpose of the indicator.
- **Length-only for everything**: worse UX when juggling test/prod credentials side-by-side; operator can't tell two long keys apart.
- **Trailing-4 + length-fallback**: confirms identity, never reveals provider-prefix structure, and degrades gracefully for short stub/dev values.

## Verification
- New **Test 16** in `tests/test_setup_script.sh` seeds a long Google key (`AIzaSyB-fake-prefix-LONG-SUFFIX-WXYZ`) and a short Jina key (`jina_S3CR`), runs interactive mode pressing Enter through every prompt, and asserts:
  - Positive: stdout contains `…WXYZ` and `9-char value set`
  - Negative: stdout does NOT contain `AIzaSyB-`, `fake-prefix`, or `jina_S3CR`
  - Idempotency: both keys remain byte-identical in `.env` after Enter
- Full test suite: **65 → 73 passes** (8 new assertions, all green)

## Pre-existing test failures (unrelated)
`upstream/main` already fails 2 environment-specific assertions:
- `stdout warns about missing python`
- `master key NOT regenerated (still placeholder)`

These are not touched by this change. Verified by running the unmodified upstream/main test script in the same worktree (also 2 failures, same names).

## Test plan
- [x] New Test 16 passes (8/8 assertions)
- [x] No regression in remaining 65 pre-existing assertions
- [x] Long-key path: trailing-4 mask, no prefix leak
- [x] Short-key path: length-only marker, no value leak
- [x] Both keys preserved on Enter (Enter = keep semantics intact)
- [ ] Live operator dry-run (test harness drives stdin, not a real terminal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)