### PR TITLE
fix(bot): replace empty validateEnv() stub with WARN-only startup checks (#53)

### DIFF
--- a/bot/src/index.ts
+++ b/bot/src/index.ts
@@ -11,6 +11,7 @@ import { registerBridgeRoutes, recordTelegramChat, recordTeamsConversation } fro
 import { jsonResponse, readBody, MAX_BODY_SIZE, BodyTooLargeError } from "./http-utils.js";
 import { ChatManager } from "./chat-manager.js";
 import { WebhookBuffer } from "./webhook-buffer.js";
+import { validateEnv } from "./validate-env.js";
 
 // ── Environment validation ──────────────────────────────────────────────────
 
@@ -18,10 +19,9 @@ const BACKEND_URL = process.env.BACKEND_URL || "http://localhost:8000";
 const REDIS_URL = process.env.REDIS_URL || "redis://localhost:6379";
 const PORT = parseInt(process.env.BOT_PORT || "3001", 10);
 
-function validateEnv(): void {
-  // No platform-specific env vars are required — connections are loaded at
-  // runtime from the backend database or fall back to .env credentials.
-}
+// Issue #53 — validateEnv lives in ./validate-env.ts; it's WARN-only and
+// never gates startup (platform-specific creds are loaded from the backend
+// database at runtime). See that module for the full check list.
 
 // ── Handler registration ─────────────────────────────────────────────────────
 

--- a/bot/src/validate-env.test.ts
+++ b/bot/src/validate-env.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Tests for detectEnvWarnings (issue #53).
+ *
+ * The function is WARN-only by design — these tests assert the right
+ * conditions trigger the right warning lines, and that the bot's
+ * tolerant-defaults philosophy survives (clean dev env produces only
+ * the warnings the operator can act on).
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { detectEnvWarnings } from "./validate-env.js";
+
+const FULL_ENV = {
+  BACKEND_URL: "http://backend:8000",
+  REDIS_URL: "redis://redis:6379",
+  BEEVER_API_KEYS: "k1",
+  BRIDGE_API_KEY: "bridge-key",
+  BEEVER_ENV: "production",
+} as const;
+
+describe("detectEnvWarnings", () => {
+  it("returns no warnings when every critical var is set", () => {
+    assert.deepEqual(detectEnvWarnings(FULL_ENV), []);
+  });
+
+  it("warns on missing BEEVER_API_KEYS in dev (not gated by mode)", () => {
+    const warnings = detectEnvWarnings({
+      BACKEND_URL: "http://localhost:8000",
+      REDIS_URL: "redis://localhost:6379",
+      BEEVER_API_KEYS: "",
+      BEEVER_ENV: "development",
+    });
+    assert.equal(warnings.length, 1);
+    assert.match(warnings[0], /BEEVER_API_KEYS is empty/);
+  });
+
+  it("treats whitespace-only BEEVER_API_KEYS as empty", () => {
+    const warnings = detectEnvWarnings({ ...FULL_ENV, BEEVER_API_KEYS: "  ,  ,  " });
+    assert.equal(warnings.length, 1);
+    assert.match(warnings[0], /BEEVER_API_KEYS is empty/);
+  });
+
+  it("accepts BEEVER_API_KEYS with at least one non-empty entry", () => {
+    const warnings = detectEnvWarnings({ ...FULL_ENV, BEEVER_API_KEYS: ",,real-key,," });
+    assert.deepEqual(warnings, []);
+  });
+
+  it("warns on missing BRIDGE_API_KEY in production only", () => {
+    const prodWarn = detectEnvWarnings({ ...FULL_ENV, BRIDGE_API_KEY: "" });
+    assert.equal(prodWarn.length, 1);
+    assert.match(prodWarn[0], /BRIDGE_API_KEY is empty in production/);
+
+    const devNoWarn = detectEnvWarnings({
+      ...FULL_ENV,
+      BRIDGE_API_KEY: "",
+      BEEVER_ENV: "development",
+    });
+    assert.deepEqual(devNoWarn, []);
+
+    const stagingNoWarn = detectEnvWarnings({
+      ...FULL_ENV,
+      BRIDGE_API_KEY: "",
+      BEEVER_ENV: "staging",
+    });
+    assert.deepEqual(stagingNoWarn, []);
+  });
+
+  it("falls back to NODE_ENV when BEEVER_ENV is unset", () => {
+    const warnings = detectEnvWarnings({
+      ...FULL_ENV,
+      BEEVER_ENV: undefined,
+      NODE_ENV: "production",
+      BRIDGE_API_KEY: "",
+    });
+    assert.equal(warnings.length, 1);
+    assert.match(warnings[0], /BRIDGE_API_KEY is empty in production/);
+  });
+
+  it("warns on unparseable BACKEND_URL", () => {
+    const warnings = detectEnvWarnings({ ...FULL_ENV, BACKEND_URL: "not a url" });
+    assert.equal(warnings.length, 1);
+    assert.match(warnings[0], /BACKEND_URL=not a url is not a valid URL/);
+  });
+
+  it("warns on unexpected BACKEND_URL scheme", () => {
+    const warnings = detectEnvWarnings({ ...FULL_ENV, BACKEND_URL: "ftp://backend" });
+    assert.equal(warnings.length, 1);
+    assert.match(warnings[0], /BACKEND_URL=ftp:\/\/backend has unexpected scheme 'ftp:'/);
+  });
+
+  it("warns on unexpected REDIS_URL scheme", () => {
+    const warnings = detectEnvWarnings({ ...FULL_ENV, REDIS_URL: "http://oops:6379" });
+    assert.equal(warnings.length, 1);
+    assert.match(warnings[0], /REDIS_URL=http:\/\/oops:6379 has unexpected scheme 'http:'/);
+  });
+
+  it("accepts rediss:// (TLS) for REDIS_URL", () => {
+    const warnings = detectEnvWarnings({ ...FULL_ENV, REDIS_URL: "rediss://tls-redis:6380" });
+    assert.deepEqual(warnings, []);
+  });
+
+  it("accepts https:// for BACKEND_URL", () => {
+    const warnings = detectEnvWarnings({ ...FULL_ENV, BACKEND_URL: "https://api.example.com" });
+    assert.deepEqual(warnings, []);
+  });
+
+  it("aggregates multiple independent warnings", () => {
+    const warnings = detectEnvWarnings({
+      BACKEND_URL: "ftp://wrong",
+      REDIS_URL: "garbage",
+      BEEVER_API_KEYS: "",
+      BRIDGE_API_KEY: "",
+      BEEVER_ENV: "production",
+    });
+    assert.equal(warnings.length, 4);
+  });
+});

--- a/bot/src/validate-env.ts
+++ b/bot/src/validate-env.ts
@@ -1,0 +1,72 @@
+/**
+ * Bot startup env validation (issue #53).
+ *
+ * Lightweight WARN-only checks; never gates startup. The bot is intentionally
+ * tolerant of partial configuration (connections are loaded from the backend
+ * at runtime, with .env as fallback), so a misconfigured env should produce
+ * a loud log line at boot — not a hard fail mid-flight.
+ *
+ * Detection is split from logging so tests can assert on the warning list
+ * without mocking console.warn.
+ */
+
+type WarnableEnv = {
+  BACKEND_URL?: string | undefined;
+  REDIS_URL?: string | undefined;
+  BEEVER_API_KEYS?: string | undefined;
+  BRIDGE_API_KEY?: string | undefined;
+  BEEVER_ENV?: string | undefined;
+  NODE_ENV?: string | undefined;
+};
+
+const URL_CHECKS: ReadonlyArray<readonly [keyof WarnableEnv, string, readonly string[]]> = [
+  ["BACKEND_URL", "http://localhost:8000", ["http:", "https:"]],
+  ["REDIS_URL", "redis://localhost:6379", ["redis:", "rediss:"]],
+];
+
+export function detectEnvWarnings(env: WarnableEnv = process.env): string[] {
+  const warnings: string[] = [];
+
+  for (const [name, fallback, allowed] of URL_CHECKS) {
+    const value = env[name] || fallback;
+    let parsed: URL;
+    try {
+      parsed = new URL(value);
+    } catch {
+      warnings.push(`${name}=${value} is not a valid URL`);
+      continue;
+    }
+    if (!allowed.includes(parsed.protocol)) {
+      warnings.push(
+        `${name}=${value} has unexpected scheme '${parsed.protocol}' (expected ${allowed.join(" / ")})`,
+      );
+    }
+  }
+
+  const hasApiKey = (env.BEEVER_API_KEYS || "")
+    .split(",")
+    .map((k) => k.trim())
+    .some(Boolean);
+  if (!hasApiKey) {
+    warnings.push(
+      "BEEVER_API_KEYS is empty — bot cannot authenticate to backend; /api/channels/*/ask calls will return 401",
+    );
+  }
+
+  // Bridge auth: only warn in production. Dev allows BRIDGE_ALLOW_UNAUTH=true
+  // as an explicit opt-in escape hatch (see bridge.ts:checkAuth).
+  const mode = env.BEEVER_ENV || env.NODE_ENV || "";
+  if (mode === "production" && !env.BRIDGE_API_KEY) {
+    warnings.push(
+      "BRIDGE_API_KEY is empty in production — incoming backend webhooks will be rejected as 401",
+    );
+  }
+
+  return warnings;
+}
+
+export function validateEnv(env: WarnableEnv = process.env): void {
+  for (const w of detectEnvWarnings(env)) {
+    console.warn(`[validateEnv] WARN: ${w}`);
+  }
+}


### PR DESCRIPTION
## Summary
- Closes #53 — `bot/src/index.ts:validateEnv()` was a no-op (empty body with a "we don't need this" comment). The bot kept running on misconfig but produced confusing runtime failures: empty \`BEEVER_API_KEYS\` made every \`askBackend()\` 401; empty \`BRIDGE_API_KEY\` in prod made every backend webhook bounce.
- Replaces the stub with a small set of **WARN-only** checks. The bot's tolerant-by-default philosophy survives — none of these gate startup; they emit one log line per misconfig at boot so operators can correlate runtime errors back to a missing var.

## What's checked
| Var | Check | Why |
|---|---|---|
| \`BACKEND_URL\` | URL parses, scheme ∈ {\`http:\`, \`https:\`} | Catches typos like \`http:/localhost:8000\` |
| \`REDIS_URL\` | URL parses, scheme ∈ {\`redis:\`, \`rediss:\`} | Catches \`http://redis:6379\` mistakes |
| \`BEEVER_API_KEYS\` | At least one non-empty entry after CSV split | Bot needs it to call \`/api/channels/*/ask\` |
| \`BRIDGE_API_KEY\` | Non-empty when \`BEEVER_ENV=production\` (or \`NODE_ENV\` fallback) | Bridge will reject all webhooks otherwise |

What's **not** checked: platform-specific creds (TEAMS_APP_ID, SLACK_BOT_TOKEN, etc.) — those are loaded from the backend at connection-activation time, so blank-at-startup is normal.

## Why WARN-only (not hard-fail)
- Bot deliberately runs in many configurations (dev with no bridge key, single-platform deployments, backend-driven connection registry).
- Bridge already fail-closes the first request when \`BRIDGE_API_KEY\` is missing in prod, so a startup gate is redundant and would prevent partial-degradation troubleshooting ("running but webhooks bounce" → operator sees the warn line and knows what to fix).
- Dev allows \`BRIDGE_ALLOW_UNAUTH=true\` as a documented escape hatch (see \`bridge.ts:checkAuth\`); we explicitly only warn on missing \`BRIDGE_API_KEY\` in production mode.

## Files
- **\`bot/src/validate-env.ts\`** (NEW): \`detectEnvWarnings(env): string[]\` (pure) + \`validateEnv(env): void\` (logger wrapper). Splitting detection from logging makes the check directly testable without mocking console.
- **\`bot/src/validate-env.test.ts\`** (NEW): 12 cases covering every warning trigger plus its negative — full-env → 0 warnings, dev → no bridge warning, \`rediss://\` accepted, whitespace-only \`BEEVER_API_KEYS\` treated as empty, multi-warning aggregation.
- **\`bot/src/index.ts\`**: imports \`validateEnv\` from the new module; \`main()\` callsite unchanged.

## Verification
- \`npm test\` → **152 passed** (140 existing + 12 new), 0 fail
- \`tsc --noEmit\` → clean
- \`npm run build\` → emits \`dist/validate-env.{js,d.ts}\`
- \`npm run lint\` → 0 errors (test file emits the same floating-promise warnings from \`node:test\`'s \`describe\`/\`it\` that 7 other test files already produce — pattern is consistent with the repo)

## Test plan
- [x] All 152 unit tests pass
- [x] tsc strict-mode clean
- [x] npm run build succeeds
- [x] No new lint errors (warnings match existing test-file pattern)
- [ ] Live prod boot with \`BRIDGE_API_KEY\` unset (would surface the warning in real deploy logs — not run in this worktree)

🤖 Generated with [Claude Code](https://claude.com/claude-code)