### PR TITLE
fix(scripts): single asyncio.run() in wiki_bench (#54)

### DIFF
--- a/scripts/wiki_bench.py
+++ b/scripts/wiki_bench.py
@@ -249,6 +249,51 @@ async def _run_once(gathered: dict, cassette: CassetteLLM) -> tuple[float, list[
     return wall_ms, handler.records, pages
 
 
+async def _bench_loop(
+    gathered: dict,
+    cassette: CassetteLLM,
+    n_runs: int,
+) -> tuple[list[float], int, int, int, int]:
+    """Run every benchmark iteration in a single event loop.
+
+    Returns (durations_ms, parse_failures_total, empty_content_total,
+    dash_wall_pages_total, page_count). Per-iteration progress prints stay
+    inside this coroutine so timing output matches the pre-#54 cadence.
+    """
+    durations: list[float] = []
+    parse_failures_total = 0
+    empty_content_total = 0
+    dash_wall_pages_total = 0
+    page_count = 0
+
+    for run_idx in range(n_runs):
+        wall_ms, records, pages = await _run_once(gathered, cassette)
+        durations.append(wall_ms)
+
+        parse_fail = _count_warnings(records, "failed to parse LLM JSON")
+        empty = _count_warnings(records, "empty content after")
+        parse_failures_total += parse_fail
+        empty_content_total += empty
+
+        dash_walls = sum(1 for p in pages.values() if _is_degenerate_page(p))
+        dash_wall_pages_total += dash_walls
+        page_count = len(pages)
+
+        print(
+            f"  run {run_idx + 1}/{n_runs}: {wall_ms:.0f}ms  "
+            f"pages={page_count}  parse_fail={parse_fail}  "
+            f"empty={empty}  dash_wall={dash_walls}"
+        )
+
+    return (
+        durations,
+        parse_failures_total,
+        empty_content_total,
+        dash_wall_pages_total,
+        page_count,
+    )
+
+
 def _p_percentile(values: list[float], p: int) -> int:
     if not values:
         return 0
@@ -284,30 +329,17 @@ def run_bench(
     gathered = _load_fixture(fixture_path)
     cassette = CassetteLLM(cassette_path)
 
-    durations: list[float] = []
-    parse_failures_total = 0
-    empty_content_total = 0
-    dash_wall_pages_total = 0
-    page_count = 0
-
-    for run_idx in range(n_runs):
-        wall_ms, records, pages = asyncio.run(_run_once(gathered, cassette))
-        durations.append(wall_ms)
-
-        parse_fail = _count_warnings(records, "failed to parse LLM JSON")
-        empty = _count_warnings(records, "empty content after")
-        parse_failures_total += parse_fail
-        empty_content_total += empty
-
-        dash_walls = sum(1 for p in pages.values() if _is_degenerate_page(p))
-        dash_wall_pages_total += dash_walls
-        page_count = len(pages)
-
-        print(
-            f"  run {run_idx + 1}/{n_runs}: {wall_ms:.0f}ms  "
-            f"pages={page_count}  parse_fail={parse_fail}  "
-            f"empty={empty}  dash_wall={dash_walls}"
-        )
+    # Issue #54 — single asyncio.run() drives every iteration through one
+    # event loop instead of N (was: asyncio.run() inside the for body),
+    # avoiding loop-churn overhead and the FD-leak risk if any future
+    # _run_once change adds real async resources.
+    (
+        durations,
+        parse_failures_total,
+        empty_content_total,
+        dash_wall_pages_total,
+        page_count,
+    ) = asyncio.run(_bench_loop(gathered, cassette, n_runs))
 
     if cassette.misses:
         raise CassetteLLM.CassetteMissError(


### PR DESCRIPTION
## Summary
- Closes #54 — \`wiki_bench.py:run_bench()\` called \`asyncio.run()\` *inside* the \`for run_idx in range(n_runs)\` loop, creating and tearing down a fresh event loop on every iteration. Today's impact is low (\`_run_once\` uses mocked I/O via \`CassetteLLM\`), but the pattern blocks future evolution: any real async resource (httpx client, connection pool) added to \`_run_once\` would leak FDs across loop teardowns.
- Extracts a new \`_bench_loop()\` coroutine that runs every iteration in **one** event loop and returns the aggregated metrics. Single \`asyncio.run(_bench_loop(...))\` at the callsite.

## Diff shape
\`\`\`python
async def _bench_loop(gathered, cassette, n_runs):
    # ... per-iteration awaits + accumulators + progress prints
    return (durations, parse_failures_total, empty_content_total,
            dash_wall_pages_total, page_count)

# run_bench:
(durations, parse_failures_total, empty_content_total,
 dash_wall_pages_total, page_count) = asyncio.run(
    _bench_loop(gathered, cassette, n_runs)
)
\`\`\`

## Behavior preservation
- **Per-iteration progress prints**: kept inside the coroutine, so the \"run k/N\" cadence matches pre-fix output exactly.
- **Cassette-miss assertion**: still runs after the loop returns. It's synchronous and raising from inside the coroutine would partially consume loop state without the baseline-construction context.
- **\`run_bench\` / \`main\` signatures**: unchanged.

## Verification
- Smoke-ran the refactored bench against the checked-in fixtures (\`--runs 2\`):
  \`\`\`
    run 1/2: 3ms  pages=2  parse_fail=0  empty=0  dash_wall=0
    run 2/2: 1ms  pages=2  parse_fail=0  empty=0  dash_wall=0
  \`\`\`
  \`baseline.json\` shape identical to pre-fix.
- \`pytest tests/wiki/\` → **153 passed**, 0 fail.
- \`py_compile scripts/wiki_bench.py\` clean.

## Scope notes
- Pre-existing F401s in \`scripts/wiki_bench.py\` (\`hashlib\`, \`AsyncMock\`) are untouched — \`scripts/\` is not in CI's ruff target (\`uv run ruff check src/ tests/\`), and drive-by cleanup isn't part of this fix per project conventions.

## Test plan
- [x] Smoke-run against \`tests/wiki/fixtures/{gathered_bench,cassette_llm}.json\` produces matching output
- [x] Wiki test suite green (153 / 153)
- [x] py_compile clean
- [ ] Long-run benchmark against real Gemini/Jina (requires API keys; not run in this worktree — cassette path is the supported config)

🤖 Generated with [Claude Code](https://claude.com/claude-code)