### PR TITLE
fix(security): exact-host match for URL substring sanitization (CodeQL alerts #12–#20, #33–#36)

### DIFF
--- a/bot/src/bridge.ts
+++ b/bot/src/bridge.ts
@@ -1698,12 +1698,30 @@ function getFirstBridge(chatManager: ChatManager): { platform: string; bridge: P
   return null;
 }
 
-/** Infer platform from a file URL pattern. */
+/** Infer platform from a file URL.
+ *
+ * Uses parsed-URL hostname checks (exact match or proper subdomain suffix),
+ * NOT `url.includes(host)` substring matching. Substring matching against a
+ * full URL string would let an attacker host like `evil.com/files.slack.com`
+ * or `files.slack.com.evil.com` route to the wrong platform — wrong-adapter
+ * routing, not a direct security sink (the SSRF defense lives in
+ * `assertAllowedFetchUrl` per-platform), but worth fixing for hygiene and to
+ * close CodeQL `js/incomplete-url-substring-sanitization` (alerts #12–#18).
+ * Mattermost has no fixed host (per-instance baseUrl) so its detection still
+ * uses a path-pattern check.
+ */
 function detectPlatformFromUrl(url: string): string | null {
-  if (url.includes("files.slack.com") || url.includes("slack-files.com")) return "slack";
-  if (url.includes("cdn.discordapp.com") || url.includes("media.discordapp.net")) return "discord";
-  if (url.includes("graph.microsoft.com") || url.includes("sharepoint.com")) return "teams";
-  if (url.includes("api.telegram.org")) return "telegram";
+  let host: string;
+  try {
+    host = new URL(url).hostname.toLowerCase();
+  } catch {
+    return null;
+  }
+  if (host === "files.slack.com" || host === "slack-files.com") return "slack";
+  if (host === "cdn.discordapp.com" || host === "media.discordapp.net") return "discord";
+  if (host === "graph.microsoft.com" || host.endsWith(".sharepoint.com")) return "teams";
+  if (host === "api.telegram.org") return "telegram";
+  // Mattermost is self-hosted on a per-instance baseUrl; detect by API path.
   if (url.includes("/api/v4/files/")) return "mattermost";
   return null;
 }

--- a/src/beever_atlas/wiki/compiler.py
+++ b/src/beever_atlas/wiki/compiler.py
@@ -2578,7 +2578,11 @@ class WikiCompiler:
                 domain = "unknown"
             if domain in _SOCIAL_DOMAINS:
                 cap = 5
-            elif "github.com" in domain:
+            elif domain == "github.com" or domain.endswith(".github.com"):
+                # CodeQL alert #33: `domain` is already a parsed hostname
+                # (line ~2567), so substring `"github.com" in domain` is
+                # redundant AND would match `github.com.evil.com`. Use
+                # exact-match-or-proper-subdomain instead.
                 cap = 10
             else:
                 cap = 5

--- a/tests/wiki/test_wiki_quality_improvements.py
+++ b/tests/wiki/test_wiki_quality_improvements.py
@@ -10,6 +10,8 @@ Covers:
 
 from __future__ import annotations
 
+from urllib.parse import urlparse
+
 from beever_atlas.wiki.compiler import (
     WikiCompiler,
     _compute_size_tier,
@@ -137,7 +139,10 @@ def test_filter_media_social_cap_is_5_per_platform():
         for i in range(20)
     ]
     filtered = WikiCompiler._filter_media_for_resources(items)
-    x_items = [m for m in filtered if "x.com" in m["url"]]
+    # CodeQL alert #34: parse hostname instead of substring-matching the URL
+    # so a hypothetical `evil.com/x.com/...` test fixture would not be
+    # mis-counted as an x.com item.
+    x_items = [m for m in filtered if (urlparse(m["url"]).hostname or "").lower() == "x.com"]
     assert len(x_items) == 5
 
 
@@ -164,8 +169,16 @@ def test_filter_media_twitter_and_x_share_a_cap():
             }
         )
     filtered = WikiCompiler._filter_media_for_resources(items)
+
     # Both canonicalize to x.com, so 10 candidates collapse to the cap.
-    social = [m for m in filtered if ("x.com" in m["url"] or "twitter.com" in m["url"])]
+    # CodeQL alerts #35, #36: parse hostname instead of substring-matching
+    # the URL. Hosts compared exactly so attacker-positioned `evil.com/x.com`
+    # would not be mis-counted as social.
+    def _is_x_or_twitter(url: str) -> bool:
+        host = (urlparse(url).hostname or "").lower()
+        return host in ("x.com", "twitter.com")
+
+    social = [m for m in filtered if _is_x_or_twitter(m["url"])]
     assert len(social) == 5
 
 

--- a/web/src/components/graph/MediaModal.tsx
+++ b/web/src/components/graph/MediaModal.tsx
@@ -15,7 +15,18 @@ export function MediaModal({ name, url, mediaType, onClose }: MediaModalProps) {
   // synchronous `buildLoaderUrl` (raw key) because anchor URLs cannot
   // await an async mint without click-time resolution; that migration
   // is tracked as a follow-up.
-  const isSlackFile = url.includes("files.slack.com");
+  //
+  // CodeQL alert #19: parse the URL and compare the hostname rather
+  // than `url.includes("files.slack.com")` — substring matching against
+  // the full URL would treat an attacker URL like
+  // `evil.com/files.slack.com` as a Slack file.
+  const isSlackFile = (() => {
+    try {
+      return new URL(url).hostname.toLowerCase() === "files.slack.com";
+    } catch {
+      return false;
+    }
+  })();
   const proxyPath = `/api/files/proxy?url=${encodeURIComponent(url)}`;
   const anchorHref = isSlackFile ? buildLoaderUrl(proxyPath) : url;
 

--- a/web/src/components/wiki/WikiMarkdown.tsx
+++ b/web/src/components/wiki/WikiMarkdown.tsx
@@ -11,9 +11,21 @@ import { ProxiedImage } from "@/components/common/ProxiedImage";
 import type { WikiCitation } from "@/lib/types";
 
 /** Returns the route path needed to mint a signed loader token, or null
- * if the URL is public (no proxy needed). */
+ * if the URL is public (no proxy needed).
+ *
+ * Compares the parsed-URL hostname against the allowlist instead of
+ * `url.includes("files.slack.com")` — substring matching against the full
+ * URL would treat `evil.com/files.slack.com` as a Slack file and 404 on
+ * the proxy with attacker-controlled bytes in the URL. CodeQL alert #20.
+ */
 function proxyPathFor(url: string): string | null {
-  if (url.includes("files.slack.com")) {
+  let host: string;
+  try {
+    host = new URL(url).hostname.toLowerCase();
+  } catch {
+    return null;
+  }
+  if (host === "files.slack.com") {
     return `/api/files/proxy?url=${encodeURIComponent(url)}`;
   }
   return null;


### PR DESCRIPTION
## Summary

Fixes 13 CodeQL `incomplete-url-substring-sanitization` alerts (12 JavaScript + 1 Python) by replacing `url.includes("<host>")` style checks with parsed-URL hostname comparisons (exact match or proper-subdomain suffix).

| Range | Alerts | Area | Commit |
|---|---|---|---|
| #12–#18 | 7 | `bot/src/bridge.ts` `detectPlatformFromUrl` | `59d274c` |
| #19–#20 | 2 | `web/src/components/{graph/MediaModal,wiki/WikiMarkdown}.tsx` | `3c1b76a` |
| #33 | 1 | `src/beever_atlas/wiki/compiler.py` | `2797e77` |
| #34–#36 | 3 | `tests/wiki/test_wiki_quality_improvements.py` | `193eef7` |

## Risk classification

**None of these are security-critical sinks.** They're routing decisions and test code. Substring-bypass would cause:
- Bot bridge: wrong-adapter routing (the actual SSRF defense lives in `assertAllowedFetchUrl` per-platform — see PR #109).
- Web: spurious proxy attempt (server-side host check rejects non-Slack URLs with 400).
- Compiler: wrong rate cap (5 vs 10) — content-quality issue, not security.
- Tests: weakened assertion that could miss future deceptive fixtures.

Defense-in-depth + alert hygiene fix; no exploitable vulnerability is being closed.

## Why one PR

Same rule, same fix shape (`url.includes(host)` → `new URL(url).hostname === host` or `host.endsWith(".host.com")`). Mechanical edits, small per-file footprint. Per-area commits keep individual reverts atomic; the bundle ensures consistency between sibling sites.

## Behavioral verification

For every site, the new behavior is **byte-identical for legitimate URLs**:
- Bot routing: real Slack/Discord/Teams/Telegram URLs hit the same branch.
- Web proxying: legitimate `https://files.slack.com/...` URLs still proxy.
- Compiler cap: `github.com` and `gist.github.com` still get cap=10; `raw.githubusercontent.com` continues to fall under the default cap=5.
- Tests: every existing fixture has the host as the URL's hostname → assertion result unchanged.

The behavior **diverges only for adversarial inputs** (`evil.com/files.slack.com`, `files.slack.com.evil.com`, etc.), where the new code correctly rejects what the old substring match incorrectly accepted.

## Test plan

- [x] `cd bot && npm test` — 151/151 PASS
- [x] `cd bot && npm run build` — `tsc` clean
- [x] `cd web && npx tsc --noEmit` — clean
- [x] `cd web && npm run lint` — 0 errors (75 pre-existing warnings unchanged)
- [x] `pytest tests/wiki/test_wiki_quality_improvements.py` — 23/23 PASS
- [x] `ruff check + format --check` — clean
- [ ] After merge: confirm CodeQL re-scan auto-closes alerts #12–#20, #33–#36

## SharePoint subdomain note

`bot/bridge.ts` Teams branch now uses `host.endsWith(".sharepoint.com")` (proper subdomain match for per-tenant hosts like `contoso.sharepoint.com`, `contoso-my.sharepoint.com`). The apex `sharepoint.com` is intentionally excluded — it's not a tenant and shouldn't route to the Teams adapter. Same pattern as the SSRF allowlist in PR #109.

🤖 Generated with [Claude Code](https://claude.com/claude-code)