### PR TITLE
fix(tests): raise adaptive-batcher perf-test ceilings 1.0s → 3.0s (#55)

### DIFF
--- a/tests/test_adaptive_batcher.py
+++ b/tests/test_adaptive_batcher.py
@@ -188,8 +188,13 @@ class TestBatcherPerformance:
         batches = token_aware_batches(msgs, max_tokens=12_000)
         elapsed = time.perf_counter() - t0
         assert sum(len(b) for b in batches) == 1000
-        # Adaptive batcher must stay well under 1s for 1k messages on CI hardware.
-        assert elapsed < 1.0, f"default batching too slow: {elapsed:.3f}s"
+        # Issue #55 — sanity ceiling, not a perf gate. The batcher is pure
+        # Python with no I/O so 1k messages typically completes in <50ms;
+        # 3.0s gives ~60x headroom for loaded CI hosts while still catching
+        # O(n²) regressions (those would push past several seconds at 1k).
+        # Algorithmic regression detection lives in
+        # test_perf_parity_default_vs_output_aware (relative, load-immune).
+        assert elapsed < 3.0, f"default batching too slow: {elapsed:.3f}s"
 
     def test_perf_with_output_budget_1000_messages(self):
         msgs = self._make_messages(1000)
@@ -199,8 +204,10 @@ class TestBatcherPerformance:
         )
         elapsed = time.perf_counter() - t0
         assert sum(len(b) for b in batches) == 1000
-        # Output-aware path must not regress materially vs. default.
-        assert elapsed < 1.0, f"output-aware batching too slow: {elapsed:.3f}s"
+        # Issue #55 — see test_perf_default_1000_messages for threshold
+        # rationale; output-aware regression vs. default is checked
+        # relatively in test_perf_parity_default_vs_output_aware.
+        assert elapsed < 3.0, f"output-aware batching too slow: {elapsed:.3f}s"
 
     def test_perf_parity_default_vs_output_aware(self):
         """Output-aware path must not be more than 3x slower than default."""


### PR DESCRIPTION
## Summary
- Closes #55 — \`TestBatcherPerformance.test_perf_default_1000_messages\` and \`test_perf_with_output_budget_1000_messages\` had absolute wall-clock thresholds of \`elapsed < 1.0\` for batching 1k messages. The issue notes flakes are rare but the pattern is fragile under CI load.
- Bumps the threshold to **3.0s** (~60× the typical ~50ms runtime) and clarifies in inline comments that these are *sanity ceilings*, not perf gates. The third test in the class (\`test_perf_parity_default_vs_output_aware\`) already uses the right pattern (relative comparison against a self-calibrated baseline) and is unchanged.

## Why option (1), not (2) or (3)
Issue lists three suggested options:

1. **Increase threshold to 2-3s** ← chose this
2. Use relative comparisons (like the third test, against an in-test baseline)
3. \`@pytest.mark.slow\` / \`.perf\` and exclude from default CI

- **(2)** would duplicate what \`test_perf_parity\` already does — algorithmic-regression detection via relative comparison. Tests 1/2 are intentionally simpler smoke checks; turning them into a second relative-comparison setup would double their wall-clock for marginal value.
- **(3)** loses the smoke-check value entirely (these tests run on every CI build today; gating them behind a marker means a regression slips by until someone manually flips the slow-suite flag). Overkill for a "rarely flakes" issue.
- **(1)** is the minimal change that raises headroom without changing semantics or coverage.

## Verification
- \`pytest tests/test_adaptive_batcher.py\` → **20 passed**, 0 fail
- \`pytest tests/test_adaptive_batcher.py::TestBatcherPerformance\` → 3 passed (incl. both bumped tests + the relative one)
- Both bumped tests still pass locally well under the new 3.0s ceiling (~50ms typical)
- \`test_perf_parity_default_vs_output_aware\` (the relative test) is **unchanged** — it remains the algorithmic-regression gate

## Test plan
- [x] All 20 batcher tests pass
- [x] Both modified tests pass under new 3.0s ceiling
- [x] Relative-comparison test untouched (still gates output-aware path)
- [ ] Reproduce historical flake under simulated CI load (would require docker/cgroup throttling — not run in this worktree)

## Forward-looking note
If these tests flake again on CI even with the 3.0s ceiling, the next step is option (2) (in-test baseline + relative ratio), not bumping further — an absolute 5s+ ceiling dilutes the sanity check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)