### PR TITLE
fix(ci): smoke gates on healthy-only + uses compose service name (#56)

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -51,8 +51,16 @@ jobs:
           RESP=$(curl -sf http://localhost:8000/api/health)
           echo "Health response: $RESP"
           STATUS=$(echo "$RESP" | jq -r '.status')
-          if [ "$STATUS" != "healthy" ] && [ "$STATUS" != "degraded" ]; then
+          # Issue #56 — smoke runs against a fresh `docker compose up` with
+          # every registered dependency (weaviate, neo4j, mongodb, redis)
+          # available, so anything other than "healthy" indicates a real
+          # problem. Previously "degraded" was accepted, which masked
+          # failures of non-critical components that are still expected
+          # to be up under CI.
+          if [ "$STATUS" != "healthy" ]; then
             echo "Unexpected status: $STATUS"
+            echo "Components NOT 'up':"
+            echo "$RESP" | jq -r '.components | to_entries[] | select(.value.status != "up") | "  - \(.key): status=\(.value.status) error=\(.value.error // "n/a") critical=\(.value.critical)"'
             exit 1
           fi
           echo "$RESP" | jq -e '.components | keys | length > 0' > /dev/null
@@ -68,8 +76,12 @@ jobs:
           docker compose logs --no-color --timestamps --tail=all || true
           echo '== raw docker ps -a =='
           docker ps -a || true
-          echo '== raw beever-atlas logs =='
-          docker logs beever-atlas-beever-atlas-1 2>&1 || true
+          # Issue #56 — `docker compose logs <service>` uses the stable
+          # service name from compose, not the project-prefixed container
+          # name (which breaks if the working directory is renamed or
+          # Compose changes its naming convention).
+          echo '== beever-atlas logs (compose) =='
+          docker compose logs --no-color --timestamps --tail=all beever-atlas || true
 
       - name: Tear down
         if: always()


### PR DESCRIPTION
## Summary
- Closes #56 — two issues in `.github/workflows/smoke.yml`:
  1. Health assertion accepted both `healthy` AND `degraded` as success — masked failures of non-critical components (neo4j, redis) that smoke is supposed to catch.
  2. Failure-log dump hardcoded `docker logs beever-atlas-beever-atlas-1`, which is a Compose v2 naming detail (project + service + index). Renaming the working dir or any naming-convention change breaks log collection silently because of the `|| true`.

## Changes

### 1. Strict status check + actionable failure output
```bash
-if [ "$STATUS" != "healthy" ] && [ "$STATUS" != "degraded" ]; then
+if [ "$STATUS" != "healthy" ]; then
   echo "Unexpected status: $STATUS"
+  echo "Components NOT 'up':"
+  echo "$RESP" | jq -r '.components | to_entries[] |
+    select(.value.status != "up") |
+    "  - \(.key): status=\(.value.status) error=\(.value.error // "n/a") critical=\(.value.critical)"'
   exit 1
fi
```

Smoke runs against a fresh `docker compose up` with all four registered dependencies (`weaviate`, `neo4j`, `mongodb`, `redis`) on the same network, so any `down` component is a real bug — even if marked non-critical. The non-critical flag on neo4j/redis lets the *runtime* boot in a degraded state (intentional graceful degradation), but the smoke test is a different bar.

The new failure output turns "smoke failed because status was 'degraded'" into "smoke failed because neo4j is down with 'connect refused'" — actionable, no need to dig through 20MB of compose logs.

### 2. Compose service name (not project-prefixed container name)
```bash
-echo '== raw beever-atlas logs =='
-docker logs beever-atlas-beever-atlas-1 2>&1 || true
+echo '== beever-atlas logs (compose) =='
+docker compose logs --no-color --timestamps --tail=all beever-atlas || true
```

Service name (`beever-atlas`) is stable in compose.yml; project-name-prefixed container names are an implementation detail.

## Verification
- `yaml.safe_load` on the modified workflow → parses cleanly
- jq query validated on a synthetic degraded payload:
  ```
  - neo4j: status=down error=connect refused critical=false
  - redis: status=down error=timeout critical=false
  ```
- The healthy path is unchanged — existing PRs against main continue to pass smoke as before
- Cannot be tested locally end-to-end (workflow runs only on GitHub Actions); the PR's own CI run is the first proof

## Why not other options
- **`ALLOW_DEGRADED` env gate**: adds complexity for an edge case (smoke against a non-Compose deployment) that no current scenario calls for.
- **Drop the components assertion entirely**: relies on runtime crash-loop for failure signal — slower, harder to triage in CI where containers are gone by the time logs upload.

## Test plan
- [x] YAML parses
- [x] jq query produces actionable output on synthetic degraded payload
- [x] Healthy path unchanged
- [ ] PR's own smoke CI run passes (first end-to-end proof)

🤖 Generated with [Claude Code](https://claude.com/claude-code)