### PR TITLE
fix(ci): least-privilege workflow permissions (CodeQL #1–#7)

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -12,6 +12,10 @@ concurrency:
   group: audit-${{ github.ref }}
   cancel-in-progress: true
 
+# Least-privilege default. CodeQL alert #3 — actions/missing-workflow-permissions.
+permissions:
+  contents: read
+
 jobs:
   audit:
     name: pip-audit + npm audit (HIGH/CRITICAL gate)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,13 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+# Default to least-privilege at the workflow level. Individual jobs may
+# elevate via their own `permissions:` block if a future change needs
+# write access (e.g. to comment on PRs or upload SBOMs). CodeQL alerts
+# #2, #4, #5, #7 — actions/missing-workflow-permissions.
+permissions:
+  contents: read
+
 jobs:
   backend:
     name: Backend (Python 3.12)

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -5,6 +5,10 @@ on:
     - cron: "0 6 * * *"
   workflow_dispatch:
 
+# Least-privilege default. CodeQL alert #1 — actions/missing-workflow-permissions.
+permissions:
+  contents: read
+
 jobs:
   contracts:
     name: Graph backend contract tests

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -11,6 +11,10 @@ concurrency:
   group: smoke-${{ github.ref }}
   cancel-in-progress: true
 
+# Least-privilege default. CodeQL alert #6 — actions/missing-workflow-permissions.
+permissions:
+  contents: read
+
 jobs:
   smoke:
     name: Docker Compose smoke test


### PR DESCRIPTION
## Summary
- Adds `permissions: contents: read` at the workflow level for `ci.yml`, `nightly.yml`, `audit.yml`, `smoke.yml`.
- Resolves CodeQL `actions/missing-workflow-permissions` alerts **#1–#7** by removing reliance on implicit GITHUB_TOKEN scope.
- Jobs that need elevated scope can opt-in via per-job `permissions:` blocks.

## Test plan
- [ ] CI workflow runs and all four jobs (backend/web/bot/supply-chain-lint) pass on this branch
- [ ] Nightly contract-tests workflow remains schedulable
- [ ] Security audit workflow still runs `pip-audit` + `npm audit`
- [ ] Smoke workflow still brings up docker-compose and reaches `/api/health`

🤖 Generated with [Claude Code](https://claude.com/claude-code)