### PR TITLE
fix(bot): sanitize error responses with safeErrorMessage (CodeQL #10–#11)

### DIFF
--- a/bot/src/bridge.ts
+++ b/bot/src/bridge.ts
@@ -19,8 +19,8 @@ import type { ChatManager } from "./chat-manager.js";
 export type { PlatformErrorShape } from "./bridge/platformError.js";
 export { classifyPlatformError } from "./bridge/platformError.js";
 import { classifyPlatformError } from "./bridge/platformError.js";
-import { jsonResponse, readBody, BodyTooLargeError } from "./http-utils.js";
-export { jsonResponse } from "./http-utils.js";
+import { jsonResponse, readBody, BodyTooLargeError, safeErrorMessage } from "./http-utils.js";
+export { jsonResponse, safeErrorMessage } from "./http-utils.js";
 import { logger } from "./logger.js";
 
 // ── Types ───────────────────────────────────────────────────────────────────
@@ -1796,7 +1796,7 @@ async function handleListChannels(
   } catch (err) {
     console.error("Bridge: listChannels error:", err);
     const classified = classifyPlatformError(err);
-    jsonResponse(res, classified.status, { error: String(err), code: classified.code });
+    jsonResponse(res, classified.status, { error: safeErrorMessage(err), code: classified.code });
   }
 }
 
@@ -1865,7 +1865,7 @@ async function handleGetMessages(
   } catch (err) {
     console.error("Bridge: getMessages error:", err);
     const classified = classifyPlatformError(err);
-    jsonResponse(res, classified.status, { error: String(err), code: classified.code });
+    jsonResponse(res, classified.status, { error: safeErrorMessage(err), code: classified.code });
   }
 }
 
@@ -1897,7 +1897,7 @@ async function handleGetMessageCount(
   } catch (err) {
     console.error("Bridge: getMessageCount error:", err);
     const classified = classifyPlatformError(err);
-    jsonResponse(res, classified.status, { error: String(err), code: classified.code });
+    jsonResponse(res, classified.status, { error: safeErrorMessage(err), code: classified.code });
   }
 }
 
@@ -1930,7 +1930,7 @@ async function handleGetThreadMessages(
   } catch (err) {
     console.error("Bridge: getThreadMessages error:", err);
     const classified = classifyPlatformError(err);
-    jsonResponse(res, classified.status, { error: String(err), code: classified.code });
+    jsonResponse(res, classified.status, { error: safeErrorMessage(err), code: classified.code });
   }
 }
 
@@ -1990,7 +1990,7 @@ async function handleFileProxy(
         // All adapters failed
         console.error("Bridge: fileProxy all adapters failed:", lastErr);
         const classified = classifyPlatformError(lastErr);
-        jsonResponse(res, classified.status, { error: String(lastErr), code: classified.code });
+        jsonResponse(res, classified.status, { error: safeErrorMessage(lastErr), code: classified.code });
         return;
       }
     }
@@ -2015,7 +2015,7 @@ async function handleFileProxy(
   } catch (err) {
     console.error("Bridge: fileProxy error:", err);
     const classified = classifyPlatformError(err);
-    jsonResponse(res, classified.status, { error: String(err), code: classified.code });
+    jsonResponse(res, classified.status, { error: safeErrorMessage(err), code: classified.code });
   }
 }
 
@@ -2061,7 +2061,7 @@ async function handleRegisterAdapter(
     jsonResponse(res, 200, { status: "ok", platform, connectionId: connectionId || platform });
   } catch (err) {
     console.error("Bridge: registerAdapter error:", err);
-    jsonResponse(res, 500, { status: "error", message: String(err) });
+    jsonResponse(res, 500, { status: "error", message: safeErrorMessage(err) });
   }
 }
 
@@ -2081,7 +2081,7 @@ async function handleUnregisterAdapter(
     jsonResponse(res, 200, { status: "ok" });
   } catch (err) {
     console.error("Bridge: unregisterAdapter error:", err);
-    jsonResponse(res, 500, { status: "error", message: String(err) });
+    jsonResponse(res, 500, { status: "error", message: safeErrorMessage(err) });
   }
 }
 
@@ -2179,7 +2179,7 @@ async function handleValidateAdapter(
     // CodeQL js/tainted-format-string (alert #22): static format string +
     // arguments so user-tainted `platform` cannot influence format specifiers.
     console.error("Bridge: validateAdapter(%s) error:", platform, err);
-    jsonResponse(res, 200, { valid: false, error: String(err) });
+    jsonResponse(res, 200, { valid: false, error: safeErrorMessage(err) });
   }
 }
 
@@ -2208,7 +2208,7 @@ async function handleConnectionRoute(
       // CodeQL js/tainted-format-string (alert #23).
       console.error("Bridge: connection route error (%s):", connectionId, err);
     }
-    jsonResponse(res, classified.status, { error: String(err), code: classified.code });
+    jsonResponse(res, classified.status, { error: safeErrorMessage(err), code: classified.code });
   }
 }
 
@@ -2230,7 +2230,7 @@ async function handleConnectionChannels(
     // CodeQL js/tainted-format-string (alert #24).
     console.error("Bridge: listChannels error (connection %s):", connectionId, err);
     const classified = classifyPlatformError(err);
-    jsonResponse(res, classified.status, { error: String(err), code: classified.code });
+    jsonResponse(res, classified.status, { error: safeErrorMessage(err), code: classified.code });
   }
 }
 
@@ -2266,7 +2266,7 @@ async function handlePlatformChannelsAggregated(
     // CodeQL js/tainted-format-string (alert #26).
     console.error("Bridge: aggregated listChannels error for %s:", platform, err);
     const classified = classifyPlatformError(err);
-    jsonResponse(res, classified.status, { error: String(err), code: classified.code });
+    jsonResponse(res, classified.status, { error: safeErrorMessage(err), code: classified.code });
   }
 }
 

--- a/bot/src/http-utils.ts
+++ b/bot/src/http-utils.ts
@@ -13,6 +13,39 @@ export function jsonResponse(res: ServerResponse, status: number, data: unknown)
   res.end(JSON.stringify(data));
 }
 
+/**
+ * Render an unknown thrown value as a short, single-line, stack-trace-free
+ * string suitable for inclusion in HTTP error responses.
+ *
+ * `String(err)` on a typical `Error` returns just `"<Name>: <message>"`, but
+ * CodeQL `js/stack-trace-exposure` (alerts #10, #11) flags any flow from a
+ * caught error to the response body because some hosts attach `.stack` to
+ * the default `toString` (or callers later substitute a thrown object whose
+ * `toString` interpolates `.stack`). We extract `err.message` explicitly,
+ * collapse whitespace, and cap the length so the response never carries
+ * line-numbered frame data even if a future call site goes through here.
+ */
+const _MAX_ERROR_MESSAGE_LEN = 200;
+
+export function safeErrorMessage(err: unknown): string {
+  let raw: string;
+  if (err instanceof Error) {
+    raw = err.message || err.name || "error";
+  } else if (typeof err === "string") {
+    raw = err;
+  } else if (err && typeof err === "object" && "message" in err) {
+    const m = (err as { message?: unknown }).message;
+    raw = typeof m === "string" ? m : "error";
+  } else {
+    raw = "error";
+  }
+  // Collapse all whitespace runs (including newlines from any accidentally
+  // multi-line message) into single spaces, then trim and length-cap.
+  const flat = raw.replace(/\s+/g, " ").trim();
+  if (flat.length <= _MAX_ERROR_MESSAGE_LEN) return flat;
+  return `${flat.slice(0, _MAX_ERROR_MESSAGE_LEN)}…`;
+}
+
 /** Maximum HTTP request body the bot will accept (1 MB). */
 export const MAX_BODY_SIZE = 1_048_576;
 

--- a/bot/src/readbody.test.ts
+++ b/bot/src/readbody.test.ts
@@ -153,9 +153,13 @@ describe("readBody — HTTP integration (Test #7)", () => {
         }
         res.writeHead(200, { "Content-Type": "application/json" });
         res.end(JSON.stringify({ status: "ok", got: body.length }));
-      } catch (err) {
+      } catch (_err) {
+        // Test fixture: surface only a generic 500 to satisfy CodeQL
+        // js/stack-trace-exposure (alert #11). The real bridge handlers
+        // route through `safeErrorMessage`; this fixture only exercises
+        // the 413 path so the message itself is irrelevant to the test.
         res.writeHead(500);
-        res.end(String(err));
+        res.end("internal error");
       }
     });
 


### PR DESCRIPTION
## Summary
- New `safeErrorMessage(err)` helper in `bot/src/http-utils.ts` returns just `err.message`, whitespace-collapsed and length-capped (200 chars), with safe fallbacks for non-Error throws.
- All 11 \`jsonResponse(..., { error: String(err) ... })\` callsites in \`bot/src/bridge.ts\` switched to \`safeErrorMessage(err)\`.
- \`bot/src/readbody.test.ts\` fixture's 500-fallback now returns a static \"internal error\" instead of \`String(err)\` — only the 413 path is asserted.
- Resolves CodeQL \`js/stack-trace-exposure\` alerts **#10, #11**.

## Test plan
- [x] \`npm run build\` (bot)
- [x] \`npm test\` (bot) — 163/163 pass, including readbody integration test that checks the 413 path still flushes
- [ ] CodeQL re-run shows alerts #10 and #11 closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)