### PR TITLE
fix(bot): avoid double-decoding HTML entities (CodeQL #8)

### DIFF
--- a/bot/src/slack-mrkdwn.test.ts
+++ b/bot/src/slack-mrkdwn.test.ts
@@ -125,6 +125,16 @@ describe("cleanSlackMrkdwn", () => {
     );
   });
 
+  // CodeQL js/double-escaping (alert #8): if the user literally typed
+  // `&lt;`, Slack escapes the leading `&` as `&amp;`, so the message we
+  // receive is `&amp;lt;`. We must decode `&lt;`/`&gt;` before `&amp;`
+  // so the final pass surfaces `&lt;` as text, not `<`.
+  it("does not double-decode user-typed entities", () => {
+    assert.strictEqual(cleanSlackMrkdwn("&amp;lt;"), "&lt;");
+    assert.strictEqual(cleanSlackMrkdwn("&amp;gt;"), "&gt;");
+    assert.strictEqual(cleanSlackMrkdwn("&amp;amp;"), "&amp;");
+  });
+
   // ── Formatting markers ────────────────────────────────────────────
 
   it("strips *bold* markers", () => {

--- a/bot/src/slack-mrkdwn.ts
+++ b/bot/src/slack-mrkdwn.ts
@@ -54,10 +54,18 @@ export function cleanSlackMrkdwn(
     return inner;
   });
 
-  // 2. Decode HTML entities that Slack uses
-  cleaned = cleaned.replace(/&amp;/g, "&");
+  // 2. Decode HTML entities that Slack uses.
+  //
+  // Order matters (CodeQL js/double-escaping, alert #8): decode `&amp;`
+  // LAST. Slack escapes user-typed `&` as `&amp;`, so an original input
+  // of literally `&lt;` arrives as `&amp;lt;`. If we decode `&amp;` →
+  // `&` first, the result `&lt;` then gets decoded to `<`, swallowing
+  // the user's literal text. Decoding the angle-brackets first leaves
+  // any `&amp;`-escaped sequences intact for the final `&amp;` → `&`
+  // pass, so a literal `&lt;` survives as `&lt;` text.
   cleaned = cleaned.replace(/&lt;/g, "<");
   cleaned = cleaned.replace(/&gt;/g, ">");
+  cleaned = cleaned.replace(/&amp;/g, "&");
 
   // 3. Strip bold/italic/strikethrough markers (preserve content)
   //    Use non-greedy match, avoid stripping mid-word underscores (e.g. snake_case)


### PR DESCRIPTION
## Summary
- Reorder HTML entity decoding in \`cleanSlackMrkdwn\`: \`&lt;\` and \`&gt;\` first, then \`&amp;\` last.
- A user-typed \`&lt;\` arrives as \`&amp;lt;\` (Slack escapes the leading \`&\`); the previous order silently turned that into \`<\`.
- Adds regression test asserting \`&amp;lt;\` → \`&lt;\` and \`&amp;amp;\` → \`&amp;\`.
- Resolves CodeQL \`js/double-escaping\` alert **#8**.

## Test plan
- [x] \`npm test\` (bot) — 164/164 pass, including the new \"does not double-decode user-typed entities\" case
- [x] Existing \"decodes &amp; &lt; &gt;\" test still passes (single-level decode unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)