### PR TITLE
fix(bot): static-dictionary error responses (CodeQL #60)

### DIFF
--- a/bot/src/bridge.ts
+++ b/bot/src/bridge.ts
@@ -19,8 +19,13 @@ import type { ChatManager } from "./chat-manager.js";
 export type { PlatformErrorShape } from "./bridge/platformError.js";
 export { classifyPlatformError } from "./bridge/platformError.js";
 import { classifyPlatformError } from "./bridge/platformError.js";
-import { jsonResponse, readBody, BodyTooLargeError, safeErrorMessage } from "./http-utils.js";
-export { jsonResponse, safeErrorMessage } from "./http-utils.js";
+import {
+  jsonResponse,
+  readBody,
+  BodyTooLargeError,
+  messageForCode,
+} from "./http-utils.js";
+export { jsonResponse, safeErrorMessage, messageForCode } from "./http-utils.js";
 import { logger } from "./logger.js";
 
 // ── Types ───────────────────────────────────────────────────────────────────
@@ -2081,7 +2086,7 @@ async function handleListChannels(
   } catch (err) {
     console.error("Bridge: listChannels error:", err);
     const classified = classifyPlatformError(err);
-    jsonResponse(res, classified.status, { error: safeErrorMessage(err), code: classified.code });
+    jsonResponse(res, classified.status, { error: messageForCode(classified.code), code: classified.code });
   }
 }
 
@@ -2150,7 +2155,7 @@ async function handleGetMessages(
   } catch (err) {
     console.error("Bridge: getMessages error:", err);
     const classified = classifyPlatformError(err);
-    jsonResponse(res, classified.status, { error: safeErrorMessage(err), code: classified.code });
+    jsonResponse(res, classified.status, { error: messageForCode(classified.code), code: classified.code });
   }
 }
 
@@ -2182,7 +2187,7 @@ async function handleGetMessageCount(
   } catch (err) {
     console.error("Bridge: getMessageCount error:", err);
     const classified = classifyPlatformError(err);
-    jsonResponse(res, classified.status, { error: safeErrorMessage(err), code: classified.code });
+    jsonResponse(res, classified.status, { error: messageForCode(classified.code), code: classified.code });
   }
 }
 
@@ -2215,7 +2220,7 @@ async function handleGetThreadMessages(
   } catch (err) {
     console.error("Bridge: getThreadMessages error:", err);
     const classified = classifyPlatformError(err);
-    jsonResponse(res, classified.status, { error: safeErrorMessage(err), code: classified.code });
+    jsonResponse(res, classified.status, { error: messageForCode(classified.code), code: classified.code });
   }
 }
 
@@ -2275,7 +2280,7 @@ async function handleFileProxy(
         // All adapters failed
         console.error("Bridge: fileProxy all adapters failed:", lastErr);
         const classified = classifyPlatformError(lastErr);
-        jsonResponse(res, classified.status, { error: safeErrorMessage(lastErr), code: classified.code });
+        jsonResponse(res, classified.status, { error: messageForCode(classified.code), code: classified.code });
         return;
       }
     }
@@ -2300,7 +2305,7 @@ async function handleFileProxy(
   } catch (err) {
     console.error("Bridge: fileProxy error:", err);
     const classified = classifyPlatformError(err);
-    jsonResponse(res, classified.status, { error: safeErrorMessage(err), code: classified.code });
+    jsonResponse(res, classified.status, { error: messageForCode(classified.code), code: classified.code });
   }
 }
 
@@ -2345,8 +2350,10 @@ async function handleRegisterAdapter(
     await chatManager.register(platform, normalizedCreds, connectionId || undefined);
     jsonResponse(res, 200, { status: "ok", platform, connectionId: connectionId || platform });
   } catch (err) {
+    // CodeQL js/stack-trace-exposure (alert #60): static prose, never derived
+    // from `err`. Operators see the full error in the console.error line above.
     console.error("Bridge: registerAdapter error:", err);
-    jsonResponse(res, 500, { status: "error", message: safeErrorMessage(err) });
+    jsonResponse(res, 500, { status: "error", message: "adapter registration failed" });
   }
 }
 
@@ -2365,8 +2372,10 @@ async function handleUnregisterAdapter(
     }
     jsonResponse(res, 200, { status: "ok" });
   } catch (err) {
+    // CodeQL js/stack-trace-exposure (alert #60): static prose, never derived
+    // from `err`. Operators see the full error in the console.error line above.
     console.error("Bridge: unregisterAdapter error:", err);
-    jsonResponse(res, 500, { status: "error", message: safeErrorMessage(err) });
+    jsonResponse(res, 500, { status: "error", message: "adapter unregistration failed" });
   }
 }
 
@@ -2463,8 +2472,10 @@ async function handleValidateAdapter(
   } catch (err) {
     // CodeQL js/tainted-format-string (alert #22): static format string +
     // arguments so user-tainted `platform` cannot influence format specifiers.
+    // CodeQL js/stack-trace-exposure (alert #60): static prose, never derived
+    // from `err`. Operators see the full error in the console.error line above.
     console.error("Bridge: validateAdapter(%s) error:", platform, err);
-    jsonResponse(res, 200, { valid: false, error: safeErrorMessage(err) });
+    jsonResponse(res, 200, { valid: false, error: "validation failed" });
   }
 }
 
@@ -2493,7 +2504,7 @@ async function handleConnectionRoute(
       // CodeQL js/tainted-format-string (alert #23).
       console.error("Bridge: connection route error (%s):", connectionId, err);
     }
-    jsonResponse(res, classified.status, { error: safeErrorMessage(err), code: classified.code });
+    jsonResponse(res, classified.status, { error: messageForCode(classified.code), code: classified.code });
   }
 }
 
@@ -2515,7 +2526,7 @@ async function handleConnectionChannels(
     // CodeQL js/tainted-format-string (alert #24).
     console.error("Bridge: listChannels error (connection %s):", connectionId, err);
     const classified = classifyPlatformError(err);
-    jsonResponse(res, classified.status, { error: safeErrorMessage(err), code: classified.code });
+    jsonResponse(res, classified.status, { error: messageForCode(classified.code), code: classified.code });
   }
 }
 
@@ -2551,7 +2562,7 @@ async function handlePlatformChannelsAggregated(
     // CodeQL js/tainted-format-string (alert #26).
     console.error("Bridge: aggregated listChannels error for %s:", platform, err);
     const classified = classifyPlatformError(err);
-    jsonResponse(res, classified.status, { error: safeErrorMessage(err), code: classified.code });
+    jsonResponse(res, classified.status, { error: messageForCode(classified.code), code: classified.code });
   }
 }
 

--- a/bot/src/bridge/withPlatformError.ts
+++ b/bot/src/bridge/withPlatformError.ts
@@ -9,7 +9,7 @@
 
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { classifyPlatformError } from "./platformError.js";
-import { jsonResponse } from "../http-utils.js";
+import { jsonResponse, messageForCode } from "../http-utils.js";
 
 export type BridgeHandler = (
   req: IncomingMessage,
@@ -21,8 +21,12 @@ export function withPlatformError(handler: BridgeHandler): BridgeHandler {
     try {
       await handler(req, res);
     } catch (err) {
+      // CodeQL js/stack-trace-exposure (alert #60): the response prose
+      // is derived ONLY from the closed `code` enum, never from `err`.
+      // The full error is still available to operators via console.error.
       const { status, code } = classifyPlatformError(err);
-      jsonResponse(res, status, { error: String(err), code });
+      console.error("Bridge: handler error:", err);
+      jsonResponse(res, status, { error: messageForCode(code), code });
     }
   };
 }

--- a/bot/src/http-utils.test.ts
+++ b/bot/src/http-utils.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Tests for the response-side helpers in `http-utils.ts`.
+ *
+ * `messageForCode` is the canonical static-dictionary lookup that
+ * replaces `safeErrorMessage(err)` at HTTP response sinks. It exists
+ * to break the data-flow edge from caught `Error` values to the
+ * response body that triggered CodeQL `js/stack-trace-exposure`
+ * alert #60. The dictionary surface is small and stable; pinning it
+ * here protects future contributors from accidentally widening the
+ * keyspace or piping `err`-derived strings back through.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { messageForCode } from "./http-utils.js";
+
+describe("messageForCode", () => {
+  it("maps every classifyPlatformError code to a static prose message", () => {
+    assert.strictEqual(messageForCode("NOT_FOUND"), "resource not found");
+    assert.strictEqual(messageForCode("FORBIDDEN"), "access denied");
+    assert.strictEqual(messageForCode("RATE_LIMITED"), "rate limited");
+    assert.strictEqual(messageForCode("NOT_SUPPORTED"), "operation not supported");
+    assert.strictEqual(messageForCode("PLATFORM_ERROR"), "upstream platform error");
+  });
+
+  it("returns generic 'internal error' for unknown codes", () => {
+    assert.strictEqual(messageForCode("WAT"), "internal error");
+    assert.strictEqual(messageForCode(""), "internal error");
+  });
+
+  it("does not resolve via prototype-chain lookup", () => {
+    // Guards against a future caller passing user input where a closed
+    // enum was expected. `toString`, `hasOwnProperty`, etc. live on the
+    // prototype and would resolve via plain bracket access; the helper
+    // uses `Object.prototype.hasOwnProperty.call` so they fall through
+    // to the generic message.
+    assert.strictEqual(messageForCode("toString"), "internal error");
+    assert.strictEqual(messageForCode("hasOwnProperty"), "internal error");
+    assert.strictEqual(messageForCode("__proto__"), "internal error");
+  });
+});

--- a/bot/src/http-utils.ts
+++ b/bot/src/http-utils.ts
@@ -46,6 +46,44 @@ export function safeErrorMessage(err: unknown): string {
   return `${flat.slice(0, _MAX_ERROR_MESSAGE_LEN)}…`;
 }
 
+/**
+ * Static prose dictionary for the closed enum returned by
+ * `classifyPlatformError`. Use this — NOT `safeErrorMessage` — when
+ * building HTTP error responses.
+ *
+ * CodeQL `js/stack-trace-exposure` (alert #60) treats any data-flow
+ * edge from a caught `Error` to a response body as tainted, including
+ * `err.message` access — its taint model can't prove `.message`
+ * doesn't carry frame data on arbitrary SDK errors. Routing the
+ * response through this dictionary breaks the edge entirely: the
+ * outgoing string is derived only from the `code` enum, which is a
+ * compile-time literal set. Operators retain full debug visibility
+ * via `console.error("...", err)` at every catch site — logs are not
+ * the response body.
+ *
+ * Directive: do NOT call `safeErrorMessage(err)` (or `String(err)`,
+ * `err.message`, `err.toString()`) at a response sink. Always derive
+ * the response prose from `messageForCode(classifyPlatformError(err).code)`.
+ */
+const _CODE_MESSAGES: Readonly<Record<string, string>> = Object.freeze({
+  NOT_FOUND: "resource not found",
+  FORBIDDEN: "access denied",
+  RATE_LIMITED: "rate limited",
+  NOT_SUPPORTED: "operation not supported",
+  PLATFORM_ERROR: "upstream platform error",
+});
+
+export function messageForCode(code: string): string {
+  // Object.prototype.hasOwnProperty.call avoids prototype-pollution
+  // bypass — `code` is a closed enum from classifyPlatformError but
+  // the helper is exported, so a future caller could pass arbitrary
+  // input.
+  if (Object.prototype.hasOwnProperty.call(_CODE_MESSAGES, code)) {
+    return _CODE_MESSAGES[code];
+  }
+  return "internal error";
+}
+
 /** Maximum HTTP request body the bot will accept (1 MB). */
 export const MAX_BODY_SIZE = 1_048_576;
 


### PR DESCRIPTION
## Summary
- Replaces `safeErrorMessage(err)` (and the missed `String(err)` in `withPlatformError.ts`) at all HTTP response sinks with `messageForCode(classifyPlatformError(err).code)` — a frozen 5-key dictionary lookup over the closed enum.
- The outgoing `error:` field is now derived **only** from the code enum or a literal — no data-flow edge from caught `Error` values to the response body.
- Operators retain full debug visibility via `console.error("...", err)` at every catch site (logs are not the response body).

## Why
CodeQL `js/stack-trace-exposure` re-fired as alert **#60** with 15 distinct flow paths after PR #122 because:
1. `bot/src/bridge/withPlatformError.ts:25` still emitted `String(err)` — that single wrapper executes for every wrapped route.
2. The `safeErrorMessage` helper itself read `err.message`, which the CodeQL taint model treats as part of the stack-trace flow (it can't prove `.message` doesn't carry frame data on arbitrary SDK errors).

## Files
- `bot/src/http-utils.ts` — adds `messageForCode(code)` with `Object.prototype.hasOwnProperty.call` guard against prototype-chain lookups.
- `bot/src/bridge/withPlatformError.ts` — uses `messageForCode(code)`, adds `console.error` for operator visibility.
- `bot/src/bridge.ts` — 9 classified-context sites switched to `messageForCode(classified.code)`; 3 non-classified sites (`registerAdapter`, `unregisterAdapter`, `validateAdapter`) get hard-coded literals.
- `bot/src/http-utils.test.ts` — new file pinning the dictionary, the generic fallback, and the prototype-pollution guard.

## Test plan
- [x] `npm run build` (bot) — clean
- [x] `npm test` (bot) — 167/167 pass (3 new for `messageForCode`)
- [ ] CodeQL re-run shows alert #60 closed (all 15 paths)
- [ ] Manual smoke: confirm a 4xx/5xx response from any bridge route still surfaces the right `code:` and a sensible (now-static) `error:` prose

## Behavior change visible to API clients
The `code:` field is unchanged. The `error:` prose is now one of:
- `"resource not found"` (NOT_FOUND, status 404)
- `"access denied"` (FORBIDDEN, status 403)
- `"rate limited"` (RATE_LIMITED, status 429)
- `"operation not supported"` (NOT_SUPPORTED, status 501)
- `"upstream platform error"` (PLATFORM_ERROR, status 502)
- `"adapter registration failed"` / `"adapter unregistration failed"` / `"validation failed"` for the 3 non-classified handlers
- `"internal error"` as the catch-all

Any client parsing `error:` prose (vs. `code:`) will need to switch to keying off `code:` — but that's the intended contract; prose was never load-bearing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)