### PR TITLE
fix(ci): least-privilege GITHUB_TOKEN scope on 4 workflows (CodeQL #1–#7)

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -12,6 +12,12 @@ concurrency:
   group: audit-${{ github.ref }}
   cancel-in-progress: true
 
+# Least-privilege GITHUB_TOKEN — workflow only checks out the repo and
+# runs pip-audit / npm audit. No artifact uploads or PR comments, so
+# contents: read is sufficient (CodeQL #3).
+permissions:
+  contents: read
+
 jobs:
   audit:
     name: pip-audit + npm audit (HIGH/CRITICAL gate)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,12 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+# Least-privilege GITHUB_TOKEN — every job here only checks out the repo
+# and runs tests / lint / build. No artifact uploads, PR comments, or
+# pushes, so contents: read covers all four jobs (CodeQL #2, #4, #5, #7).
+permissions:
+  contents: read
+
 jobs:
   backend:
     name: Backend (Python 3.12)

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -5,6 +5,12 @@ on:
     - cron: "0 6 * * *"
   workflow_dispatch:
 
+# Least-privilege GITHUB_TOKEN — workflow only checks out the repo and
+# runs tests against ephemeral service containers. No artifact uploads,
+# PR comments, or pushes, so contents: read is sufficient (CodeQL #1).
+permissions:
+  contents: read
+
 jobs:
   contracts:
     name: Graph backend contract tests

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -11,6 +11,12 @@ concurrency:
   group: smoke-${{ github.ref }}
   cancel-in-progress: true
 
+# Least-privilege GITHUB_TOKEN — workflow only checks out the repo and
+# runs `docker compose up`. No artifact uploads or PR comments, so
+# contents: read is sufficient (CodeQL #6).
+permissions:
+  contents: read
+
 jobs:
   smoke:
     name: Docker Compose smoke test


### PR DESCRIPTION
## Summary
Closes CodeQL alerts **#1, #2, #3, #4, #5, #6, #7** (rule \`actions/missing-workflow-permissions\`) — adds a top-level \`permissions: contents: read\` block to \`nightly.yml\`, \`ci.yml\`, \`audit.yml\`, and \`smoke.yml\`. Without an explicit block, GitHub Actions hands the job a write-all \`GITHUB_TOKEN\` — far broader than these workflows need.

## Audit (why \`contents: read\` is sufficient everywhere)
All four workflows consist only of:
- \`actions/checkout@v4\`
- \`actions/setup-{python,node,uv}@*\`
- \`docker/setup-buildx-action@v4\` (smoke only)
- shell \`run:\` steps that test / lint / build / \`docker compose up\`

There are **no** \`upload-artifact\`, \`github-script\`, PR-comment, deploy, or push steps. So a single workflow-level \`contents: read\` covers every job — no per-job overrides needed.

## File ↔ alert map
| File | Alerts |
|---|---|
| \`nightly.yml\` | #1 |
| \`ci.yml\` | #2, #4, #5, #7 *(4 jobs share one workflow-level block)* |
| \`audit.yml\` | #3 |
| \`smoke.yml\` | #6 |

## Untouched
- \`codeql.yml\` — already declares \`actions: read | contents: read | security-events: write\` per CodeQL's own template.
- \`deploy.yml\`, \`trigger-docs-rebuild.yml\` — not in this alert batch; unchanged.

## Verification
- \`python yaml.safe_load\` passes on all four files
- Diff is 24 lines (one block × 4 files), no logic changes
- The PR's own CI / smoke / audit runs are the first runtime proof — if any step actually needed write scope, it'd fail loudly with a permissions error, not silently

## Forward-looking
The added comment block above each \`permissions:\` declaration points at the rationale (e.g. \"contents: read is sufficient because no artifact uploads or PR comments\"). New workflows should copy this header as a template and only widen scopes when a specific step demands it (\`security-events: write\` for SARIF upload, \`contents: write\` for push-back, etc.).

## Test plan
- [x] YAML parses on all four files
- [x] No logic / step / runner changes
- [x] CodeQL re-scan after merge will mark #1–#7 closed
- [ ] PR's own CI / smoke / audit runs pass under the new permissions (first runtime proof)

🤖 Generated with [Claude Code](https://claude.com/claude-code)