### PR TITLE
chore(deps): bump bot+web Dockerfiles to node:24-alpine (LTS)

### DIFF
--- a/bot/Dockerfile
+++ b/bot/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-alpine@sha256:8ea2348b068a9544dae7317b4f3aafcdc032df1647bb7d768a05a5cad1a7683f AS build
+FROM node:24-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f AS build
 
 WORKDIR /app
 COPY package*.json ./
@@ -7,9 +7,9 @@ COPY tsconfig.json ./
 COPY src/ src/
 RUN npm run build
 
-FROM node:22-alpine@sha256:8ea2348b068a9544dae7317b4f3aafcdc032df1647bb7d768a05a5cad1a7683f
+FROM node:24-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f
 
-# Issue #39 — drop root. node:22-alpine ships a built-in `node` user (UID 1000).
+# Issue #39 — drop root. node:24-alpine ships a built-in `node` user (UID 1000).
 # Keep WORKDIR /app for path stability — anything hard-coding /app/dist/index.js
 # (volume mounts, log/process monitoring) continues to work.
 RUN mkdir -p /app && chown node:node /app

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-alpine@sha256:8ea2348b068a9544dae7317b4f3aafcdc032df1647bb7d768a05a5cad1a7683f AS build
+FROM node:24-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f AS build
 
 WORKDIR /app
 COPY package*.json ./


### PR DESCRIPTION
## Summary

- Bumps both `bot/Dockerfile` (build + runtime stages) and `web/Dockerfile` (build stage) from `node:22-alpine` to `node:24-alpine`.
- Replaces dependabot PRs #156 / #157, which targeted `node:26-alpine`. Node 26 is the Current release line and doesn't enter Active LTS until October 2026; Node 24 is the current Active LTS.

## Why not Node 26 (as dependabot proposed)?

- Node 26 was released April 2026 → enters Active LTS Oct 2026.
- `bot/Dockerfile` runs Node at runtime (`CMD ["node", "dist/index.js"]`), so the base image **is** the production runtime. Production runtimes should stay on Active LTS.
- Node 24 satisfies every dependency engine constraint in `bot/` and `web/` (`uuid` v14 requires ≥20, eslint v9 family ≥18, all chat-adapter family ≥18).

## Why Node 24 (not staying on 22)?

- Picks up the latest alpine base refresh.
- Node 22 enters Maintenance LTS October 2026; Node 24 is the freshest Active LTS line.

## Digest

`sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f` is the multi-arch manifest list digest for `node:24-alpine` (last_updated 2026-04-16). Satisfies the existing **Supply Chain (digest pinning)** required check.

## Test plan

- [ ] CI green on `Backend (Python 3.12)`, `Web (Node 20)`, `Bot (Node 20)`, `Docker Compose smoke test`, `Supply Chain (digest pinning)`, both CodeQL jobs, and `pip-audit + npm audit`.
- [ ] Docker Compose smoke confirms both images build and the bot container starts on Node 24.
- [ ] Verify no `engines.node` peer warnings appear during `npm ci` inside the build stage.

Closes #156
Closes #157