### PR TITLE
chore(deps): resolve hono to 4.12.18 in web lockfile (keep override floor at ^4.12.14)

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -5932,9 +5932,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.14",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
-      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
+      "version": "4.12.18",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
+      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"


### PR DESCRIPTION
## Summary

- Re-applies the hono 4.12.14 → 4.12.18 bump that dependabot opened in #153 (closed for being stale + tightening the override).
- Lockfile-only change: `web/package-lock.json` now resolves `hono@4.12.18`. `web/package.json`'s `overrides.hono` stays at `^4.12.14` (the GHSA-458j-xx4x-4375 fix floor) so future patches resolve naturally.
- hono is a transitive dep via `@modelcontextprotocol/sdk` — no direct imports in `web/src`.

## Security delta

4.12.18 picks up three additional patches over 4.12.14:

- GHSA-p77w-8qqv-26rm — cache middleware ignores `Vary: Authorization`/`Vary: Cookie` (cross-user cache leakage)
- GHSA-qp7p-654g-cw7p — CSS declaration injection via style-object values in JSX SSR
- GHSA-hm8q-7f3q-5f36 — improper NumericDate validation in JWT `verify()`

No breaking changes between 4.12.14 and 4.12.18 (all patch within the same minor).

## Why a manual PR (not just merge #153)?

1. The dependabot branch was stale — predates the `fast-uri` override added to `main` on 2026-05-12, so it would have conflicted.
2. Dependabot proposed bumping the override from `^4.12.14` to `^4.12.18`. The override's purpose is the GHSA-458j-xx4x-4375 *floor*; tightening it removes patch-resolution flexibility without security benefit. Keeping `^4.12.14` lets npm pick the latest satisfying version automatically.

## Test plan

- [ ] CI green on `verify-overrides` (prebuild script) — confirms `hono ≥ 4.12.14` floor still satisfied.
- [ ] `Web (Node 20)` build passes.
- [ ] `pip-audit + npm audit (HIGH/CRITICAL gate)` no longer flags hono.
- [ ] `Supply Chain (digest pinning)` and CodeQL clean.

Replaces #153.