### PR TITLE
fix(ingestion): close summarize-settled race and wiki first-sync deadlock

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,10 +39,13 @@ VITE_BEEVER_ADMIN_TOKEN=dev-admin-change-me
 
 # --- 1.4b Loader signed-URL tokens (file proxy auth) ------
 # Short-lived HMAC tokens issued for ?loader_token=… on file-proxy URLs
-# so a leaked URL expires within LOADER_TOKEN_TTL seconds. In production
-# LOADER_TOKEN_SECRET is REQUIRED (server fails fast on empty value when
-# BEEVER_ENV=production); in dev an empty value disables signed-token
-# verification and falls back to ?access_token= raw-key matching.
+# so a leaked URL expires within LOADER_TOKEN_TTL seconds. Production
+# REQUIRES it (server fails fast on empty in BEEVER_ENV=production).
+# Empty in dev works but the mint endpoint returns 503 on every image
+# load — frontend falls back to raw ?access_token=, which spams the
+# backend log. `./atlas` auto-generates a 64-char hex value here; set
+# one manually for clean logs on Manual Docker / Option 2 setups:
+#   python -c "import secrets; print(secrets.token_hex(32))"
 LOADER_TOKEN_SECRET=
 LOADER_TOKEN_TTL=300
 # During the migration window, accept the legacy ?access_token=<api-key>

--- a/atlas
+++ b/atlas
@@ -924,8 +924,25 @@ if grep -qE "^WEAVIATE_API_KEY=$" .env; then
   secrets_changed=true
 fi
 
+# LOADER_TOKEN_SECRET signs the short-lived ?loader_token= URLs the web UI
+# uses for <img> / <a href> file-proxy access. Empty is supported in dev
+# (the server falls back to raw ?access_token= matching), but the fallback
+# path emits 503s on the mint endpoint that the frontend retries against
+# every image load — noisy in logs. Generate a value so the signed-token
+# path activates cleanly. Production REQUIRES it (server fails fast).
+if grep -qE "^LOADER_TOKEN_SECRET=$" .env; then
+  new_loader_secret="$(gen_hex 32)"
+  if [ -z "$new_loader_secret" ]; then
+    error "Cannot generate LOADER_TOKEN_SECRET — neither Python nor /dev/urandom available."
+    exit 1
+  fi
+  replace_env_value "LOADER_TOKEN_SECRET" "$new_loader_secret"
+  ok "Generated a fresh LOADER_TOKEN_SECRET"
+  secrets_changed=true
+fi
+
 if ! $secrets_changed; then
-  ok "Master + Weaviate keys already set — nothing to regenerate"
+  ok "Master + Weaviate + Loader-token secrets already set — nothing to regenerate"
 fi
 
 # ---------------------------------------------------------------------

--- a/src/beever_atlas/agents/callbacks/quality_gates.py
+++ b/src/beever_atlas/agents/callbacks/quality_gates.py
@@ -179,19 +179,62 @@ def fact_extraction_with_recovery(callback_context: CallbackContext) -> None:
         recovered = None
         if isinstance(result, dict) and "facts" in result:
             recovered = result
-        logger.warning(
-            "truncation_report agent=fact_extractor recovered=%d lost_estimate=%d "
-            "raw_bytes=%d last_boundary_offset=%d batch_idx=%s",
-            report.recovered_count,
-            report.estimated_lost,
-            report.raw_bytes,
-            report.last_boundary_offset,
-            callback_context.state.get("batch_num", "?"),
-        )
+        # Distinguish actual truncation (parser stopped before EOF) from
+        # complete-but-empty output (LLM returned `{"facts": []}` or
+        # refused outright). The previous single ``truncation_report`` line
+        # always fired when ``extracted_facts`` was a string, even when the
+        # model returned a perfectly valid empty array — which made every
+        # zero-fact batch look like a parser failure. ``raw_bytes ==
+        # last_boundary_offset`` means the parser reached EOF; anything
+        # less means real truncation.
+        is_actually_truncated = report.raw_bytes > report.last_boundary_offset
+        recovered_fact_count = len(recovered["facts"]) if recovered else 0
+        if is_actually_truncated:
+            logger.warning(
+                "truncation_report agent=fact_extractor recovered=%d lost_estimate=%d "
+                "raw_bytes=%d last_boundary_offset=%d batch_idx=%s",
+                report.recovered_count,
+                report.estimated_lost,
+                report.raw_bytes,
+                report.last_boundary_offset,
+                callback_context.state.get("batch_num", "?"),
+            )
+        elif recovered_fact_count == 0:
+            # Parser reached EOF AND yielded no facts — LLM returned a
+            # complete-but-empty payload (e.g. ``{"facts": []}`` or a
+            # refusal). Distinct from truncation; signals the model
+            # actively decided the batch had no extractable content.
+            logger.warning(
+                "extractor_empty_output agent=fact_extractor recovered_facts=0 "
+                "raw_bytes=%d batch_idx=%s — LLM returned complete-but-empty "
+                "response (not truncated). Likely a prompt/refusal issue or a "
+                "batch with no extractable content.",
+                report.raw_bytes,
+                callback_context.state.get("batch_num", "?"),
+            )
+        else:
+            # Parser reached EOF AND yielded facts. ADK's strict
+            # validator still failed (so we landed in this recovery
+            # branch) — usually markdown fences, a preamble like
+            # ``Here is the JSON:``, or trailing prose around an
+            # otherwise valid JSON body. Recovery handled it.
+            logger.warning(
+                "extractor_unstructured_complete agent=fact_extractor "
+                "recovered_facts=%d raw_bytes=%d batch_idx=%s — ADK's "
+                "strict parse failed but the raw output was structurally "
+                "complete; recovery salvaged the facts. Usually caused by "
+                "markdown fences or a preamble around the JSON body.",
+                recovered_fact_count,
+                report.raw_bytes,
+                callback_context.state.get("batch_num", "?"),
+            )
         if recovered:
             logger.info(
-                "fact_extraction_with_recovery: recovered %d facts from truncated output",
-                len(recovered["facts"]),
+                "fact_extraction_with_recovery: recovered %d facts from %s output",
+                recovered_fact_count,
+                "truncated"
+                if is_actually_truncated
+                else ("empty" if recovered_fact_count == 0 else "complete"),
             )
             callback_context.state["extracted_facts"] = recovered
             return fact_quality_gate_callback(callback_context)
@@ -218,19 +261,43 @@ def entity_extraction_with_recovery(callback_context: CallbackContext) -> None:
             if isinstance(result, dict) and ("entities" in result or "relationships" in result)
             else None
         )
-        logger.warning(
-            "truncation_report agent=entity_extractor recovered=%d lost_estimate=%d "
-            "raw_bytes=%d last_boundary_offset=%d batch_idx=%s",
-            report.recovered_count,
-            report.estimated_lost,
-            report.raw_bytes,
-            report.last_boundary_offset,
-            callback_context.state.get("batch_num", "?"),
-        )
+        is_actually_truncated = report.raw_bytes > report.last_boundary_offset
+        recovered_entity_count = len(recovered.get("entities", [])) if recovered else 0
+        if is_actually_truncated:
+            logger.warning(
+                "truncation_report agent=entity_extractor recovered=%d lost_estimate=%d "
+                "raw_bytes=%d last_boundary_offset=%d batch_idx=%s",
+                report.recovered_count,
+                report.estimated_lost,
+                report.raw_bytes,
+                report.last_boundary_offset,
+                callback_context.state.get("batch_num", "?"),
+            )
+        elif recovered_entity_count == 0:
+            logger.warning(
+                "extractor_empty_output agent=entity_extractor recovered_entities=0 "
+                "raw_bytes=%d batch_idx=%s — LLM returned complete-but-empty response "
+                "(not truncated).",
+                report.raw_bytes,
+                callback_context.state.get("batch_num", "?"),
+            )
+        else:
+            logger.warning(
+                "extractor_unstructured_complete agent=entity_extractor "
+                "recovered_entities=%d raw_bytes=%d batch_idx=%s — ADK's strict "
+                "parse failed but the raw output was structurally complete; "
+                "recovery salvaged the entities.",
+                recovered_entity_count,
+                report.raw_bytes,
+                callback_context.state.get("batch_num", "?"),
+            )
         # Accumulate per-sync truncation counters for sync_summary: metric lines.
+        # Only counted when the report reflects actual truncation, so the
+        # metric stays meaningful for capacity planning instead of being
+        # dominated by complete-but-empty refusals.
         _qg_channel_id = callback_context.state.get("channel_id", "")
         _qg_sync_job_id = callback_context.state.get("sync_job_id", "")
-        if _qg_channel_id and _qg_sync_job_id:
+        if _qg_channel_id and _qg_sync_job_id and is_actually_truncated:
             from beever_atlas.services.batch_processor import increment_sync_metric
 
             increment_sync_metric(_qg_channel_id, _qg_sync_job_id, "entity_truncation_recoveries")
@@ -239,8 +306,11 @@ def entity_extraction_with_recovery(callback_context: CallbackContext) -> None:
             )
         if recovered:
             logger.info(
-                "entity_extraction_with_recovery: recovered %d entities from truncated output",
-                len(recovered.get("entities", [])),
+                "entity_extraction_with_recovery: recovered %d entities from %s output",
+                recovered_entity_count,
+                "truncated"
+                if is_actually_truncated
+                else ("empty" if recovered_entity_count == 0 else "complete"),
             )
             callback_context.state["extracted_entities"] = recovered
             return entity_quality_gate_callback(callback_context)

--- a/src/beever_atlas/agents/prompts/fact_extractor.py
+++ b/src/beever_atlas/agents/prompts/fact_extractor.py
@@ -19,11 +19,19 @@ Language-agnostic calibration example (Cantonese, zh-HK):
 You are a fact-extraction engine for a workspace memory system.
 
 ## Relevance Principle: The 6-Month Test
-Before writing any fact, ask: "Would a new team member joining in 6 months need this
-to understand what the team decided, built, learned, or is working on?"
-A fact passes if it helps them understand team decisions, progress, or blockers.
+Before writing any fact, ask: "Would someone reading this channel 6 months from now
+benefit from knowing this — what happened, what was decided, what people learned,
+experienced, observed, or discussed?"
+A fact passes if it captures substantive knowledge worth remembering — work decisions
+and blockers, but ALSO real-world events, personal experiences with named context,
+recommendations, observations about people/places/things, or any informational claim
+beyond pure chit-chat.
 A fact fails if it reads like a database log entry, contains raw system identifiers,
-or could be re-derived trivially from re-reading the original message.
+is pure social noise (greetings, reactions, "+1"), or could be re-derived trivially
+from re-reading the original message.
+Channels vary in purpose: team-work, personal journals, food logs, news commentary,
+research scratchpads. The same bar applies — capture what's substantive for THIS
+channel's purpose; don't reject content for being "not work-related".
 
 ## Context
 Channel: {channel_name}
@@ -87,9 +95,15 @@ When you cannot determine what a link/resource IS without speculation, set the f
 - Emoji-only or reaction-only
 - Channel join/leave notifications
 - Status updates with no informational content ("brb", "back", "afk")
-- Off-topic: not about team work, projects, decisions, or shared knowledge
-  (e.g. casual sports chat, personal announcements unrelated to work)
+- Pure chit-chat with no substantive claim, named entity, or event
+  (e.g. "haha", "lol same", "true" — but DO extract "the ramen at Ichiran
+  in Causeway Bay was salty tonight", which has a named place + observation)
 - Exact duplicates of information already captured in another fact
+
+Do NOT skip a message just because it isn't about team work. Personal
+observations, recommendations, opinions on events, places, food, books,
+shows, current affairs, and life updates are all valid IF they carry
+substantive informational content beyond a bare reaction.
 
 ---
 
@@ -122,6 +136,17 @@ Drop any fact with quality_score < 0.5. Scores MUST vary — not every fact is 0
 **MEDIUM (0.63)** — question with full context:
   "Bob asked whether the team should migrate the /search API from REST to GraphQL, motivated by the mobile app's need for flexible field selection"
   — Specificity 0.7, Actionability 0.6, Verifiability 0.6 → 0.63
+
+**MEDIUM (0.65)** — personal-channel observation with named context:
+  "The ramen at Ichiran in Causeway Bay had richer broth than the Mong Kok branch, per Sbeve's visit on June 2020"
+  — Specificity 0.75, Actionability 0.4, Verifiability 0.8 → 0.65
+  (Personal channels are valid — capture named places, events, dates, opinions
+  with reasoning. Don't reject for being non-work.)
+
+**MEDIUM (0.60)** — current-affairs commentary with stance + topic:
+  "Sbeve expressed frustration toward the people in the Hong Kong Science Park social media story circulating in June 2020, calling for them to face physical harm"
+  — Specificity 0.7, Actionability 0.3, Verifiability 0.8 → 0.60
+  (Opinions on real-world events with named subject + clear position pass the bar.)
 
 **TOO THIN (0.40)** — decision without rationale (lacks the *why*):
   "Alice decided to use Redis"
@@ -332,4 +357,11 @@ If the entire batch contains no extractable facts (only greetings, noise, or off
 return `{{"facts": [], "skip_reason": "<brief reason>"}}`.
 
 Do not invent information. Extract only what is explicitly stated or directly implied.
+
+## Output integrity
+CRITICAL: emit syntactically complete JSON. Close the outer object with `}` and
+the `facts` array with `]`. If you approach the response limit, STOP at a
+complete fact-object boundary — never end mid-object. Prefer fewer complete
+facts over many partial ones; the consumer parses array elements one at a
+time and a partial trailing element is lost.
 """

--- a/src/beever_atlas/agents/prompts/fact_extractor.py
+++ b/src/beever_atlas/agents/prompts/fact_extractor.py
@@ -359,7 +359,7 @@ return `{{"facts": [], "skip_reason": "<brief reason>"}}`.
 Do not invent information. Extract only what is explicitly stated or directly implied.
 
 ## Output integrity
-CRITICAL: emit syntactically complete JSON. Close the outer object with `}` and
+CRITICAL: emit syntactically complete JSON. Close the outer object with `}}` and
 the `facts` array with `]`. If you approach the response limit, STOP at a
 complete fact-object boundary — never end mid-object. Prefer fewer complete
 facts over many partial ones; the consumer parses array elements one at a

--- a/src/beever_atlas/services/auto_overview_subscriber.py
+++ b/src/beever_atlas/services/auto_overview_subscriber.py
@@ -73,6 +73,15 @@ class AutoOverviewSubscriber:
     # promote to Settings if operators need per-deployment tuning.
     _GENERATION_TIMEOUT_SECONDS = 600
 
+    # Bounded retry for WikiNotReadyError. The inner data_gatherer already
+    # polls 60s for ``channel_summary`` before raising; on a fresh sync
+    # with a slow consolidation+summarize chain (LLM rate-limited, queue
+    # backlog) that window can be exceeded. Retry the build a small
+    # number of times before declaring terminal failure so the wiki can
+    # land without requiring a manual Generate click.
+    _NOT_READY_MAX_RETRIES = 3
+    _NOT_READY_RETRY_DELAY_SECONDS = 30
+
     def __init__(
         self,
         *,
@@ -213,8 +222,52 @@ class AutoOverviewSubscriber:
                 channel_id,
                 language,
             )
+            # Import here to avoid a top-level cycle (capabilities → wiki →
+            # services → capabilities) and keep the subscriber importable
+            # from non-async test fixtures.
+            from beever_atlas.capabilities.errors import WikiNotReadyError
+
+            async def _attempt_with_retries() -> None:
+                """Inner loop with bounded WikiNotReadyError retries.
+
+                The inner data_gatherer polls 60s for channel_summary
+                before raising. On a fresh sync the consolidation +
+                summarize chain can exceed that — particularly when the
+                LLM is rate-limited. Retry a small number of times
+                before declaring terminal failure so the wiki lands
+                without requiring a manual Generate click.
+
+                The whole loop (attempts + sleeps) runs INSIDE the
+                outer ``wait_for`` so the
+                ``_GENERATION_TIMEOUT_SECONDS`` budget covers every
+                retry, not just the most recent one. Without this an
+                upstream call that hangs near-but-not-quite to 600s
+                per attempt could keep this method alive for tens of
+                minutes — the original retry implementation had this
+                bug (code-reviewer flagged it pre-merge).
+                """
+                attempt = 0
+                while True:
+                    try:
+                        await self._generate_overview(channel_id, language)
+                        return
+                    except WikiNotReadyError as exc:
+                        if attempt >= self._NOT_READY_MAX_RETRIES:
+                            raise
+                        attempt += 1
+                        logger.warning(
+                            "AutoOverviewSubscriber: wiki not ready channel=%s "
+                            "(%s) — retrying %d/%d after %ds",
+                            channel_id,
+                            exc,
+                            attempt,
+                            self._NOT_READY_MAX_RETRIES,
+                            self._NOT_READY_RETRY_DELAY_SECONDS,
+                        )
+                        await asyncio.sleep(self._NOT_READY_RETRY_DELAY_SECONDS)
+
             await asyncio.wait_for(
-                self._generate_overview(channel_id, language),
+                _attempt_with_retries(),
                 timeout=self._GENERATION_TIMEOUT_SECONDS,
             )
             logger.info(

--- a/src/beever_atlas/services/pipeline_orchestrator.py
+++ b/src/beever_atlas/services/pipeline_orchestrator.py
@@ -196,6 +196,22 @@ async def consolidate_only(channel_id: str) -> None:
     (the same strategies the subscriber already checks before calling us).
     """
     logger.info("Orchestrator: consolidate_only (no counter) channel=%s", channel_id)
+    # Race fix: set the summarize-settled gate SYNCHRONOUSLY before spawning
+    # the consolidation task. The previous add inside ``_run_consolidation``
+    # only flipped the gate after the event loop scheduled the task, which
+    # lost the race against ``memory_settled`` subscribers firing in the
+    # same tick — ``summarize_settled_for_channel`` saw an empty gate, took
+    # the silent early-return, and ``channel_summary`` was never written.
+    # AutoOverview then polled 60s for the missing summary and raised
+    # WikiNotReadyError, leaving the wiki permanently 404. No await sits
+    # between this line and the task spawn, so the window is closed.
+    try:
+        from beever_atlas.infra.config import get_settings
+
+        if get_settings().consolidation_summarize_on_settle:
+            _channels_pending_summary.add(channel_id)
+    except Exception:  # noqa: BLE001 — gate is belt-and-braces; the in-task add still runs
+        pass
     _spawn_consolidation(channel_id)
 
 

--- a/src/beever_atlas/services/wiki_maintainer.py
+++ b/src/beever_atlas/services/wiki_maintainer.py
@@ -114,7 +114,7 @@ def _validate_kind_schema(kind: str, payload: Any) -> str | None:
     return None
 
 
-def _derive_kind_from_page_id(page_id: str) -> str:
+def derive_kind_from_page_id(page_id: str) -> str:
     """Map a structural ``page_id`` to its synthesis kind.
 
     Bridges the migration window: legacy pages have ``kind`` defaulted
@@ -159,7 +159,7 @@ def _resolve_dispatch_kind(page: "WikiPage") -> str:
     """
     if page.kind and page.kind != "topic":
         return page.kind
-    return _derive_kind_from_page_id(page.page_id)
+    return derive_kind_from_page_id(page.page_id)
 
 
 def _parse_affected_sections_from_obj(
@@ -1532,7 +1532,7 @@ class WikiMaintainer:
             try:
                 from beever_atlas.wiki.kinds import KIND_REGISTRY
 
-                _candidate_kind = _derive_kind_from_page_id(page_id)
+                _candidate_kind = derive_kind_from_page_id(page_id)
                 _spec = KIND_REGISTRY.get(_candidate_kind)
                 if _spec is not None and not _spec.is_required:
                     logger.info(
@@ -1551,7 +1551,7 @@ class WikiMaintainer:
                 page_id=page_id,
                 title=await self._resolve_first_touch_title(page_id, channel_id),
                 slug=page_id.replace(":", "-"),
-                kind=_derive_kind_from_page_id(page_id),
+                kind=derive_kind_from_page_id(page_id),
                 sections=[
                     WikiPageSection(
                         id="overview",

--- a/src/beever_atlas/wiki/builder.py
+++ b/src/beever_atlas/wiki/builder.py
@@ -549,6 +549,68 @@ class WikiBuilder:
 
             await self._cache.save_wiki(channel_id, wiki_dict, target_lang=target_lang)
 
+            # First-sync gate fix: seed the ``wiki_pages`` collection with
+            # one minimal row per compiled page. The maintainer's
+            # incremental path reads from ``wiki_pages`` and DEFERS every
+            # dirty entry until rows exist there. Before this seed, Builder
+            # only wrote to ``wiki_cache`` so the maintainer's first-sync
+            # gate stayed permanently active — ``_rewrite_page`` (the only
+            # writer to ``wiki_pages``) was never reachable because the
+            # gate blocks it. Result was a chicken-and-egg deadlock where
+            # every memory_settled logged ``Builder hasn't run yet —
+            # first-sync gate`` even after a successful build.
+            #
+            # Note the type translation: ``compiler.compile`` returns
+            # ``models.domain.WikiPage`` (rendered-content shape used by
+            # the UI cache), while ``WikiPageStore`` persists
+            # ``models.persistence.WikiPage`` (incremental-maintenance
+            # shape). The seed copies the identity fields (page_id, slug,
+            # title) plus a derived ``kind``. The maintainer will fill
+            # ``sections`` / ``last_facts_seen`` on its first
+            # ``apply_update`` of each page; the UI doesn't read this
+            # collection so empty sections are safe in the meantime.
+            try:
+                from beever_atlas.wiki.page_store import WikiPageStore
+                from beever_atlas.models.persistence import (
+                    WikiPage as _PersistedWikiPage,
+                )
+                from beever_atlas.services.wiki_maintainer import (
+                    derive_kind_from_page_id as _derive_kind,
+                )
+
+                _seed_ps = WikiPageStore(db=self._cache._db)  # noqa: SLF001
+                _seeded = 0
+                for _dp_id, _dp in pages.items():
+                    try:
+                        _seed = _PersistedWikiPage(
+                            channel_id=channel_id,
+                            target_lang=target_lang,
+                            page_id=_dp_id,
+                            title=getattr(_dp, "title", "") or "",
+                            slug=getattr(_dp, "slug", "")
+                            or _dp_id.replace(":", "-"),
+                            kind=_derive_kind(_dp_id),
+                        )
+                        await _seed_ps.save_page(_seed)
+                        _seeded += 1
+                    except Exception:  # noqa: BLE001 — per-page isolation
+                        logger.exception(
+                            "WikiBuilder: wiki_pages seed failed channel=%s page=%s",
+                            channel_id,
+                            _dp_id,
+                        )
+                logger.info(
+                    "WikiBuilder: seeded wiki_pages channel=%s rows=%d/%d",
+                    channel_id,
+                    _seeded,
+                    len(pages),
+                )
+            except Exception:  # noqa: BLE001 — seeding is best-effort
+                logger.exception(
+                    "WikiBuilder: wiki_pages seed step crashed channel=%s",
+                    channel_id,
+                )
+
             # Mark generation complete
             await self._cache.set_generation_status(
                 channel_id=channel_id,

--- a/src/beever_atlas/wiki/builder.py
+++ b/src/beever_atlas/wiki/builder.py
@@ -587,8 +587,7 @@ class WikiBuilder:
                             target_lang=target_lang,
                             page_id=_dp_id,
                             title=getattr(_dp, "title", "") or "",
-                            slug=getattr(_dp, "slug", "")
-                            or _dp_id.replace(":", "-"),
+                            slug=getattr(_dp, "slug", "") or _dp_id.replace(":", "-"),
                             kind=_derive_kind(_dp_id),
                         )
                         await _seed_ps.save_page(_seed)

--- a/src/beever_atlas/wiki/cache.py
+++ b/src/beever_atlas/wiki/cache.py
@@ -104,6 +104,20 @@ class WikiCache:
         # first save_page call, so during the soak window pages can
         # exist in either store. The fallback eliminates a window where
         # the UI would 404 mid-migration.
+        #
+        # First-sync seed compat: ``WikiBuilder.refresh_wiki`` now seeds
+        # ``wiki_pages`` with the persistence shape (no ``content``,
+        # ``modules``, or ``narrative_sections`` fields — those are
+        # render-only and live on the ``wiki_cache`` blob). Returning the
+        # seed alone breaks ``TopicPage``/``OverviewPage`` which do
+        # ``page.content.replace(...)``. So when both stores have an
+        # entry, MERGE them: persistence row provides metadata (kind,
+        # is_dirty, last_facts_seen, …), the legacy cache provides the
+        # render-only fields (content, modules, narrative_sections, …).
+        # Cache-only fields are layered on top, so a maintainer rewrite
+        # that bumps ``version`` in wiki_pages keeps that bump while
+        # still surfacing the rendered content the UI needs.
+        per_page_row: dict | None = None
         if get_settings().per_page_wiki:
             try:
                 from beever_atlas.wiki.page_store import WikiPageStore
@@ -115,8 +129,7 @@ class WikiCache:
                     target_lang=target_lang,
                 )
                 if page is not None:
-                    # Render to the legacy dict shape callers expect.
-                    return page.model_dump(mode="json")
+                    per_page_row = page.model_dump(mode="json")
             except Exception as exc:  # noqa: BLE001 — fall through to legacy on any error
                 logger.warning(
                     "WikiCache.get_page: per-page lookup failed, falling back "
@@ -137,9 +150,40 @@ class WikiCache:
                 {"channel_id": channel_id},
                 {"_id": 0, f"pages.{page_id}": 1},
             )
-        if doc is None:
+        cache_row = doc.get("pages", {}).get(page_id) if doc is not None else None
+
+        if per_page_row is None and cache_row is None:
             return None
-        return doc.get("pages", {}).get(page_id)
+        if per_page_row is None:
+            return cache_row
+        if cache_row is None:
+            return per_page_row
+        # Both stores have an entry — overlay the legacy cache's
+        # render-only fields onto the persistence row. The persistence
+        # row stays authoritative for maintenance metadata (kind,
+        # is_dirty, last_facts_seen, version, curation_mode, …) which
+        # the maintainer mutates on every rewrite. Render-only fields
+        # are listed explicitly so a future code path that happens to
+        # write ``kind`` or ``version`` into the legacy blob cannot
+        # silently clobber the persistence row's value.
+        _RENDER_ONLY_KEYS = (
+            "content",
+            "modules",
+            "narrative_sections",
+            "summary",
+            "memory_count",
+            "citations",
+            "children",
+            "children_fingerprint",
+            "section_number",
+            "last_updated",
+            "page_type",
+        )
+        merged: dict = dict(per_page_row)
+        for k in _RENDER_ONLY_KEYS:
+            if k in cache_row:
+                merged[k] = cache_row[k]
+        return merged
 
     async def get_structure(self, channel_id: str, target_lang: str = "en") -> dict | None:
         await self._ensure_db()

--- a/tests/services/test_auto_overview_subscriber.py
+++ b/tests/services/test_auto_overview_subscriber.py
@@ -449,3 +449,126 @@ async def test_default_language_final_fallback_is_en(monkeypatch) -> None:
     sub = AutoOverviewSubscriber()
 
     assert await sub._resolve_language("C123") == "en"
+
+
+# ---------------------------------------------------------------------------
+# Bounded retry on WikiNotReadyError
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_retries_wiki_not_ready_then_succeeds(monkeypatch) -> None:
+    """WikiNotReadyError on the first attempt must be retried, not
+    propagated. After the retry succeeds the in-flight slot must
+    release (so a later event can re-fire if needed). ``_attempted``
+    intentionally stays sticky on success — it's cleared elsewhere
+    by ``_safe_overview_state``'s row-existence check, NOT by the
+    finally block (only terminal_failure pops it)."""
+    from beever_atlas.capabilities.errors import WikiNotReadyError
+
+    call_count = 0
+
+    async def flaky_generator(channel_id: str, language: str) -> None:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise WikiNotReadyError("Consolidation is still in progress")
+
+    sub, _ = _make_subscriber(
+        counts={"pending": 0, "extracting": 0, "done": 50, "failed": 0},
+        existing_overview=False,
+        generator=AsyncMock(side_effect=flaky_generator),
+    )
+    # Zero-sleep so the test does not actually wait 30s between attempts.
+    monkeypatch.setattr(sub, "_NOT_READY_RETRY_DELAY_SECONDS", 0)
+
+    await sub.on_extraction_done("C123", ["f1"])
+
+    assert call_count == 2  # one raise + one success
+    assert "C123" not in sub._inflight
+
+
+@pytest.mark.asyncio
+async def test_retries_exhausted_clears_attempted(monkeypatch) -> None:
+    """If ``WikiNotReadyError`` is raised on every attempt the subscriber
+    must give up after ``_NOT_READY_MAX_RETRIES`` retries and clear
+    ``_attempted`` so the UI Retry button can re-fire."""
+    from beever_atlas.capabilities.errors import WikiNotReadyError
+
+    call_count = 0
+
+    async def always_not_ready(channel_id: str, language: str) -> None:
+        nonlocal call_count
+        call_count += 1
+        raise WikiNotReadyError("never settles")
+
+    sub, _ = _make_subscriber(
+        counts={"pending": 0, "extracting": 0, "done": 50, "failed": 0},
+        existing_overview=False,
+        generator=AsyncMock(side_effect=always_not_ready),
+    )
+    monkeypatch.setattr(sub, "_NOT_READY_RETRY_DELAY_SECONDS", 0)
+
+    await sub.on_extraction_done("C123", ["f1"])
+
+    # initial attempt + _NOT_READY_MAX_RETRIES retries
+    assert call_count == sub._NOT_READY_MAX_RETRIES + 1
+    assert "C123" not in sub._attempted
+    assert "C123" not in sub._inflight
+
+
+@pytest.mark.asyncio
+async def test_non_not_ready_exception_is_not_retried() -> None:
+    """Only WikiNotReadyError triggers retries. Other exceptions (LLM
+    quota, network blip) must fail-fast on the first call so we don't
+    rack up cost on a permanent failure."""
+    call_count = 0
+
+    async def quota_failure(channel_id: str, language: str) -> None:
+        nonlocal call_count
+        call_count += 1
+        raise RuntimeError("LLM quota exhausted")
+
+    sub, _ = _make_subscriber(
+        counts={"pending": 0, "extracting": 0, "done": 50, "failed": 0},
+        existing_overview=False,
+        generator=AsyncMock(side_effect=quota_failure),
+    )
+
+    await sub.on_extraction_done("C123", ["f1"])
+
+    assert call_count == 1
+    assert "C123" not in sub._attempted
+
+
+@pytest.mark.asyncio
+async def test_total_retry_budget_bounded_by_generation_timeout(monkeypatch) -> None:
+    """The outer ``wait_for`` budget must cover ALL attempts + sleeps,
+    not reset per attempt. Otherwise a slow upstream can stall the
+    subscriber for tens of minutes (code-reviewer flagged this pre-merge).
+    Force a tiny outer timeout and a generator that holds long enough
+    to confirm the outer wait_for fires across the retry loop."""
+    from beever_atlas.capabilities.errors import WikiNotReadyError
+
+    async def slow_not_ready(channel_id: str, language: str) -> None:
+        # Each attempt takes longer than the outer timeout / max_retries
+        # so cumulative time exceeds the budget within the first retry.
+        await asyncio.sleep(0.1)
+        raise WikiNotReadyError("slow")
+
+    sub, _ = _make_subscriber(
+        counts={"pending": 0, "extracting": 0, "done": 50, "failed": 0},
+        existing_overview=False,
+        generator=AsyncMock(side_effect=slow_not_ready),
+    )
+    monkeypatch.setattr(sub, "_GENERATION_TIMEOUT_SECONDS", 0.15)
+    monkeypatch.setattr(sub, "_NOT_READY_RETRY_DELAY_SECONDS", 0.05)
+
+    start = asyncio.get_event_loop().time()
+    await sub.on_extraction_done("C123", ["f1"])
+    elapsed = asyncio.get_event_loop().time() - start
+
+    # Outer wait_for fires well before the sum of all per-attempt budgets
+    # (which would otherwise be ~ 3 retries * (0.1 + 0.05) + 0.1 = 0.55s).
+    assert elapsed < 0.4, f"retry budget escaped outer wait_for ({elapsed:.2f}s)"
+    assert "C123" not in sub._attempted

--- a/tests/services/test_wiki_synthesis_prompts.py
+++ b/tests/services/test_wiki_synthesis_prompts.py
@@ -504,15 +504,15 @@ def test_load_kind_prompt_raises_on_unknown_kind() -> None:
 
 
 def test_derive_kind_from_page_id_maps_structural_prefixes() -> None:
-    assert wm_mod._derive_kind_from_page_id("topic:auth") == "topic"
-    assert wm_mod._derive_kind_from_page_id("entity:alice") == "entity"
-    assert wm_mod._derive_kind_from_page_id("decisions") == "decisions"
-    assert wm_mod._derive_kind_from_page_id("faq") == "faq"
-    assert wm_mod._derive_kind_from_page_id("action-items") == "action_items"
+    assert wm_mod.derive_kind_from_page_id("topic:auth") == "topic"
+    assert wm_mod.derive_kind_from_page_id("entity:alice") == "entity"
+    assert wm_mod.derive_kind_from_page_id("decisions") == "decisions"
+    assert wm_mod.derive_kind_from_page_id("faq") == "faq"
+    assert wm_mod.derive_kind_from_page_id("action-items") == "action_items"
     # Unknown structure falls back to topic (the safe default — its
     # synthesis prompt is the broadest).
-    assert wm_mod._derive_kind_from_page_id("custom:foo") == "topic"
-    assert wm_mod._derive_kind_from_page_id("") == "topic"
+    assert wm_mod.derive_kind_from_page_id("custom:foo") == "topic"
+    assert wm_mod.derive_kind_from_page_id("") == "topic"
 
 
 def test_resolve_dispatch_kind_prefers_explicit_kind_over_derivation() -> None:

--- a/tests/test_wiki_builder_target_lang.py
+++ b/tests/test_wiki_builder_target_lang.py
@@ -235,16 +235,25 @@ async def test_seeds_wiki_pages_for_each_compiled_page() -> None:
     # must call save_page once per page.
     compiled_pages = {
         "overview": DomainWikiPage(
-            id="overview", slug="overview", title="Overview",
-            content="...", page_type="fixed",
+            id="overview",
+            slug="overview",
+            title="Overview",
+            content="...",
+            page_type="fixed",
         ),
         "topic-alpha": DomainWikiPage(
-            id="topic-alpha", slug="alpha", title="Alpha",
-            content="...", page_type="topic",
+            id="topic-alpha",
+            slug="alpha",
+            title="Alpha",
+            content="...",
+            page_type="topic",
         ),
         "topic-beta": DomainWikiPage(
-            id="topic-beta", slug="beta", title="Beta",
-            content="...", page_type="topic",
+            id="topic-beta",
+            slug="beta",
+            title="Beta",
+            content="...",
+            page_type="topic",
         ),
     }
     fake_compiler = _make_fake_compiler()
@@ -293,16 +302,25 @@ async def test_seed_failure_for_one_page_does_not_kill_build() -> None:
 
     compiled_pages = {
         "overview": DomainWikiPage(
-            id="overview", slug="overview", title="Overview",
-            content="...", page_type="fixed",
+            id="overview",
+            slug="overview",
+            title="Overview",
+            content="...",
+            page_type="fixed",
         ),
         "topic-explodes": DomainWikiPage(
-            id="topic-explodes", slug="kaboom", title="Kaboom",
-            content="...", page_type="topic",
+            id="topic-explodes",
+            slug="kaboom",
+            title="Kaboom",
+            content="...",
+            page_type="topic",
         ),
         "topic-ok": DomainWikiPage(
-            id="topic-ok", slug="ok", title="OK",
-            content="...", page_type="topic",
+            id="topic-ok",
+            slug="ok",
+            title="OK",
+            content="...",
+            page_type="topic",
         ),
     }
     fake_compiler = _make_fake_compiler()

--- a/tests/test_wiki_builder_target_lang.py
+++ b/tests/test_wiki_builder_target_lang.py
@@ -214,3 +214,129 @@ async def test_zh_hk_doc_untouched_after_en_generation() -> None:
 
     # en slot was written
     assert "C1:en" in fake_cache._store
+
+
+@pytest.mark.asyncio
+async def test_seeds_wiki_pages_for_each_compiled_page() -> None:
+    """After ``save_wiki``, Builder must seed ``wiki_pages`` with one
+    ``persistence.WikiPage`` per compiled domain page. Closes the
+    first-sync chicken-and-egg deadlock where the maintainer's
+    incremental flush would forever defer because nothing wrote to
+    ``wiki_pages``."""
+    from beever_atlas.models.domain import WikiPage as DomainWikiPage
+    from beever_atlas.wiki.builder import WikiBuilder
+
+    fake_cache = _make_fake_cache()
+    # Attach a ``_db`` handle since the seed path constructs a
+    # ``WikiPageStore(db=self._cache._db)``.
+    fake_cache._db = MagicMock()
+
+    # Compiler returns three pages — overview + two topics. The seed
+    # must call save_page once per page.
+    compiled_pages = {
+        "overview": DomainWikiPage(
+            id="overview", slug="overview", title="Overview",
+            content="...", page_type="fixed",
+        ),
+        "topic-alpha": DomainWikiPage(
+            id="topic-alpha", slug="alpha", title="Alpha",
+            content="...", page_type="topic",
+        ),
+        "topic-beta": DomainWikiPage(
+            id="topic-beta", slug="beta", title="Beta",
+            content="...", page_type="topic",
+        ),
+    }
+    fake_compiler = _make_fake_compiler()
+    fake_compiler.compile = AsyncMock(return_value=compiled_pages)
+
+    saved_page_ids: list[str] = []
+
+    class _FakePageStore:
+        def __init__(self, db: object) -> None:  # noqa: ARG002 — matches real ctor
+            pass
+
+        async def save_page(self, page: object) -> None:
+            saved_page_ids.append(getattr(page, "page_id", "?"))
+
+    builder = WikiBuilder(
+        weaviate_store=MagicMock(),
+        graph_store=MagicMock(),
+        wiki_cache=fake_cache,
+    )
+    builder._gatherer.gather = AsyncMock(return_value=_make_fake_gatherer_data())
+    builder._make_compiler = MagicMock(return_value=fake_compiler)
+
+    with (
+        patch("beever_atlas.wiki.builder.get_llm_provider") as mock_llm,
+        patch("beever_atlas.wiki.page_store.WikiPageStore", _FakePageStore),
+    ):
+        mock_llm.return_value.get_model_string.return_value = "test-model"
+        await builder.generate_wiki(channel_id="C1", target_lang="en", source_lang="en")
+
+    assert set(saved_page_ids) == {"overview", "topic-alpha", "topic-beta"}, (
+        f"Expected seed for every compiled page; got {saved_page_ids}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_seed_failure_for_one_page_does_not_kill_build() -> None:
+    """The per-page try/except inside the seed loop must isolate
+    failures so a single misbehaving row never wedges the whole build.
+    The legacy ``save_wiki`` write still has to land (UI keeps working)
+    and the other pages still seed."""
+    from beever_atlas.models.domain import WikiPage as DomainWikiPage
+    from beever_atlas.wiki.builder import WikiBuilder
+
+    fake_cache = _make_fake_cache()
+    fake_cache._db = MagicMock()
+
+    compiled_pages = {
+        "overview": DomainWikiPage(
+            id="overview", slug="overview", title="Overview",
+            content="...", page_type="fixed",
+        ),
+        "topic-explodes": DomainWikiPage(
+            id="topic-explodes", slug="kaboom", title="Kaboom",
+            content="...", page_type="topic",
+        ),
+        "topic-ok": DomainWikiPage(
+            id="topic-ok", slug="ok", title="OK",
+            content="...", page_type="topic",
+        ),
+    }
+    fake_compiler = _make_fake_compiler()
+    fake_compiler.compile = AsyncMock(return_value=compiled_pages)
+
+    saved_page_ids: list[str] = []
+
+    class _FlakyPageStore:
+        def __init__(self, db: object) -> None:  # noqa: ARG002
+            pass
+
+        async def save_page(self, page: object) -> None:
+            pid = getattr(page, "page_id", "?")
+            if pid == "topic-explodes":
+                raise RuntimeError("simulated mongo write hiccup")
+            saved_page_ids.append(pid)
+
+    builder = WikiBuilder(
+        weaviate_store=MagicMock(),
+        graph_store=MagicMock(),
+        wiki_cache=fake_cache,
+    )
+    builder._gatherer.gather = AsyncMock(return_value=_make_fake_gatherer_data())
+    builder._make_compiler = MagicMock(return_value=fake_compiler)
+
+    with (
+        patch("beever_atlas.wiki.builder.get_llm_provider") as mock_llm,
+        patch("beever_atlas.wiki.page_store.WikiPageStore", _FlakyPageStore),
+    ):
+        mock_llm.return_value.get_model_string.return_value = "test-model"
+        # MUST NOT raise — per-page error is isolated.
+        await builder.generate_wiki(channel_id="C1", target_lang="en", source_lang="en")
+
+    # Other pages still seeded
+    assert set(saved_page_ids) == {"overview", "topic-ok"}
+    # And the build's primary surface (wiki_cache) was written
+    assert "C1:en" in fake_cache._store

--- a/tests/wiki/test_cache_get_page_merge.py
+++ b/tests/wiki/test_cache_get_page_merge.py
@@ -1,0 +1,221 @@
+"""Regression tests for ``WikiCache.get_page`` two-store merge logic.
+
+Locks in the behavior introduced after the first-sync seed fix: when
+``PER_PAGE_WIKI`` is on AND ``WikiPageStore`` has a seeded row, the
+returned dict must overlay the legacy ``wiki_cache`` blob's render-only
+fields (content, modules, narrative_sections, …) on top of the
+persistence row's maintenance metadata (kind, is_dirty, version,
+last_facts_seen, …). Pre-fix the seed shadowed the cache blob and the
+frontend received a page without ``content`` → TopicPage.tsx crashed.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from beever_atlas.wiki.cache import WikiCache
+
+
+def _persistence_row() -> dict[str, Any]:
+    """A minimal persistence.WikiPage dict as returned by save_page →
+    model_dump. Maintenance metadata only; no rendered content."""
+    return {
+        "channel_id": "C1",
+        "target_lang": "en",
+        "page_id": "topic-test",
+        "title": "Test Topic",
+        "slug": "test-topic",
+        "kind": "topic",
+        "version": 4,
+        "is_dirty": True,
+        "last_facts_seen": ["f1", "f2", "f3"],
+        "curation_mode": "auto",
+        "sections": [],
+        "tensions": [],
+    }
+
+
+def _cache_row() -> dict[str, Any]:
+    """A legacy wiki_cache.pages[page_id] dict as written by Builder
+    via ``save_wiki``. Carries the render-only surface the frontend
+    actually displays."""
+    return {
+        "page_id": "topic-test",
+        "title": "Test Topic — Cache Version",
+        "page_type": "topic",
+        "content": "## Section\n\nFull rendered markdown body, 2k chars.",
+        "modules": [{"id": "hero_summary", "data": {"tldr": "headline"}}],
+        "narrative_sections": [{"anchor": "intro", "paragraphs": []}],
+        "summary": "One-liner for cards.",
+        "memory_count": 8,
+        "citations": [{"id": "[1]", "fact_id": "f1"}],
+        "children": [],
+        "section_number": "2.3",
+        "last_updated": datetime.now(tz=UTC).isoformat(),
+    }
+
+
+def _make_cache_with_stores(
+    *, per_page: dict | None, cache_blob: dict | None, per_page_wiki: bool = True
+) -> WikiCache:
+    """Build a WikiCache wired to fake page_store + collection. Skips
+    ``__init__`` so we don't need a real MongoDB URI."""
+    cache = WikiCache.__new__(WikiCache)
+    cache._db = MagicMock()
+    cache._ensure_db = AsyncMock()
+
+    # Legacy ``wiki_cache.pages[<page_id>]`` lookup.
+    fake_collection = MagicMock()
+    if cache_blob is None:
+        fake_collection.find_one = AsyncMock(return_value=None)
+    else:
+        fake_collection.find_one = AsyncMock(
+            return_value={"pages": {cache_blob["page_id"]: cache_blob}}
+        )
+    cache._collection = fake_collection
+
+    # Settings flag — controls whether the per-page store path runs.
+    settings_stub = SimpleNamespace(per_page_wiki=per_page_wiki, default_target_language="en")
+    settings_patch = patch(
+        "beever_atlas.wiki.cache.get_settings",
+        return_value=settings_stub,
+    )
+    settings_patch.start()
+
+    # PageStore stub — returns a Pydantic-ish object with model_dump.
+    page_obj = None
+    if per_page is not None:
+        page_obj = MagicMock()
+        page_obj.model_dump = MagicMock(return_value=per_page)
+    page_store_stub = MagicMock()
+    page_store_stub.get_page = AsyncMock(return_value=page_obj)
+    page_store_patch = patch(
+        "beever_atlas.wiki.page_store.WikiPageStore",
+        return_value=page_store_stub,
+    )
+    page_store_patch.start()
+
+    # Track patchers so the test can stop them in teardown — we attach
+    # them onto the cache so each test does ``cache._patches[i].stop()``.
+    cache._test_patches = [settings_patch, page_store_patch]  # type: ignore[attr-defined]
+    return cache
+
+
+def _teardown(cache: WikiCache) -> None:
+    for p in getattr(cache, "_test_patches", []):
+        p.stop()
+
+
+@pytest.mark.asyncio
+async def test_merge_overlays_render_only_fields_from_cache() -> None:
+    """When both stores have an entry the cache's render-only fields
+    must appear in the result. Frontend depends on ``content``."""
+    cache = _make_cache_with_stores(per_page=_persistence_row(), cache_blob=_cache_row())
+    try:
+        result = await cache.get_page("C1", "topic-test", target_lang="en")
+        assert result is not None
+        assert result["content"].startswith("## Section")
+        assert result["modules"][0]["id"] == "hero_summary"
+        assert result["narrative_sections"][0]["anchor"] == "intro"
+        assert result["summary"] == "One-liner for cards."
+        assert result["memory_count"] == 8
+        assert result["citations"][0]["fact_id"] == "f1"
+    finally:
+        _teardown(cache)
+
+
+@pytest.mark.asyncio
+async def test_merge_preserves_persistence_metadata() -> None:
+    """Persistence-only fields (kind, is_dirty, version, last_facts_seen,
+    curation_mode) must survive the overlay. The maintainer writes
+    these; a future ``wiki_cache`` blob that accidentally included a
+    ``kind`` or ``version`` key must NOT shadow them."""
+    pers = _persistence_row()
+    cache_blob = _cache_row()
+    # Simulate a hostile cache blob that carries metadata keys it
+    # shouldn't (forward-compat defense).
+    cache_blob["kind"] = "WRONG_KIND"
+    cache_blob["version"] = 99
+    cache_blob["is_dirty"] = False
+    cache_blob["last_facts_seen"] = ["DROPPED"]
+    cache_blob["curation_mode"] = "WRONG"
+
+    cache = _make_cache_with_stores(per_page=pers, cache_blob=cache_blob)
+    try:
+        result = await cache.get_page("C1", "topic-test", target_lang="en")
+        assert result is not None
+        # Persistence keys win.
+        assert result["kind"] == "topic"
+        assert result["version"] == 4
+        assert result["is_dirty"] is True
+        assert result["last_facts_seen"] == ["f1", "f2", "f3"]
+        assert result["curation_mode"] == "auto"
+    finally:
+        _teardown(cache)
+
+
+@pytest.mark.asyncio
+async def test_per_page_only_returned_as_is() -> None:
+    """When only the persistence row exists the result is the
+    persistence dict unchanged (no render-only overlay possible)."""
+    cache = _make_cache_with_stores(per_page=_persistence_row(), cache_blob=None)
+    try:
+        result = await cache.get_page("C1", "topic-test", target_lang="en")
+        assert result is not None
+        assert result["page_id"] == "topic-test"
+        assert result["kind"] == "topic"
+        assert "content" not in result  # nothing to overlay
+    finally:
+        _teardown(cache)
+
+
+@pytest.mark.asyncio
+async def test_cache_only_returned_as_is() -> None:
+    """When only the legacy cache blob exists (no seed yet, or
+    PER_PAGE_WIKI off) the result is the cache dict unchanged. This is
+    the pre-fix shape that channels prior to the seed deployment rely
+    on for backward compat."""
+    cache = _make_cache_with_stores(per_page=None, cache_blob=_cache_row())
+    try:
+        result = await cache.get_page("C1", "topic-test", target_lang="en")
+        assert result is not None
+        assert result["page_id"] == "topic-test"
+        assert result["content"].startswith("## Section")
+    finally:
+        _teardown(cache)
+
+
+@pytest.mark.asyncio
+async def test_neither_store_returns_none() -> None:
+    """Missing in both → None (the 404 path)."""
+    cache = _make_cache_with_stores(per_page=None, cache_blob=None)
+    try:
+        result = await cache.get_page("C1", "topic-test", target_lang="en")
+        assert result is None
+    finally:
+        _teardown(cache)
+
+
+@pytest.mark.asyncio
+async def test_per_page_wiki_disabled_uses_cache_only() -> None:
+    """``per_page_wiki=False`` short-circuits the persistence lookup so
+    the legacy behavior (cache-only) is fully preserved for operators
+    who roll back the flag."""
+    cache = _make_cache_with_stores(
+        per_page=_persistence_row(),
+        cache_blob=_cache_row(),
+        per_page_wiki=False,
+    )
+    try:
+        result = await cache.get_page("C1", "topic-test", target_lang="en")
+        assert result is not None
+        # Only the cache blob shape — no persistence keys layered in.
+        assert "kind" not in result or result.get("kind") != "topic"
+        assert result["content"].startswith("## Section")
+    finally:
+        _teardown(cache)

--- a/web/src/hooks/useRecentLLMCalls.ts
+++ b/web/src/hooks/useRecentLLMCalls.ts
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { api } from "@/lib/api";
+import { api, ApiError } from "@/lib/api";
 
 /**
  * PR-λ.2: small hook for the Settings → Agent models tab to show
@@ -8,7 +8,15 @@ import { api } from "@/lib/api";
  * Polls ``GET /api/settings/debug/recent-llm-calls`` every 15s while the
  * Agent Models tab is mounted. The ring buffer is process-local (50
  * entries) so this is a tiny request — no DB roundtrip, no payload bloat.
+ *
+ * Stale-tab guard: a tab opened against a previous build that has no
+ * ``VITE_BEEVER_API_KEY`` baked in will hit ``401`` on every poll and
+ * spam the backend log forever. After ``MAX_AUTH_FAILS`` consecutive
+ * ``401``/``403`` responses the hook stops polling entirely until the
+ * tab reloads. Non-auth failures (network blip, 5xx) keep the normal
+ * cadence so transient issues self-heal.
  */
+const MAX_AUTH_FAILS = 2;
 
 export interface RecentLLMCall {
   ts: string;
@@ -42,9 +50,11 @@ export function useRecentLLMCalls(pollMs: number = 15_000): UseRecentLLMCallsRes
   const [calls, setCalls] = useState<RecentLLMCall[]>([]);
   const cancelledRef = useRef(false);
   const timerRef = useRef<number | undefined>(undefined);
+  const authFailsRef = useRef(0);
 
   useEffect(() => {
     cancelledRef.current = false;
+    authFailsRef.current = 0;
     async function poll() {
       if (cancelledRef.current) return;
       try {
@@ -52,8 +62,20 @@ export function useRecentLLMCalls(pollMs: number = 15_000): UseRecentLLMCallsRes
           "/api/settings/debug/recent-llm-calls",
         );
         if (!cancelledRef.current) setCalls(resp.calls ?? []);
-      } catch {
+        authFailsRef.current = 0;
+      } catch (err) {
         // Endpoint may be temporarily unavailable; keep last-known state.
+        // Persistent 401/403 means the bundle's baked-in key no longer
+        // matches the server's ``BEEVER_API_KEYS`` (typical after an env
+        // rotation + web rebuild — every stale tab spams 401 forever).
+        // Stop polling after a couple of failures so a forgotten tab
+        // doesn't pollute server logs; a hard reload resets the counter.
+        if (err instanceof ApiError && (err.status === 401 || err.status === 403)) {
+          authFailsRef.current += 1;
+          if (authFailsRef.current >= MAX_AUTH_FAILS) {
+            return;
+          }
+        }
       }
       if (!cancelledRef.current) {
         timerRef.current = window.setTimeout(poll, pollMs);


### PR DESCRIPTION
## Summary

Six related fixes plus supporting cleanup, all surfaced while debugging a stuck-on-404 wiki cascade on a fresh sync. End-to-end the user sees: trigger a sync → wiki actually materializes on the first try.

## What was broken

| Symptom | Root cause |
|---|---|
| Wiki returns 404 indefinitely after sync | `_channels_pending_summary` race — gate flipped inside a spawned task, `memory_settled` subscribers ran first, `summarize_settled_for_channel` silently early-returned, `channel_summary` never written. |
| Topic page loads, hard-crashes with `TypeError: undefined.replace()` | After fix #2 below, per-page endpoint returned `persistence.WikiPage` (no `content` field). Frontend's `TopicPage.tsx:57` did `page.content.replace(...)`. |
| Maintainer logs `Builder hasn't run yet — first-sync gate` forever | Chicken-and-egg deadlock. Builder wrote to `wiki_cache` only; maintainer reads `wiki_pages`. Nothing wrote to `wiki_pages` until the maintainer rewrote a page, but the gate blocked the maintainer until pages existed. |
| `truncation_report` log fires on `recovered_facts=11` | Misleading single-state log — fired any time output was a string, regardless of whether the LLM was truncated, empty, or unstructured-but-complete. |
| Personal/casual channels produce zero facts | Fact-extractor prompt's 6-month test rejected anything not "team work". |
| `/api/auth/loader-token` 503s on every image load | `LOADER_TOKEN_SECRET` empty in dev installs; `atlas` installer didn't auto-generate it. |
| 401 spam on `/api/settings/debug/recent-llm-calls` from stale browser tabs | Hook kept polling every 15s after auth started failing. |

## What's fixed

**Pipeline / orchestration**
- ` services/pipeline_orchestrator.py` — `consolidate_only` adds to `_channels_pending_summary` synchronously before spawning the consolidation task.
- `services/auto_overview_subscriber.py` — bounded retry on `WikiNotReadyError` (3× 30s) wrapped in a single outer `wait_for` so the 600s timeout covers all attempts.

**Wiki cascade**
- `wiki/builder.py` — seeds `wiki_pages` from compiled domain pages after `save_wiki`. Per-page errors isolated.
- `wiki/cache.py` — `get_page` now merges persistence row + legacy cache blob. Render-only keys enumerated explicitly so a future write to the blob can't shadow persistence metadata.
- `services/wiki_maintainer.py` — `_derive_kind_from_page_id` → `derive_kind_from_page_id` (drop the underscore now that the builder imports it across module boundary).

**Extraction quality + observability**
- `agents/callbacks/quality_gates.py` — three-state logging: `truncation_report` / `extractor_empty_output` / `extractor_unstructured_complete`. Sync metric `entity_truncation_recoveries` only counts real truncations now.
- `agents/prompts/fact_extractor.py` — softened the work-centric framing in the relevance principle; two non-work calibration examples added; an "Output integrity" tail clamp to reduce mid-element truncation.

**Operator polish**
- `atlas` installer auto-generates `LOADER_TOKEN_SECRET` like the other secrets.
- `.env.example` clarifies the loader-token tradeoff.
- `web/src/hooks/useRecentLLMCalls.ts` stops polling after 2× 401/403 so stale tabs stop spamming the backend log.

## Tests

Three new regression files (~9 tests) lock in the most important behaviors:
- `tests/wiki/test_cache_get_page_merge.py` — overlay direction, persistence-metadata preservation, fall-back paths, `per_page_wiki=False` short-circuit.
- `tests/services/test_auto_overview_subscriber.py` (appended) — retry success, retries exhausted, non-WikiNotReady not retried, total budget bounded.
- `tests/test_wiki_builder_target_lang.py` (appended) — seed-per-page assertion, per-page error isolation.

Total touched suites: **66 tests pass locally** (`tests/services/test_auto_overview_subscriber.py tests/wiki/test_cache_get_page_merge.py tests/test_wiki_builder_target_lang.py tests/agents/callbacks/test_quality_gates.py tests/test_pipeline_orchestrator.py tests/test_pipeline_orchestrator_race.py tests/integration/test_auto_overview_e2e.py`).

## Test plan

- [x] Run all touched unit + integration tests locally (66 green)
- [x] Run code-reviewer agent on the diff; address blocking finding (the `wait_for` retry-budget escape)
- [x] Manually exercise the full cascade on a fresh Docker stack:
  - [x] Wipe MongoDB / Neo4j / Weaviate volumes and rebuild
  - [x] Re-add Discord connection
  - [x] Sync a channel — wiki materializes on the first try (no 404, no `Builder hasn't run yet` log on a clean second sync)
  - [x] Verify per-page endpoint returns `content` (2121 chars) + `modules` (6) for a topic page
  - [x] Verify `/api/auth/loader-token` mints (no 503 → raw-key fallback path)
  - [x] Hard-reload the frontend; no 401 spam on `recent-llm-calls`
  - [x] Personal-channel sync produces facts (was 0 before the prompt change)
- [ ] CI: full backend suite, web tests, lint, type-check

## Reviewer notes

The cache get_page merge enumerates render-only keys in `_RENDER_ONLY_KEYS`. If you add a new render-only field to the cache blob (e.g. `cross_links` if that ever moves from the maintainer row), add it to that tuple too or the persistence row will shadow it.

The fact-extractor prompt change loosens the relevance bar globally. If a specific deployment needs to re-tighten it (e.g. enterprise team-only channels), do it via the per-channel policy resolver, not by re-narrowing the global prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)