### PR TITLE
feat(graph): memory graph overhaul — typed entities, classifier, co-mentions, UI

### DIFF
--- a/runbooks/channel-reset.md
+++ b/runbooks/channel-reset.md
@@ -1,0 +1,78 @@
+# Channel Reset — drop and re-sync to refresh the graph
+
+Use this when a channel's graph memory shipped under the pre-fix code path
+(Topic-stub monoculture, missing types) and you want a clean baseline after
+the Unresolved heal-path + 4 new entity types went in.
+
+Existing entities/relationships in Neo4j are *not* auto-migrated. The
+heal-path only kicks in for *new* writes — re-sync triggers fresh
+extraction and the new pipeline produces a properly typed graph.
+
+## Prerequisites
+
+- API running locally on `http://localhost:8000`
+- `BEEVER_ADMIN_TOKEN` or `BEEVER_API_KEYS` exported as `$T`
+- `cypher-shell` available with credentials to your Neo4j instance
+- Replace `$CH` and `$CH_NAME` below with the target channel id / display
+  name.
+
+## Steps
+
+```bash
+# 0. Identify the channel.
+export T=0e59c822ee9756a4d7a9adeba51d7001d2447bb7151ffa1c
+export CH=agypsmc1qfynzexdc4ec8wuske          # biz-consumer-council
+
+# 1. Drop channel-scoped entities + relationships in Neo4j.
+#    Global Persons / Technologies remain — they are workspace-wide and
+#    will be re-bound to this channel on the next sync.
+cypher-shell -u neo4j -p "$NEO4J_PASSWORD" "
+  MATCH (e:Entity)-[:MENTIONED_IN]->(:Event {channel_id:'$CH'})
+    DETACH DELETE e;
+  MATCH (ev:Event {channel_id:'$CH'}) DETACH DELETE ev;
+"
+
+# 2. Mark the channel's facts for re-embed (or wipe them via the admin
+#    endpoint). The admin route resets stored facts so the next sync
+#    re-extracts them from the source messages.
+curl -X POST -H "Authorization: Bearer $T" \
+  "http://localhost:8000/api/admin/sources/$CH/reset"
+
+# 3. Force a fresh sync.
+curl -X POST -H "Authorization: Bearer $T" \
+  "http://localhost:8000/api/channels/$CH/sync?force=true"
+
+# 4. Wait 5-8 min for a 417-message channel, then verify.
+curl -s -H "Authorization: Bearer $T" \
+  "http://localhost:8000/api/graph/entities?channel_id=$CH&limit=500" \
+  | jq '[.[] | .type] | group_by(.) | map({t: .[0], n: length})'
+```
+
+## Acceptance targets (post-resync)
+
+| Metric | Pre-fix | Post-resync target |
+|---|---|---|
+| Visible nodes in Memory Graph | ~40 (capped) | ≥ 100 |
+| `Topic` entity share | ≈ 99% | ≤ 5% (only LLM-emitted Topic, no stubs) |
+| `Unresolved` entities | 0 | ≤ 10 (transient — heal as more writes land) |
+| Sum of typed entities (Person + Technology + Project + Team + Decision + Meeting + Artifact + Organization + Concept + Location + Event) | ~0 | ≥ 100 |
+| `wiki/graph` `references_entity` edges | 0 | ≥ 50 |
+| "Unconnected" pill in UI | 36 | ≤ 5 |
+
+## Rollback
+
+If something looks wrong, the heal path is fully forward-compatible —
+old `Topic` stubs are not deleted by the new code, only avoided.
+Reverting the application code restores the old behavior without any
+schema-level rollback.
+
+## Notes
+
+- The 4 new entity types (`Organization`, `Concept`, `Location`, `Event`)
+  are additive — existing `Person` / `Technology` / `Project` / `Team` /
+  `Decision` / `Meeting` / `Artifact` remain unchanged.
+- `Unresolved`-typed entities are *backend-only* — the LLM is never
+  instructed to emit `Unresolved`; the persister/store uses it as a
+  transitional state until a typed write heals it in place.
+- Stub orphans (`Unresolved` with no edges, older than 24h) are pruned
+  on the existing `orphan_reconciler` schedule.

--- a/src/beever_atlas/agents/ingestion/persister.py
+++ b/src/beever_atlas/agents/ingestion/persister.py
@@ -363,7 +363,11 @@ class PersisterAgent(BaseAgent):
                         summarize_normalizations,
                     )
 
-                    relationships, _norm_log = normalize_relationships(
+                    # Use a fresh name for the normalized list so the
+                    # closure capture of the outer ``relationships`` (set
+                    # at line 313 of the enclosing function) isn't shadowed
+                    # by a function-local assignment — F823 from ruff.
+                    normalized_rels, _norm_log = normalize_relationships(
                         relationships, sync_job_id=sync_job_id
                     )
                     if _norm_log and channel_id and sync_job_id:
@@ -396,7 +400,7 @@ class PersisterAgent(BaseAgent):
                                 sync_job_id,
                             )
                     _rel_eids = await stores.graph.batch_upsert_relationships(
-                        relationships,
+                        normalized_rels,
                         channel_id=channel_id,
                         sync_job_id=sync_job_id,
                         batch_idx=batch_num,
@@ -407,7 +411,7 @@ class PersisterAgent(BaseAgent):
                         sync_job_id,
                         channel_id,
                         batch_num,
-                        len(relationships),
+                        len(normalized_rels),
                     )
                     if _dropped and channel_id and sync_job_id:
                         from beever_atlas.services.batch_processor import increment_sync_metric

--- a/src/beever_atlas/agents/ingestion/persister.py
+++ b/src/beever_atlas/agents/ingestion/persister.py
@@ -352,6 +352,49 @@ class PersisterAgent(BaseAgent):
                         len(entities),
                     )
                 if relationships:
+                    # Verb normalization (PR-B): collapse the long tail of
+                    # LLM-emitted verbs into a small canonical set BEFORE
+                    # writing to Neo4j. Mutates rel.type in place; source/
+                    # target/direction untouched. Audit ledger is rolled
+                    # into sync_summary.normalizations[] for replay-based
+                    # recovery (per v2 plan §B.5 — no per-edge field).
+                    from beever_atlas.agents.ingestion.verb_normalizer import (
+                        normalize_relationships,
+                        summarize_normalizations,
+                    )
+
+                    relationships, _norm_log = normalize_relationships(
+                        relationships, sync_job_id=sync_job_id
+                    )
+                    if _norm_log and channel_id and sync_job_id:
+                        from beever_atlas.services.batch_processor import (
+                            increment_sync_metric,
+                        )
+
+                        increment_sync_metric(
+                            channel_id,
+                            sync_job_id,
+                            "relationships_normalized_total",
+                            sum(1 for _ in _norm_log),
+                        )
+                        # Persist per-rule ledger rows so an operator can
+                        # replay the mapping later. Stored as a structured
+                        # log line keyed by sync_job_id; sync_summary
+                        # roll-up reads these via the sync_summary
+                        # collector.
+                        summary_rows = summarize_normalizations(_norm_log)
+                        for row in summary_rows:
+                            logger.info(
+                                "sync_summary: metric=verb_normalization "
+                                "original=%s canonical=%s rule=%s count=%s "
+                                "channel_id=%s sync_job_id=%s",
+                                row["original_verb"],
+                                row["canonical"],
+                                row["rule"],
+                                row["count"],
+                                channel_id,
+                                sync_job_id,
+                            )
                     _rel_eids = await stores.graph.batch_upsert_relationships(
                         relationships,
                         channel_id=channel_id,
@@ -448,17 +491,52 @@ class PersisterAgent(BaseAgent):
 
         # --- 4. Reconcile entity_tags: create stub entities for missing names ---
         # Only create stubs for names that appear in relationships to avoid orphan nodes.
+        # Heal-path tightening:
+        #   * Confidence gate — only relationships with confidence ≥ 0.8 seed
+        #     stubs. Lower-confidence rels are too speculative to manufacture
+        #     entities from.
+        #   * 2-unknown drop — when BOTH endpoints of a rel are absent from
+        #     the typed-entity set, the rel cannot be healed and should not
+        #     have been written. We increment ``relationships_dropped_total``
+        #     with reason ``both_endpoints_unknown`` so observability picks
+        #     it up. The rel has already been committed by the earlier
+        #     ``batch_upsert_relationships`` call; the gate here prevents
+        #     us from also manufacturing the two stub Entity rows that
+        #     would otherwise connect.
         if not skip_graph:
+            extracted_names: set[str] = {e.name for e in entities}
+            high_conf_rels = [r for r in relationships if r.confidence >= 0.8]
             rel_names: set[str] = set()
-            for rel in relationships:
+            both_unknown_count = 0
+            for rel in high_conf_rels:
+                src_known = rel.source in extracted_names
+                tgt_known = rel.target in extracted_names
+                if not src_known and not tgt_known:
+                    both_unknown_count += 1
+                    continue
                 rel_names.add(rel.source)
                 rel_names.add(rel.target)
+            if both_unknown_count and channel_id and sync_job_id:
+                from beever_atlas.services.batch_processor import increment_sync_metric
+
+                increment_sync_metric(
+                    channel_id,
+                    sync_job_id,
+                    "relationships_dropped_total",
+                    both_unknown_count,
+                )
+                logger.info(
+                    "PersisterAgent: dropped %d relationships reason=both_endpoints_unknown job_id=%s channel=%s batch=%s",
+                    both_unknown_count,
+                    sync_job_id,
+                    channel_id,
+                    batch_num,
+                )
             all_tag_names: set[str] = set()
             for f in facts:
                 all_tag_names.update(f.entity_tags)
             # Intersect with relationship names — stubs without relationships are orphans
             all_tag_names &= rel_names
-            extracted_names: set[str] = {e.name for e in entities}
             missing_names = all_tag_names - extracted_names
             if missing_names:
                 try:
@@ -470,20 +548,24 @@ class PersisterAgent(BaseAgent):
                     logger.warning(
                         "PersisterAgent: batch_find_entities_by_name failed", exc_info=True
                     )
-                # Create stub entities for truly missing names.
-                # ``type='Topic'`` aligns with the in-Cypher MERGE default
-                # in upsert_relationship + batch_create_episodic_links
-                # (PR-2). ``Topic`` is generic; ``Project`` is
-                # domain-specific and the persister cannot infer the
-                # actual domain from a bare relationship endpoint.
+                # Create stub entities for truly missing names. They are
+                # tagged ``type='Unresolved'`` (backend-only synthetic
+                # type, never emitted by the LLM) plus ``awaiting_type``
+                # so a later typed ``upsert_entity`` for the same name
+                # heals the row in place via the heal-path in
+                # ``Neo4jStore.upsert_entity``.
                 stubs: list[GraphEntity] = []
                 for name in missing_names:
                     stubs.append(
                         GraphEntity(
                             name=name,
-                            type="Topic",
+                            type="Unresolved",
                             scope="global",
-                            properties={"stub": True},
+                            properties={
+                                "stub": True,
+                                "reason": "rel_endpoint",
+                                "awaiting_type": True,
+                            },
                             source_message_id=facts[0].source_message_id if facts else "",
                             message_ts=facts[0].message_ts if facts else "",
                         )

--- a/src/beever_atlas/agents/ingestion/verb_normalizer.py
+++ b/src/beever_atlas/agents/ingestion/verb_normalizer.py
@@ -1,0 +1,294 @@
+"""Verb normalization for graph relationships.
+
+Maps the long tail of LLM-emitted SCREAMING_SNAKE_CASE verbs to a small
+canonical set BEFORE the relationship is written to Neo4j. The mutation
+happens inside ``persister._upsert_graph`` so the forward write path
+sees the clean verb shape and downstream consumers (graph API, wiki
+linker, cytoscape edge labels, MCP tools) need no read-time fixes.
+
+Design highlights (v2 plan §B):
+- ``REFERENCES_MEDIA`` flows through a separate batch_upsert_media path
+  and never reaches the normalizer — but we keep the identity guard
+  defensively.
+- Direction is NEVER flipped. Both ``BLOCKS`` and ``BLOCKED_BY`` are
+  canonical; ditto ``OWNS`` and ``OWNED_BY``. The plan's v1 inversion
+  was withdrawn.
+- Per-edge ``original_verb`` and ``normalization_rule`` properties are
+  NOT persisted (would require model + Cypher + projection changes).
+  Instead a structured logger emits one line per normalization, and
+  the persister surfaces a ``NormalizationLog`` ledger that BatchProcessor
+  rolls into ``sync_summary.normalizations[]`` for replay-based recovery.
+- Bucket regex is ordered first-match-wins. DISCUSSES checked before
+  ACTS_ON; MENTIONS is the fallback catch-all.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from collections import Counter
+from dataclasses import dataclass
+
+from beever_atlas.models import GraphRelationship
+
+logger = logging.getLogger(__name__)
+
+
+# ----------------------------------------------------------------------
+# Canonical verb set
+# ----------------------------------------------------------------------
+
+# 12 from entity_extractor.py:103-104 + 6 communication verbs (per v2 §B.3.1)
+# + BLOCKS + OWNED_BY (promoted to canonical per B-5 critique)
+# + ADVISES_AGAINST (new polarity-aware canonical per B.10 fold)
+# = 21 canonical verbs.
+CANONICAL_VERBS: frozenset[str] = frozenset(
+    {
+        # Action / decision (entity_extractor preferred types)
+        "DECIDED",
+        "WORKS_ON",
+        "USES",
+        "OWNS",
+        "OWNED_BY",  # promoted (B-5 fix)
+        "BLOCKED_BY",
+        "BLOCKS",  # promoted (B-5 fix)
+        "DEPENDS_ON",
+        "CREATED",
+        "REVIEWED",
+        "DEPLOYED",
+        "PARTICIPATES_IN",
+        "RESPONSIBLE_FOR",
+        "PART_OF",
+        # Communication verbs (user-specified)
+        "MENTIONS",
+        "DISCUSSES",
+        "ASKS",
+        "SUGGESTS",
+        "SHARES",
+        # Polarity-aware
+        "ADVISES_AGAINST",
+        # System-emitted (defensive only — never normalized)
+        "REFERENCES_MEDIA",
+        # Bucket terminal (catch-all targets)
+        "ACTS_ON",
+    }
+)
+
+
+# ----------------------------------------------------------------------
+# Literal seed mappings — explicit verb → canonical verb
+# Direction is PRESERVED for every mapping (B-5 invariant; tested).
+# ----------------------------------------------------------------------
+
+VERB_NORMALIZATION: dict[str, str] = {
+    # USES family
+    "INTENDS_TO_USE": "USES",
+    "PLANS_TO_USE": "USES",
+    "SUGGESTS_TO_USE": "USES",
+    "MIGRATING_TO": "USES",
+    "ADOPTED": "USES",
+    # ADVISES_AGAINST (polarity-flipped suggestions)
+    "SUGGESTS_NOT_DISCLOSING": "ADVISES_AGAINST",
+    "ADVISES_NOT_TO": "ADVISES_AGAINST",
+    "RECOMMENDS_AGAINST": "ADVISES_AGAINST",
+    # PARTICIPATES_IN family
+    "PLANS_TO_NEGOTIATE_WITH": "PARTICIPATES_IN",
+    "SUGGESTS_TO_SCHEDULE_MEETING_WITH": "PARTICIPATES_IN",
+    "MET_WITH": "PARTICIPATES_IN",
+    "ATTENDED": "PARTICIPATES_IN",
+    # ASKS family
+    "ASKS_PERMISSION_TO_SHARE_WITH": "ASKS",
+    "QUESTIONS": "ASKS",
+    "INQUIRES": "ASKS",
+    # Direction-preserving responsibility
+    "ASSIGNED_TO": "RESPONSIBLE_FOR",  # A assigned to B → A responsible for B
+    "ACCOUNTABLE_FOR": "RESPONSIBLE_FOR",
+    # DEPENDS_ON family
+    "DEPENDS_UPON": "DEPENDS_ON",
+    "RELIES_ON": "DEPENDS_ON",
+    "REQUIRES": "DEPENDS_ON",
+    # PART_OF family
+    "MEMBER_OF": "PART_OF",
+    "BELONGS_TO": "PART_OF",
+    "CONTAINED_IN": "PART_OF",
+    # CREATED family
+    "BUILT": "CREATED",
+    "AUTHORED": "CREATED",
+    "WROTE": "CREATED",
+    "DESIGNED": "CREATED",
+    # DEPLOYED family
+    "SHIPPED": "DEPLOYED",
+    "RELEASED": "DEPLOYED",
+    "LAUNCHED": "DEPLOYED",
+    "ROLLED_OUT": "DEPLOYED",
+    # REVIEWED family
+    "REVIEWS": "REVIEWED",
+    "APPROVED": "REVIEWED",
+    "REJECTED": "REVIEWED",  # see B.10.2 — fold for v2, promote later
+    "FEEDBACK_ON": "REVIEWED",
+    # MENTIONS / DISCUSSES / SHARES / SUGGESTS communication family
+    "REFERENCES": "MENTIONS",
+    "TALKED_ABOUT": "DISCUSSES",
+    "BROUGHT_UP": "DISCUSSES",
+    "RAISED": "DISCUSSES",
+    "SHARED_WITH": "SHARES",
+    "POSTED": "SHARES",
+    "RECOMMENDED": "SUGGESTS",
+    "PROPOSED": "SUGGESTS",
+}
+
+
+# ----------------------------------------------------------------------
+# Bucket regex — ordered first-match-wins (B-6 fix)
+# DISCUSSES checked BEFORE ACTS_ON so ``PLANS_TO_DISCUSS_X`` lands in
+# DISCUSSES, not in ACTS_ON's intent bucket. MENTIONS is the catch-all.
+# ----------------------------------------------------------------------
+
+BUCKET_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    # DISCUSSES (talked-about family) — most specific first.  Matches
+    # the verb root ``DISCUSS`` (covers ``DISCUSS``, ``DISCUSSES``,
+    # ``DISCUSSED``, ``PLANS_TO_DISCUSS_X``) as well as the other
+    # explicit communication families.
+    (
+        re.compile(
+            r"(?:^|_)(?:DISCUSS|TALKS_ABOUT|TALKED_ABOUT|RAISED_TOPIC|"
+            r"BRINGS_UP|MENTIONS_TOPIC|REPLIES)"
+        ),
+        "DISCUSSES",
+    ),
+    # ACTS_ON — intent/plan verbs that aren't a canonical action,
+    # plus generic update / modify / move / *_BY|TO|WITH|FROM compounds.
+    # Anchored at the front; trailing form is unrestricted so
+    # ``WILL_REVIEW_PROPOSAL`` lands here just as ``WILL_REVIEW`` does.
+    (
+        re.compile(
+            r"^(?:PLANS_TO_|INTENDS_TO_|WILL_|WANTS_TO_|HOPES_TO_|"
+            r"UPDATES_?|UPDATE_?|MODIFIES_?|MODIFY_?|"
+            r"CREATES_?|CREATE_?|DELETES_?|DELETE_?|MOVES_?|MOVE_?)"
+            r"|"
+            r"^[A-Z]+_(?:BY|TO|WITH|FROM)$"
+        ),
+        "ACTS_ON",
+    ),
+    # MENTIONS — fallback catch-all (matches anything)
+    (re.compile(r".*"), "MENTIONS"),
+]
+
+
+# ----------------------------------------------------------------------
+# Public API
+# ----------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class NormalizationLog:
+    """One row per (raw_verb, canonical_verb, rule) per write.
+
+    The persister rolls up duplicate rows into ``sync_summary.normalizations[]``
+    entries keyed by ``(sync_job_id, raw, canonical, rule)`` with a count
+    field. The ledger is the recovery path: an operator who needs to
+    reverse a bad mapping replays from the sync_summary record.
+    """
+
+    raw_verb: str
+    canonical_verb: str
+    rule: str  # "identity" | "literal:<raw>" | "regex:<bucket>" | "fallback:MENTIONS"
+
+
+def normalize_verb(raw: str) -> tuple[str, str]:
+    """Return ``(canonical_verb, rule_string)`` for a raw verb.
+
+    Resolution order:
+      1. ``raw`` already canonical → identity.
+      2. ``raw == "REFERENCES_MEDIA"`` → identity (defensive; the path
+         that emits this never enters the normalizer, but the guard
+         protects against future refactors).
+      3. ``raw`` in literal table → ``literal:<raw>``.
+      4. First bucket-regex match → ``regex:<bucket>`` (MENTIONS pattern
+         is the catch-all, so we always return).
+    """
+    if not raw:
+        return ("MENTIONS", "fallback:MENTIONS")
+    if raw in CANONICAL_VERBS:
+        return (raw, "identity")
+    if raw == "REFERENCES_MEDIA":
+        return (raw, "identity")
+    if raw in VERB_NORMALIZATION:
+        return (VERB_NORMALIZATION[raw], f"literal:{raw}")
+    for pattern, bucket in BUCKET_PATTERNS:
+        if pattern.search(raw):
+            if bucket == "MENTIONS":
+                # Catch-all hit; mark as fallback so the audit ledger can
+                # distinguish "regex bucket landing" from "fell off the
+                # end of the list".
+                return (bucket, "fallback:MENTIONS")
+            return (bucket, f"regex:{bucket}")
+    # Unreachable — the final regex catches anything — but keep an
+    # explicit return for defensive completeness.
+    return ("MENTIONS", "fallback:MENTIONS")
+
+
+def normalize_relationships(
+    rels: list[GraphRelationship],
+    *,
+    sync_job_id: str = "",
+) -> tuple[list[GraphRelationship], list[NormalizationLog]]:
+    """Mutate ``rel.type`` in place to canonical form and return the
+    audit ledger.
+
+    The relationships list is returned as-is (same objects) so the
+    persister can pass it straight to ``batch_upsert_relationships``.
+    Only ``type`` is mutated; source/target/direction is preserved by
+    construction (B-5 invariant).
+    """
+    log: list[NormalizationLog] = []
+    counter: Counter[tuple[str, str, str]] = Counter()
+    for rel in rels:
+        raw = rel.type or ""
+        canonical, rule = normalize_verb(raw)
+        if canonical != raw:
+            # Mutate in place — caller already owns the model objects.
+            rel.type = canonical
+            counter[(raw, canonical, rule)] += 1
+            # Structured logger fires at write time (independent of the
+            # sync_summary roll-up).  Keyword args go via ``extra=`` so
+            # log aggregators can index them.
+            logger.info(
+                "verb_normalized",
+                extra={
+                    "original": raw,
+                    "canonical": canonical,
+                    "rule": rule,
+                    "sync_job_id": sync_job_id,
+                    "source": rel.source,
+                    "target": rel.target,
+                },
+            )
+    log.extend(
+        NormalizationLog(raw_verb=raw, canonical_verb=canon, rule=rule)
+        for (raw, canon, rule), _ in counter.items()
+    )
+    # Attach counts as a side return so the persister can include them
+    # in the sync_summary ledger.
+    return rels, log
+
+
+def summarize_normalizations(rels_logs: list[NormalizationLog]) -> list[dict[str, str | int]]:
+    """Collapse a list of ``NormalizationLog`` rows (across an entire
+    sync) into a ``sync_summary.normalizations[]`` entry shape.
+
+    Returns one dict per ``(original_verb, canonical, rule)`` tuple with
+    a ``count`` of how many edges were affected.
+    """
+    counter: Counter[tuple[str, str, str]] = Counter()
+    for row in rels_logs:
+        counter[(row.raw_verb, row.canonical_verb, row.rule)] += 1
+    return [
+        {
+            "original_verb": raw,
+            "canonical": canon,
+            "rule": rule,
+            "count": count,
+        }
+        for (raw, canon, rule), count in counter.items()
+    ]

--- a/src/beever_atlas/agents/prompts/entity_extractor.py
+++ b/src/beever_atlas/agents/prompts/entity_extractor.py
@@ -41,20 +41,24 @@ Messages (preprocessed, JSON array):
 
 ### Entity types
 
-| Type       | Scope   | When to use |
-|------------|---------|-------------|
-| Person     | global  | Named humans who act, decide, or are referenced substantively |
-| Technology | global  | Specific named tools, frameworks, libraries, services, languages |
-| Project    | global  | Named initiatives, products, features, or repositories |
-| Team       | global  | Named organisational units, squads, or guilds |
-| Decision   | channel | Explicit choices or conclusions reached — not mere discussion |
-| Meeting    | channel | Named or time-anchored meetings referenced in this channel |
-| Artifact   | channel | Specific named docs, PRs, tickets, specs (e.g. "PR #42", not "a PR") |
+| Type         | Scope   | When to use |
+|--------------|---------|-------------|
+| Person       | global  | Named humans who act, decide, or are referenced substantively |
+| Technology   | global  | Specific named tools, frameworks, libraries, services, languages |
+| Project      | global  | Named initiatives, products, features, or repositories |
+| Team         | global  | Named organisational units, squads, or guilds |
+| Decision     | channel | Explicit choices or conclusions reached — not mere discussion |
+| Meeting      | channel | Named or time-anchored meetings referenced in this channel |
+| Artifact     | channel | Specific named docs, PRs, tickets, specs (e.g. "PR #42", not "a PR") |
+| Organization | global  | Companies, regulators, vendors. Example: "AlibabaCloud" (vendor), "Consumer Council" (regulator). |
+| Concept      | global  | Abstract domain ideas. Example: "PIA", "DPO", "data residency", "response-time SLA". |
+| Location     | global  | Geographic/jurisdictional boundaries. Example: "Hong Kong", "Mainland China". |
+| Event        | channel | One-off events distinct from recurring Meetings. Example: tender deadline, product launch, go-live date. |
 
 **Scope**: `global` entities are meaningful workspace-wide. `channel` entities are
 only meaningful within {channel_name}.
 
-**Extending types**: These 7 types cover most workplace knowledge. If you encounter
+**Extending types**: These 11 types cover most workplace knowledge. If you encounter
 a concept that genuinely doesn't fit (e.g., a recurring Workflow, a tracked Metric,
 a team Ritual, or a domain Concept), you may create a new type. Rules for new types:
 - Use PascalCase (e.g., "Workflow", not "workflow" or "WORKFLOW")

--- a/src/beever_atlas/agents/prompts/unresolved_classifier.py
+++ b/src/beever_atlas/agents/prompts/unresolved_classifier.py
@@ -1,0 +1,56 @@
+"""Prompt for the unresolved-entity classifier (PR-A).
+
+Second-pass classifier — runs AFTER ExtractionWorker drains a channel.
+Given a stub entity name and ≤3 fact contexts harvested from its
+incident relationships, the classifier returns the most likely
+canonical entity type plus a confidence score.
+
+The prompt is intentionally minimal: the contexts already encode the
+disambiguating signal; the classifier should not invent a type that
+the contexts do not support.
+"""
+
+from __future__ import annotations
+
+UNRESOLVED_CLASSIFIER_INSTRUCTION: str = """\
+You are an entity-type classifier for a workspace knowledge graph.
+For each candidate name, decide the single most likely entity type
+based on its incident-edge contexts.
+
+Allowed types (prefer these):
+- Person       — named humans who act, decide, or are referenced substantively
+- Technology   — specific named tools, frameworks, libraries, services, languages
+- Project      — named initiatives, products, features, or repositories
+- Team         — named organisational units, squads, or guilds
+- Decision     — explicit choices or conclusions reached (not mere discussion)
+- Meeting      — named or time-anchored meetings
+- Artifact     — specific named docs, PRs, tickets, specs (e.g. "PR #42")
+- Organization — companies, regulators, vendors
+- Concept      — abstract domain ideas (e.g. "PIA", "data residency")
+- Location     — geographic/jurisdictional boundaries
+- Event        — one-off events distinct from recurring Meetings
+
+You may invent a new PascalCase type ONLY if the candidate genuinely
+fits none of the above AND your confidence is ≥ 0.8. Otherwise use
+the closest allowed type and lower your confidence.
+
+Channel types observed already (prefer these over inventing new ones
+when applicable):
+{channel_observed_types}
+
+For each candidate emit exactly one classification object. Confidence:
+- 1.0 = stated outright in the contexts ("X is the Q4 owner")
+- 0.8 = strongly implied ("X reviewed the proposal" → Person)
+- 0.5 = plausible inference from a single context
+- ≤ 0.4 = thin signal — use this when contexts are noisy or generic
+
+Output schema:
+{{
+  "classifications": [
+    {{"name": "<exact candidate name>", "type": "<PascalCase>", "confidence": 0.0-1.0}}
+  ]
+}}
+
+Candidates:
+{candidates_json}
+"""

--- a/src/beever_atlas/api/admin.py
+++ b/src/beever_atlas/api/admin.py
@@ -650,6 +650,9 @@ async def reset_channel_data(
         results["media_deleted"] = int(graph_counts.get("media_deleted", 0) or 0)
         results["entities_deleted"] = int(graph_counts.get("entities_deleted", 0) or 0)
     except Exception as exc:  # noqa: BLE001
+        # Surface only the operation name to the caller — the raw
+        # exception string can leak stack-trace fragments / internal
+        # details. Full exception is logged server-side at WARN.
         errors.append("delete_channel_data failed")
         log.warning(
             "reset_channel_data: delete_channel_data failed channel=%s: %s",
@@ -746,9 +749,7 @@ async def reset_channel_data(
 
                 # First preference: connections that explicitly opted-in this channel
                 # (selected_channels). Authoritative when present.
-                in_selected = [
-                    c for c in connected if channel_id in (c.selected_channels or [])
-                ]
+                in_selected = [c for c in connected if channel_id in (c.selected_channels or [])]
                 if in_selected:
                     preferred_connection_id = sorted(in_selected, key=lambda c: c.id)[0].id
                 else:
@@ -860,11 +861,20 @@ async def classify_unresolved(
 
     if dry_run:
         try:
-            stubs = await stores.graph.list_unresolved_stubs(
-                channel_id=channel_id, limit=limit
-            )
+            stubs = await stores.graph.list_unresolved_stubs(channel_id=channel_id, limit=limit)
         except Exception as exc:  # noqa: BLE001
-            raise HTTPException(status_code=500, detail=str(exc)) from exc
+            # Don't echo raw exception text to the caller (CodeQL
+            # info-exposure). Log full detail server-side and surface a
+            # generic message instead.
+            logger.warning(
+                "classify_unresolved dry-run: list_unresolved_stubs failed channel=%s: %s",
+                channel_id,
+                exc,
+            )
+            raise HTTPException(
+                status_code=500,
+                detail="classify_unresolved dry-run failed; see server logs",
+            ) from exc
         return {
             "channel_id": channel_id,
             "dry_run": True,
@@ -872,9 +882,7 @@ async def classify_unresolved(
         }
 
     classifier = UnresolvedClassifier(stores=stores, settings=settings)
-    report = await classifier.classify_channel(
-        channel_id, limit=limit, force=force
-    )
+    report = await classifier.classify_channel(channel_id, limit=limit, force=force)
     return report.to_dict()
 
 

--- a/src/beever_atlas/api/admin.py
+++ b/src/beever_atlas/api/admin.py
@@ -650,7 +650,7 @@ async def reset_channel_data(
         results["media_deleted"] = int(graph_counts.get("media_deleted", 0) or 0)
         results["entities_deleted"] = int(graph_counts.get("entities_deleted", 0) or 0)
     except Exception as exc:  # noqa: BLE001
-        errors.append(f"delete_channel_data: {exc}")
+        errors.append("delete_channel_data failed")
         log.warning(
             "reset_channel_data: delete_channel_data failed channel=%s: %s",
             channel_id,
@@ -662,7 +662,7 @@ async def reset_channel_data(
         weaviate_n = await stores.weaviate.delete_by_channel(channel_id)
         results["weaviate_deleted"] = int(weaviate_n or 0)
     except Exception as exc:  # noqa: BLE001
-        errors.append(f"weaviate.delete_by_channel: {exc}")
+        errors.append("weaviate.delete_by_channel failed")
         log.warning(
             "reset_channel_data: weaviate.delete_by_channel failed channel=%s: %s",
             channel_id,
@@ -676,7 +676,7 @@ async def reset_channel_data(
         await stores.mongodb.clear_channel_sync_state(channel_id)
         results["sync_state_cleared"] = 1
     except Exception as exc:  # noqa: BLE001
-        errors.append(f"clear_channel_sync_state: {exc}")
+        errors.append("clear_channel_sync_state failed")
         log.warning(
             "reset_channel_data: clear_channel_sync_state failed channel=%s: %s",
             channel_id,
@@ -712,7 +712,7 @@ async def reset_channel_data(
         )
         results["messages_marked_pending"] = int(result.modified_count)
     except Exception as exc:  # noqa: BLE001
-        errors.append(f"reset_extraction_status: {exc}")
+        errors.append("reset_extraction_status failed")
         log.warning(
             "reset_channel_data: extraction_status reset failed channel=%s: %s",
             channel_id,
@@ -801,7 +801,7 @@ async def reset_channel_data(
                     exc_info=True,
                 )
         except Exception as exc:  # noqa: BLE001
-            errors.append(f"start_sync: {exc}")
+            errors.append("start_sync failed")
             log.warning(
                 "reset_channel_data: trigger_resync failed channel=%s: %s",
                 channel_id,

--- a/src/beever_atlas/api/admin.py
+++ b/src/beever_atlas/api/admin.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import logging
 import secrets
 
-from fastapi import APIRouter, Depends, HTTPException, Response, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
 from pydantic import BaseModel, Field
 
 from beever_atlas.infra.auth import require_admin
@@ -559,6 +559,323 @@ async def llm_throttle_metrics() -> dict:
     except Exception as exc:  # noqa: BLE001 — never crash an observability endpoint
         logger.warning("llm-throttle metrics: snapshot failed: %s", exc)
         return {"providers": []}
+
+
+# ---------------------------------------------------------------------------
+# Per-channel reset — drop derived memory + optionally re-sync
+# ---------------------------------------------------------------------------
+
+
+@router.post("/channels/{channel_id}/reset")
+async def reset_channel_data(
+    channel_id: str,
+    i_understand_data_loss: str = Query(
+        ...,
+        description="Explicit confirmation token — must be the literal string 'yes'.",
+    ),
+    languages: list[str] = Query(
+        default=["en"],
+        description="Wiki languages to wipe in MongoDB. Defaults to ['en'].",
+    ),
+    trigger_resync: bool = Query(
+        default=False,
+        description="When true, kick off a full sync immediately after the wipe.",
+    ),
+) -> dict:
+    """Drop a channel's derived memory (facts, entities, wiki, graph,
+    sync state) and optionally trigger a re-sync.
+
+    Messages stay intact in MongoDB. Only derived data is wiped, so the
+    next sync auto-resolves to ``full`` and rebuilds everything with the
+    current pipeline. Designed to be safely callable after pipeline
+    changes without losing the original message history.
+
+    Stages run in fixed order — the orphan-global Entity cleanup in
+    :meth:`GraphStore.delete_channel_data` depends on the channel's
+    Events being gone first (the same ordering used inside that method),
+    and the sync-state delete must land last so it is not re-written by
+    any in-flight worker tick that observes the half-dropped state.
+
+    Each stage is wrapped in ``try/except``: a partial failure populates
+    ``errors`` and the remaining stages continue. The endpoint never
+    returns 500 from a store hiccup; the operator inspects ``errors``
+    and re-runs (the endpoint is idempotent — counts go to zero on a
+    second call).
+
+    Auth: ``X-Admin-Token`` (router-level ``require_admin`` dependency).
+    """
+    import logging as _log
+
+    log = _log.getLogger(__name__)
+
+    if i_understand_data_loss != "yes":
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="confirmation token mismatch — pass i_understand_data_loss=yes",
+        )
+
+    stores = get_stores()
+
+    # Concurrent-sync gate — refuse to drop derived data while a sync
+    # is actively rewriting it. The race would leave the channel half-
+    # purged AND half-extracted; operators should cancel or wait.
+    try:
+        latest = await stores.mongodb.get_latest_sync_job(channel_id)
+    except Exception:  # noqa: BLE001 — never let a status read leak as a 500
+        latest = None
+    if latest is not None and getattr(latest, "status", "") == "running":
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="sync in progress, cannot reset",
+        )
+
+    results: dict[str, int] = {}
+    errors: list[str] = []
+
+    # Wiki state (pages, cache bundle, generation status, Neo4j :WikiPage
+    # nodes, version archive) is INTENTIONALLY untouched here. The wiki
+    # subsystem owns its own reset path at
+    # ``POST /api/channels/{id}/wiki/refresh?mode=rebuild`` which archives
+    # the current wiki to ``wiki_versions`` BEFORE wiping — preserving
+    # rollback. Reset is a derived-knowledge primitive; the UI sequences
+    # ``/reset`` → ``/wiki/refresh?mode=rebuild`` → ``/sync`` for the
+    # one-click "fresh start" UX.
+
+    # 1. Drop derived graph data (Events, Media, channel-scoped Entities,
+    #    plus orphan-global Entity cleanup). Counts come back as
+    #    {events_deleted, media_deleted, entities_deleted}.
+    try:
+        graph_counts = await stores.graph.delete_channel_data(channel_id)
+        results["events_deleted"] = int(graph_counts.get("events_deleted", 0) or 0)
+        results["media_deleted"] = int(graph_counts.get("media_deleted", 0) or 0)
+        results["entities_deleted"] = int(graph_counts.get("entities_deleted", 0) or 0)
+    except Exception as exc:  # noqa: BLE001
+        errors.append(f"delete_channel_data: {exc}")
+        log.warning(
+            "reset_channel_data: delete_channel_data failed channel=%s: %s",
+            channel_id,
+            exc,
+        )
+
+    # 2. Drop Weaviate facts + clusters + summaries for the channel.
+    try:
+        weaviate_n = await stores.weaviate.delete_by_channel(channel_id)
+        results["weaviate_deleted"] = int(weaviate_n or 0)
+    except Exception as exc:  # noqa: BLE001
+        errors.append(f"weaviate.delete_by_channel: {exc}")
+        log.warning(
+            "reset_channel_data: weaviate.delete_by_channel failed channel=%s: %s",
+            channel_id,
+            exc,
+        )
+
+    # 3. Drop sync state (MongoDB). Run before the message-state flip so
+    #    any in-flight worker that observes the half-dropped state has
+    #    nothing to re-anchor to — the next sync auto-resolves to ``full``.
+    try:
+        await stores.mongodb.clear_channel_sync_state(channel_id)
+        results["sync_state_cleared"] = 1
+    except Exception as exc:  # noqa: BLE001
+        errors.append(f"clear_channel_sync_state: {exc}")
+        log.warning(
+            "reset_channel_data: clear_channel_sync_state failed channel=%s: %s",
+            channel_id,
+            exc,
+        )
+
+    # 4. Flip every preserved ``channel_messages`` row back to
+    #    ``extraction_status='pending'`` so the next sync re-extracts.
+    #    Without this the worker treats messages as ``done`` and the
+    #    pipeline skips them, leaving the freshly-wiped graph empty.
+    #
+    #     ``next_attempt_at`` must be SET to ``now`` (not unset). The
+    #     worker's claim filter is ``{"next_attempt_at": {"$lte": now}}``;
+    #     a missing field never satisfies ``$lte`` in MongoDB, so unsetting
+    #     would silently freeze the row out of the claim queue.
+    #
+    #     Messages themselves are intentionally preserved (they are the
+    #     authoritative source of truth from the platform).
+    try:
+        from datetime import datetime as _dt, timezone as _tz
+
+        now_utc = _dt.now(tz=_tz.utc)
+        result = await stores.mongodb.db["channel_messages"].update_many(
+            {"channel_id": channel_id},
+            {
+                "$set": {
+                    "extraction_status": "pending",
+                    "next_attempt_at": now_utc,
+                    "attempt_count": 0,
+                },
+                "$unset": {"extraction_error": ""},
+            },
+        )
+        results["messages_marked_pending"] = int(result.modified_count)
+    except Exception as exc:  # noqa: BLE001
+        errors.append(f"reset_extraction_status: {exc}")
+        log.warning(
+            "reset_channel_data: extraction_status reset failed channel=%s: %s",
+            channel_id,
+            exc,
+        )
+
+    # 5. Optionally trigger a follow-up sync via the SyncRunner directly
+    #    (the same path the user-facing /api/channels/{id}/sync endpoint
+    #    uses). Failure here is NON-fatal: the deletions are already
+    #    committed across stores, so a partial-rollback would leave the
+    #    channel in a worse state than just reporting the trigger error.
+    #
+    #    Resolve the platform connection generically: ``SyncRunner._resolve_connection_id``
+    #    filters by ``selected_channels`` membership only, which is often empty for
+    #    channels synced via the "explore + click sync" path. To stay platform-agnostic,
+    #    we ask each connected bridge adapter "do you know this channel?" and use the
+    #    first connection whose ``get_channel_info`` succeeds — the exact pattern used
+    #    by ``api/channels.get_channel`` for direct-URL navigation. No platform-format
+    #    heuristics, no hardcoded regex.
+    resync_job_id: str | None = None
+    if trigger_resync:
+        try:
+            from beever_atlas.adapters.bridge import BridgeError
+            from beever_atlas.api.sync import get_sync_runner
+            from beever_atlas.services.channel_discovery import make_bridge_adapter
+
+            preferred_connection_id: str | None = None
+            try:
+                connections = await stores.platform.list_connections()
+                connected = [c for c in connections if c.status == "connected"]
+
+                # First preference: connections that explicitly opted-in this channel
+                # (selected_channels). Authoritative when present.
+                in_selected = [
+                    c for c in connected if channel_id in (c.selected_channels or [])
+                ]
+                if in_selected:
+                    preferred_connection_id = sorted(in_selected, key=lambda c: c.id)[0].id
+                else:
+                    # Fallback: probe each bridge adapter generically. Whichever
+                    # connection's bridge can fetch the channel info owns the
+                    # channel — works for any platform, no format heuristics.
+                    for conn in connected:
+                        adapter = make_bridge_adapter(conn.id)
+                        try:
+                            await adapter.get_channel_info(channel_id)
+                            preferred_connection_id = conn.id
+                            break
+                        except (KeyError, BridgeError):
+                            continue
+                        except Exception:  # noqa: BLE001
+                            continue
+                        finally:
+                            await adapter.close()
+            except Exception as exc:  # noqa: BLE001
+                log.warning(
+                    "reset_channel_data: connection lookup failed channel=%s: %s — "
+                    "letting SyncRunner resolve via fallback.",
+                    channel_id,
+                    exc,
+                )
+
+            runner = get_sync_runner()
+            resync_job_id = await runner.start_sync(
+                channel_id,
+                sync_type="full",
+                use_batch_api=False,
+                connection_id=preferred_connection_id,
+                owner_principal_id="admin:reset",
+            )
+            # Kick the extraction worker so the freshly-pending rows are
+            # claimed on the next tick rather than after the 10s tick floor.
+            # ``SyncRunner`` only kicks on ``inserted_count > 0``; on a
+            # re-sync existing rows are matched-not-inserted, so kick here.
+            try:
+                from beever_atlas.services.extraction_worker import (
+                    get_extraction_worker,
+                )
+
+                _worker = get_extraction_worker()
+                if _worker is not None:
+                    _worker.kick()
+            except Exception:  # noqa: BLE001 — best-effort
+                log.debug(
+                    "reset_channel_data: extraction worker kick failed",
+                    exc_info=True,
+                )
+        except Exception as exc:  # noqa: BLE001
+            errors.append(f"start_sync: {exc}")
+            log.warning(
+                "reset_channel_data: trigger_resync failed channel=%s: %s",
+                channel_id,
+                exc,
+            )
+
+    # Single warning-level audit line so operators can grep for resets
+    # in the application log without re-enabling DEBUG.
+    log.warning(
+        "ADMIN RESET channel=%s principal=admin counts=%s errors=%s resync_job_id=%s",
+        channel_id,
+        results,
+        errors,
+        resync_job_id,
+    )
+
+    return {
+        "status": "reset_complete",
+        "channel_id": channel_id,
+        "counts": results,
+        "errors": errors,
+        "resync_job_id": resync_job_id,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Unresolved classifier (PR-A) — on-demand second pass for one channel
+# ---------------------------------------------------------------------------
+
+
+@router.post("/channels/{channel_id}/classify-unresolved")
+async def classify_unresolved(
+    channel_id: str,
+    dry_run: bool = Query(
+        default=False,
+        description="When true, returns the candidate count without running the LLM dispatch.",
+    ),
+    limit: int = Query(default=500, ge=1, le=2000),
+    force: bool = Query(
+        default=False,
+        description="Bypass the 7-day classifier_low_confidence_at defer gate.",
+    ),
+) -> dict:
+    """Run the post-extraction Unresolved-stub classifier for one channel.
+
+    Auth: ``X-Admin-Token`` (router-level dependency). Mirrors the
+    auto-fire path bound to ``memory_settled``; useful for ad-hoc
+    backfills against channels that synced before the classifier
+    shipped.
+    """
+    from beever_atlas.infra.config import get_settings as _gs
+    from beever_atlas.services.unresolved_classifier import UnresolvedClassifier
+
+    stores = get_stores()
+    settings = _gs()
+
+    if dry_run:
+        try:
+            stubs = await stores.graph.list_unresolved_stubs(
+                channel_id=channel_id, limit=limit
+            )
+        except Exception as exc:  # noqa: BLE001
+            raise HTTPException(status_code=500, detail=str(exc)) from exc
+        return {
+            "channel_id": channel_id,
+            "dry_run": True,
+            "candidate_count": len(stubs),
+        }
+
+    classifier = UnresolvedClassifier(stores=stores, settings=settings)
+    report = await classifier.classify_channel(
+        channel_id, limit=limit, force=force
+    )
+    return report.to_dict()
 
 
 __all__ = ["router"]

--- a/src/beever_atlas/api/graph.py
+++ b/src/beever_atlas/api/graph.py
@@ -16,7 +16,7 @@ router = APIRouter(prefix="/api/graph", tags=["graph"])
 async def list_entities(
     channel_id: str | None = Query(default=None),
     entity_type: str | None = Query(default=None),
-    limit: int = Query(default=50, ge=1, le=500),
+    limit: int = Query(default=50, ge=1, le=2000),
     principal: Principal = Depends(require_user),
 ) -> list[GraphEntity]:
     """List entities in the knowledge graph."""
@@ -31,10 +31,22 @@ async def list_entities(
 @router.get("/relationships", response_model=list[GraphRelationship])
 async def list_relationships(
     channel_id: str | None = Query(default=None),
-    limit: int = Query(default=200, ge=1, le=1000),
+    limit: int = Query(default=1000, ge=1, le=2000),
+    include_co_mentions: bool = Query(
+        default=True,
+        description=(
+            "Append synthetic CO_MENTIONED edges between entity pairs that "
+            "share at least 2 Event nodes in the channel. Helps sparse "
+            "channels where the LLM produced few explicit relationships."
+        ),
+    ),
+    co_mention_min_shared: int = Query(default=2, ge=1, le=20),
+    co_mention_limit: int = Query(default=500, ge=1, le=2000),
     principal: Principal = Depends(require_user),
 ) -> list[GraphRelationship]:
-    """List relationships in the knowledge graph, including entity-media links."""
+    """List relationships in the knowledge graph, including entity-media links
+    and (optionally) synthetic CO_MENTIONED edges derived from shared Events.
+    """
     if channel_id:
         await assert_channel_access(principal, channel_id)
     stores = get_stores()
@@ -50,6 +62,24 @@ async def list_relationships(
                 target=mr["target"],
             )
         )
+
+    # Append synthetic co-mention edges if the caller wants them and the
+    # channel is set. These come from shared :MENTIONED_IN edges to the
+    # same Event node — useful for casual channels where the LLM extracted
+    # few entity-to-entity verbs and the graph would otherwise look like a
+    # cloud of disconnected typed nodes.
+    if include_co_mentions and channel_id:
+        try:
+            co_rels = await stores.graph.list_co_mention_edges(
+                channel_id=channel_id,
+                min_shared=co_mention_min_shared,
+                limit=co_mention_limit,
+            )
+            entity_rels.extend(co_rels)
+        except AttributeError:
+            # Backend that doesn't implement list_co_mention_edges — null
+            # graph, older mock, etc. Silently skip.
+            pass
 
     return entity_rels
 

--- a/src/beever_atlas/server/app.py
+++ b/src/beever_atlas/server/app.py
@@ -992,8 +992,7 @@ async def lifespan(app: FastAPI):
                     exc = t.exception()
                     if exc is not None:
                         logging.getLogger(__name__).warning(
-                            "unresolved_classifier fan-out task raised "
-                            "channel=%s: %s",
+                            "unresolved_classifier fan-out task raised channel=%s: %s",
                             channel_id,
                             exc,
                             exc_info=exc,

--- a/src/beever_atlas/server/app.py
+++ b/src/beever_atlas/server/app.py
@@ -941,6 +941,73 @@ async def lifespan(app: FastAPI):
                 "Consolidation-after-extraction wiring failed (non-fatal): %s", exc
             )
 
+    # Unresolved classifier — second pass after memory settles (PR-A).
+    # Lives in the FastAPI lifespan (NOT services/scheduler.py) per the
+    # post-critic A-1 fix: subscribe_memory_settled calls only fire when
+    # registered on the live ExtractionWorker instance, which is owned
+    # by this lifespan via the get_extraction_worker() singleton. The
+    # consolidation block above is the model for this wiring.
+    try:
+        import asyncio as _asyncio_uc
+
+        from beever_atlas.services.extraction_worker import (
+            get_extraction_worker as _get_extraction_worker_uc,
+        )
+        from beever_atlas.services.unresolved_classifier import (
+            UnresolvedClassifier,
+        )
+
+        _uc_worker = _get_extraction_worker_uc()
+        if _uc_worker is not None:
+            _uc_classifier = UnresolvedClassifier(stores=stores, settings=settings)
+
+            async def _run_unresolved_classifier(channel_id: str) -> None:
+                try:
+                    report = await _uc_classifier.classify_channel(channel_id)
+                    logging.getLogger(__name__).info(
+                        "unresolved_classifier: channel=%s processed=%d "
+                        "classified=%d low_confidence=%d new_types=%d "
+                        "llm_calls=%d",
+                        channel_id,
+                        report.processed,
+                        report.classified,
+                        report.low_confidence,
+                        report.new_types_accepted,
+                        report.llm_calls,
+                    )
+                except Exception:  # noqa: BLE001
+                    logging.getLogger(__name__).warning(
+                        "unresolved_classifier raised channel=%s "
+                        "(best-effort, will retry on next memory_settled)",
+                        channel_id,
+                        exc_info=True,
+                    )
+
+            def _on_memory_settled_unresolved(channel_id: str) -> None:
+                task = _asyncio_uc.create_task(_run_unresolved_classifier(channel_id))
+
+                def _log_exc_uc(t: _asyncio_uc.Task) -> None:
+                    if t.cancelled():
+                        return
+                    exc = t.exception()
+                    if exc is not None:
+                        logging.getLogger(__name__).warning(
+                            "unresolved_classifier fan-out task raised "
+                            "channel=%s: %s",
+                            channel_id,
+                            exc,
+                            exc_info=exc,
+                        )
+
+                task.add_done_callback(_log_exc_uc)
+
+            _uc_worker.subscribe_memory_settled(_on_memory_settled_unresolved)
+    except Exception as exc:
+        logging.getLogger(__name__).warning(
+            "UnresolvedClassifier subscriber init failed (non-fatal): %s",
+            exc,
+        )
+
     # Initialize outbound MCP registry — non-blocking, skips unreachable servers
     from beever_atlas.agents.mcp_registry import init_mcp_registry
 

--- a/src/beever_atlas/services/orphan_reconciler.py
+++ b/src/beever_atlas/services/orphan_reconciler.py
@@ -14,7 +14,10 @@ logger = logging.getLogger(__name__)
 async def prune_expired_orphans() -> int:
     """Prune pending entities that have exceeded the grace period.
 
-    Returns the count of pruned entities.
+    Also prunes Unresolved stub entities older than 24h that never
+    gained any incident edges — see
+    :meth:`Neo4jStore.prune_stub_orphans`. The total returned is the
+    sum of both purges.
     """
     from beever_atlas.infra.config import get_settings
     from beever_atlas.stores import get_stores
@@ -22,17 +25,29 @@ async def prune_expired_orphans() -> int:
     settings = get_settings()
     stores = get_stores()
 
+    pending_count = 0
+    stub_count = 0
     try:
-        count = await stores.graph.prune_expired_pending(
+        pending_count = await stores.graph.prune_expired_pending(
             grace_period_days=settings.orphan_grace_period_days,
         )
-        if count > 0:
+        if pending_count > 0:
             logger.info(
                 "OrphanReconciler: pruned %d expired pending entities (grace=%d days)",
-                count,
+                pending_count,
                 settings.orphan_grace_period_days,
             )
-        return count
     except Exception:
-        logger.warning("OrphanReconciler: prune failed", exc_info=True)
-        return 0
+        logger.warning("OrphanReconciler: prune_expired_pending failed", exc_info=True)
+
+    try:
+        stub_count = await stores.graph.prune_stub_orphans(ttl_hours=24)
+        if stub_count > 0:
+            logger.info(
+                "OrphanReconciler: pruned %d Unresolved stub orphans (ttl=24h)",
+                stub_count,
+            )
+    except Exception:
+        logger.warning("OrphanReconciler: prune_stub_orphans failed", exc_info=True)
+
+    return pending_count + stub_count

--- a/src/beever_atlas/services/sync_runner.py
+++ b/src/beever_atlas/services/sync_runner.py
@@ -686,9 +686,7 @@ class SyncRunner:
         connected = [c for c in connections if c.status == "connected"]
 
         # Path 2: explicit selected_channels membership.
-        selected_candidates = [
-            c for c in connected if channel_id in (c.selected_channels or [])
-        ]
+        selected_candidates = [c for c in connected if channel_id in (c.selected_channels or [])]
         if len(selected_candidates) == 1:
             return selected_candidates[0].id
         if len(selected_candidates) > 1:
@@ -696,8 +694,7 @@ class SyncRunner:
             # explicitly-selected connections.
             selected = sorted(selected_candidates, key=lambda c: c.id)[0]
             logger.warning(
-                "SyncRunner: channel %s is selected in %d connections; "
-                "defaulting to connection %s",
+                "SyncRunner: channel %s is selected in %d connections; defaulting to connection %s",
                 channel_id,
                 len(selected_candidates),
                 selected.id,
@@ -718,8 +715,7 @@ class SyncRunner:
             try:
                 await adapter.get_channel_info(channel_id)
                 logger.info(
-                    "SyncRunner: bridge probe matched channel %s to "
-                    "connection %s (platform=%s)",
+                    "SyncRunner: bridge probe matched channel %s to connection %s (platform=%s)",
                     channel_id,
                     conn.id,
                     conn.platform,

--- a/src/beever_atlas/services/sync_runner.py
+++ b/src/beever_atlas/services/sync_runner.py
@@ -664,31 +664,78 @@ class SyncRunner:
         channel_id: str,
         explicit_connection_id: str | None,
     ) -> str | None:
-        """Resolve which platform connection should be used for channel fetches."""
+        """Resolve which platform connection should be used for channel fetches.
+
+        Priority order:
+          1. Explicit connection_id from the caller.
+          2. Connections whose ``selected_channels`` contains the channel id —
+             the opt-in path. Tiebreaks alphabetically on id.
+          3. Generic bridge probe — ask each connected adapter "do you know
+             this channel?" and pick the first that responds successfully.
+             Covers channels synced via "explore + click sync" (no explicit
+             selection list entry), and channels whose sync_state was wiped
+             by ``/api/admin/channels/{id}/reset``. Same pattern used by
+             ``api/channels.get_channel`` for direct-URL navigation —
+             generic, no platform-format heuristics.
+        """
         if explicit_connection_id:
             return explicit_connection_id
 
         stores = get_stores()
         connections = await stores.platform.list_connections()
-        candidates = [
-            c
-            for c in connections
-            if c.status == "connected" and channel_id in (c.selected_channels or [])
-        ]
-        if not candidates:
-            return None
-        if len(candidates) == 1:
-            return candidates[0].id
+        connected = [c for c in connections if c.status == "connected"]
 
-        # Deterministic fallback for duplicate channel IDs across connections.
-        selected = sorted(candidates, key=lambda c: c.id)[0]
-        logger.warning(
-            "SyncRunner: channel %s is selected in %d connections; defaulting to connection %s",
-            channel_id,
-            len(candidates),
-            selected.id,
-        )
-        return selected.id
+        # Path 2: explicit selected_channels membership.
+        selected_candidates = [
+            c for c in connected if channel_id in (c.selected_channels or [])
+        ]
+        if len(selected_candidates) == 1:
+            return selected_candidates[0].id
+        if len(selected_candidates) > 1:
+            # Deterministic fallback for duplicate channel IDs across
+            # explicitly-selected connections.
+            selected = sorted(selected_candidates, key=lambda c: c.id)[0]
+            logger.warning(
+                "SyncRunner: channel %s is selected in %d connections; "
+                "defaulting to connection %s",
+                channel_id,
+                len(selected_candidates),
+                selected.id,
+            )
+            return selected.id
+
+        # Path 3: generic bridge probe across every connected connection.
+        # Whichever adapter's bridge can fetch channel info owns the channel
+        # — works for any platform, no format heuristics.
+        try:
+            from beever_atlas.adapters.bridge import BridgeError
+            from beever_atlas.services.channel_discovery import make_bridge_adapter
+        except Exception:  # noqa: BLE001
+            return None
+
+        for conn in connected:
+            adapter = make_bridge_adapter(conn.id)
+            try:
+                await adapter.get_channel_info(channel_id)
+                logger.info(
+                    "SyncRunner: bridge probe matched channel %s to "
+                    "connection %s (platform=%s)",
+                    channel_id,
+                    conn.id,
+                    conn.platform,
+                )
+                return conn.id
+            except (KeyError, BridgeError):
+                continue
+            except Exception:  # noqa: BLE001
+                continue
+            finally:
+                try:
+                    await adapter.close()
+                except Exception:  # noqa: BLE001
+                    pass
+
+        return None
 
     async def _start_file_sync(
         self,

--- a/src/beever_atlas/services/unresolved_classifier.py
+++ b/src/beever_atlas/services/unresolved_classifier.py
@@ -255,9 +255,7 @@ class UnresolvedClassifier:
                     for s in batch
                 ]
                 try:
-                    classifications = await self._dispatch_batch(
-                        candidates, observed_types
-                    )
+                    classifications = await self._dispatch_batch(candidates, observed_types)
                     report.llm_calls += 1
                 except Exception as exc:  # noqa: BLE001
                     logger.warning(
@@ -278,9 +276,7 @@ class UnresolvedClassifier:
                     confidence = float(cls.confidence)
                     # Gate: new type acceptance requires high
                     # confidence OR presence in channel/catalog.
-                    is_known = (
-                        inferred in CANONICAL_TYPES or inferred in observed_types
-                    )
+                    is_known = inferred in CANONICAL_TYPES or inferred in observed_types
                     if not is_known and confidence < NEW_TYPE_THRESHOLD:
                         # Parked as low-confidence; stub stays
                         # Unresolved.
@@ -313,9 +309,7 @@ class UnresolvedClassifier:
         and as half of the new-type gate (A-5).
         """
         try:
-            entities = await self._stores.graph.list_entities(
-                channel_id=channel_id, limit=500
-            )
+            entities = await self._stores.graph.list_entities(channel_id=channel_id, limit=500)
         except Exception as exc:  # noqa: BLE001
             logger.debug(
                 "UnresolvedClassifier: observed-types lookup failed channel=%s: %s",
@@ -323,11 +317,7 @@ class UnresolvedClassifier:
                 exc,
             )
             return set()
-        return {
-            e.type
-            for e in entities
-            if e.type and e.type not in {"Unresolved", "Topic"}
-        }
+        return {e.type for e in entities if e.type and e.type not in {"Unresolved", "Topic"}}
 
     async def _dispatch_batch(
         self,

--- a/src/beever_atlas/services/unresolved_classifier.py
+++ b/src/beever_atlas/services/unresolved_classifier.py
@@ -1,0 +1,432 @@
+"""Second-pass entity-type classifier for Unresolved stubs (PR-A).
+
+Subscribes to ``ExtractionWorker.memory_settled`` events. When a
+channel's extraction queue drains, the classifier:
+
+1. Lists every ``Unresolved`` stub that's still ``awaiting_type=true``
+   AND reachable from the channel via a MENTIONED_IN→Event{channel_id}
+   pivot (A-2 scope filter).
+2. Fetches ≤3 incident-edge contexts per stub in a single
+   ``UNWIND``-based Cypher round-trip (A-4 batching).
+3. Bundles batches of ≤25 names → Gemini Flash 2.5 JSON-mode call.
+4. Validates the inferred type (PascalCase; new types gated by
+   confidence ≥ 0.8 — A-5).
+5. For accepted classifications, calls ``upsert_entity`` with the
+   inferred type — the existing symmetric heal-path at
+   :func:`Neo4jStore.upsert_entity` absorbs the stub into the typed
+   row via ``apoc.refactor.mergeNodes``.
+6. For low-confidence rows, bumps ``classifier_attempts`` so the stub
+   parks for 7 days before retry.
+
+Per-channel ``asyncio.Lock`` guards each ``memory_settled`` emit
+against double-spend (A-6 fix).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import re
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING, Any
+
+from pydantic import BaseModel
+
+from beever_atlas.models import GraphEntity
+
+if TYPE_CHECKING:
+    pass
+
+logger = logging.getLogger(__name__)
+
+
+# Canonical types from entity_extractor.py:42-56 (11 types). Used as
+# the "preferred" set; new PascalCase types from the LLM are allowed
+# only when confidence ≥ 0.8 (A-5 gate).
+CANONICAL_TYPES: frozenset[str] = frozenset(
+    {
+        "Person",
+        "Technology",
+        "Project",
+        "Team",
+        "Decision",
+        "Meeting",
+        "Artifact",
+        "Organization",
+        "Concept",
+        "Location",
+        "Event",
+    }
+)
+
+# Confidence thresholds — per plan §A.3.1.
+ACCEPT_THRESHOLD: float = 0.55
+NEW_TYPE_THRESHOLD: float = 0.8
+LOW_CONFIDENCE_TTL_DAYS: int = 7
+
+# Batch size for the LLM call — plan §A.5 pins ~25 names per batch so
+# the prompt stays under 2.5k input tokens.
+BATCH_SIZE: int = 25
+
+# Per-channel locks — module-level so concurrent ``memory_settled``
+# emits for the same channel queue serially (A-6 fix).
+_locks: dict[str, asyncio.Lock] = {}
+
+
+_PASCAL_CASE = re.compile(r"^[A-Z][A-Za-z0-9]*$")
+
+
+def _coerce_pascal(raw: str) -> str:
+    """Coerce ``raw`` to PascalCase if possible.
+
+    ``person`` → ``Person``; ``DATA_OFFICER`` → ``DataOfficer``.
+    Returns the raw string unchanged if it cannot be coerced cleanly.
+    """
+    s = (raw or "").strip()
+    if not s:
+        return s
+    if _PASCAL_CASE.match(s):
+        return s
+    if "_" in s or s.islower() or s.isupper():
+        parts = [p for p in re.split(r"[_\s-]+", s) if p]
+        return "".join(p[:1].upper() + p[1:].lower() for p in parts)
+    # Mixed-case unknown shape — just capitalise the first letter.
+    return s[:1].upper() + s[1:]
+
+
+@dataclass
+class Classification:
+    """Single LLM classification result."""
+
+    name: str
+    type: str
+    confidence: float
+
+
+@dataclass
+class ClassifyReport:
+    """Return shape for :meth:`UnresolvedClassifier.classify_channel`."""
+
+    channel_id: str
+    processed: int = 0
+    classified: int = 0
+    low_confidence: int = 0
+    new_types_accepted: int = 0
+    errors: list[str] = field(default_factory=list)
+    llm_calls: int = 0
+    est_cost_usd: float = 0.0
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "channel_id": self.channel_id,
+            "processed": self.processed,
+            "classified": self.classified,
+            "low_confidence": self.low_confidence,
+            "new_types_accepted": self.new_types_accepted,
+            "errors": list(self.errors),
+            "llm_calls": self.llm_calls,
+            "est_cost_usd": round(self.est_cost_usd, 6),
+        }
+
+
+class ClassifyReportModel(BaseModel):
+    """Pydantic wrapper for the admin endpoint response."""
+
+    channel_id: str
+    processed: int = 0
+    classified: int = 0
+    low_confidence: int = 0
+    new_types_accepted: int = 0
+    errors: list[str] = []
+    llm_calls: int = 0
+    est_cost_usd: float = 0.0
+
+
+class UnresolvedClassifier:
+    """Drives the post-extraction second pass.
+
+    The classifier never speaks Cypher directly beyond the three new
+    methods on :class:`Neo4jStore` (``list_unresolved_stubs``,
+    ``fetch_incident_contexts_batch``, ``mark_unresolved_attempt``).
+    Typed writes flow through ``upsert_entity`` so the existing heal-
+    path absorbs the stub via ``apoc.refactor.mergeNodes``.
+    """
+
+    def __init__(
+        self,
+        *,
+        stores: Any,
+        settings: Any | None = None,
+        llm_dispatcher: Any | None = None,
+        provider: str = "gemini",
+        model: str = "gemini-2.5-flash",
+        endpoint_id: str | None = None,
+    ) -> None:
+        self._stores = stores
+        self._settings = settings
+        # Caller may inject a mock dispatcher for tests. Production
+        # path resolves lazily so the LLM provider isn't imported at
+        # lifespan time.
+        self._dispatcher = llm_dispatcher
+        self._provider = provider
+        self._model = model
+        self._endpoint_id = endpoint_id
+
+    async def classify_channel(
+        self,
+        channel_id: str,
+        *,
+        limit: int = 500,
+        force: bool = False,
+    ) -> ClassifyReport:
+        """Classify every eligible Unresolved stub reachable from
+        ``channel_id``. Returns a :class:`ClassifyReport`.
+
+        ``force=true`` bypasses the 7-day ``classifier_low_confidence_at``
+        defer gate — used by the admin endpoint.
+        """
+        lock = _locks.setdefault(channel_id, asyncio.Lock())
+        report = ClassifyReport(channel_id=channel_id)
+        async with lock:
+            try:
+                stubs = await self._stores.graph.list_unresolved_stubs(
+                    channel_id=channel_id, limit=limit
+                )
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "UnresolvedClassifier: list_unresolved_stubs failed channel=%s: %s",
+                    channel_id,
+                    exc,
+                )
+                report.errors.append(f"list_unresolved_stubs: {exc}")
+                return report
+
+            now = datetime.now(tz=UTC)
+            cutoff = now - timedelta(days=LOW_CONFIDENCE_TTL_DAYS)
+            eligible: list[dict[str, Any]] = []
+            for stub in stubs:
+                if not force:
+                    raw = stub.get("low_confidence_at")
+                    if raw:
+                        try:
+                            ts = datetime.fromisoformat(str(raw).replace("Z", "+00:00"))
+                            if ts.tzinfo is None:
+                                ts = ts.replace(tzinfo=UTC)
+                            if ts > cutoff:
+                                continue
+                        except (TypeError, ValueError):
+                            # Unparseable timestamp — treat as old.
+                            pass
+                eligible.append(stub)
+
+            report.processed = len(eligible)
+            if not eligible:
+                return report
+
+            # Single batched context fetch (A-4 optimisation).
+            names = [s["name"] for s in eligible if s.get("name")]
+            try:
+                contexts_map = await self._stores.graph.fetch_incident_contexts_batch(
+                    names, limit_per_name=3
+                )
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "UnresolvedClassifier: fetch_incident_contexts_batch failed channel=%s: %s",
+                    channel_id,
+                    exc,
+                )
+                report.errors.append(f"fetch_incident_contexts_batch: {exc}")
+                return report
+
+            # Observed type catalog for this channel — used as
+            # context in the prompt + for the new-type gate.
+            observed_types = await self._observed_channel_types(channel_id)
+
+            # LLM dispatch in batches of ≤25.
+            for batch_start in range(0, len(eligible), BATCH_SIZE):
+                batch = eligible[batch_start : batch_start + BATCH_SIZE]
+                candidates = [
+                    {
+                        "name": s["name"],
+                        "contexts": contexts_map.get(s["name"], [])[:3],
+                    }
+                    for s in batch
+                ]
+                try:
+                    classifications = await self._dispatch_batch(
+                        candidates, observed_types
+                    )
+                    report.llm_calls += 1
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning(
+                        "UnresolvedClassifier: LLM dispatch failed channel=%s: %s",
+                        channel_id,
+                        exc,
+                    )
+                    report.errors.append(f"dispatch: {exc}")
+                    continue
+
+                by_name = {c.name: c for c in classifications}
+                for stub in batch:
+                    name = stub["name"]
+                    cls = by_name.get(name)
+                    if cls is None:
+                        continue
+                    inferred = _coerce_pascal(cls.type)
+                    confidence = float(cls.confidence)
+                    # Gate: new type acceptance requires high
+                    # confidence OR presence in channel/catalog.
+                    is_known = (
+                        inferred in CANONICAL_TYPES or inferred in observed_types
+                    )
+                    if not is_known and confidence < NEW_TYPE_THRESHOLD:
+                        # Parked as low-confidence; stub stays
+                        # Unresolved.
+                        await self._mark_low(stub, report)
+                        continue
+                    if confidence < ACCEPT_THRESHOLD:
+                        await self._mark_low(stub, report)
+                        continue
+                    # Accept — typed write through the heal-path.
+                    try:
+                        await self._apply_classification(stub, inferred, confidence)
+                        report.classified += 1
+                        if not is_known:
+                            report.new_types_accepted += 1
+                    except Exception as exc:  # noqa: BLE001
+                        logger.warning(
+                            "UnresolvedClassifier: upsert_entity failed name=%s: %s",
+                            name,
+                            exc,
+                        )
+                        report.errors.append(f"upsert:{name}: {exc}")
+
+            # Cost estimate — plan §A.5: ~$0.00025 / batch.
+            report.est_cost_usd = report.llm_calls * 0.00025
+            return report
+
+    async def _observed_channel_types(self, channel_id: str) -> set[str]:
+        """Return the set of distinct typed entity types currently
+        visible in the channel — used as auxiliary context for the LLM
+        and as half of the new-type gate (A-5).
+        """
+        try:
+            entities = await self._stores.graph.list_entities(
+                channel_id=channel_id, limit=500
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.debug(
+                "UnresolvedClassifier: observed-types lookup failed channel=%s: %s",
+                channel_id,
+                exc,
+            )
+            return set()
+        return {
+            e.type
+            for e in entities
+            if e.type and e.type not in {"Unresolved", "Topic"}
+        }
+
+    async def _dispatch_batch(
+        self,
+        candidates: list[dict[str, Any]],
+        observed_types: set[str],
+    ) -> list[Classification]:
+        """Run one LLM call. Returns a list of :class:`Classification`."""
+        from beever_atlas.agents.prompts.unresolved_classifier import (
+            UNRESOLVED_CLASSIFIER_INSTRUCTION,
+        )
+
+        prompt = UNRESOLVED_CLASSIFIER_INSTRUCTION.format(
+            channel_observed_types=(
+                ", ".join(sorted(observed_types)) if observed_types else "(none)"
+            ),
+            candidates_json=json.dumps(candidates, ensure_ascii=False),
+        )
+        if self._dispatcher is not None:
+            raw = await self._dispatcher(prompt)
+        else:
+            from beever_atlas.services.llm_dispatch import dispatch_completion
+
+            response = await dispatch_completion(
+                provider=self._provider,
+                model=self._model,
+                messages=[{"role": "user", "content": prompt}],
+                endpoint_id=self._endpoint_id,
+                response_format={"type": "json_object"},
+                temperature=0.2,
+                _log_consumer="unresolved_classifier",
+            )
+            raw = response.choices[0].message.content or "{}"
+
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            logger.warning(
+                "UnresolvedClassifier: LLM returned non-JSON: %s",
+                exc,
+            )
+            return []
+        rows = data.get("classifications") or []
+        out: list[Classification] = []
+        for row in rows:
+            try:
+                out.append(
+                    Classification(
+                        name=str(row.get("name", "")).strip(),
+                        type=str(row.get("type", "")).strip(),
+                        confidence=float(row.get("confidence", 0.0)),
+                    )
+                )
+            except (TypeError, ValueError) as exc:
+                logger.debug("UnresolvedClassifier: bad row %r: %s", row, exc)
+        return out
+
+    async def _apply_classification(
+        self,
+        stub: dict[str, Any],
+        inferred_type: str,
+        confidence: float,
+    ) -> None:
+        """Typed upsert — the heal-path at neo4j_store.upsert_entity
+        absorbs the original Unresolved row via APOC.
+
+        For ``scope='channel'`` stubs (legacy data) we pass both
+        ``channel_id`` and ``scope='channel'`` so the channel branch
+        of the heal-path is taken. For ``scope='global'`` stubs
+        (production case) ``channel_id=None`` triggers the global
+        branch.
+        """
+        name = stub["name"]
+        scope = stub.get("scope") or "global"
+        channel_id = stub.get("channel_id")
+        entity = GraphEntity(
+            name=name,
+            type=inferred_type,
+            scope=scope,
+            channel_id=channel_id if scope == "channel" else None,
+            properties={
+                "classifier_source": "unresolved_classifier",
+                "classifier_confidence": round(confidence, 4),
+            },
+        )
+        await self._stores.graph.upsert_entity(entity)
+
+    async def _mark_low(self, stub: dict[str, Any], report: ClassifyReport) -> None:
+        """Bump ``classifier_attempts`` and stamp the defer timestamp."""
+        try:
+            await self._stores.graph.mark_unresolved_attempt(
+                name=stub["name"],
+                scope=stub.get("scope") or "global",
+                channel_id=stub.get("channel_id"),
+            )
+            report.low_confidence += 1
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "UnresolvedClassifier: mark_unresolved_attempt failed name=%s: %s",
+                stub.get("name"),
+                exc,
+            )
+            report.errors.append(f"mark_low:{stub.get('name')}: {exc}")

--- a/src/beever_atlas/services/wiki_maintainer.py
+++ b/src/beever_atlas/services/wiki_maintainer.py
@@ -1733,7 +1733,7 @@ class WikiMaintainer:
         # ``_upsert_wiki_graph`` itself so a Neo4j hiccup never crashes
         # the maintainer's primary path.
         if use_kind_dispatch:
-            await self._upsert_wiki_graph(page, resolved_slugs)
+            await self._upsert_wiki_graph(page, resolved_slugs, target_lang=target_lang)
         # Drift A/B comparator (gated by ``Settings.wiki_drift_ab``). MUST run
         # AFTER ``save_page`` succeeds so the comparator sees the canonical
         # incremental output the user will read. The schedule helper is
@@ -1824,6 +1824,8 @@ class WikiMaintainer:
         self,
         page: "WikiPage",
         resolved_slugs: list[str],
+        *,
+        target_lang: str = "en",
     ) -> None:
         """Best-effort Neo4j upsert for the page node + REFERENCES edges.
 
@@ -1832,6 +1834,11 @@ class WikiMaintainer:
         gain parity), and any runtime Neo4j failure. The maintainer's
         primary path stays unaffected — page content is already saved
         to Mongo before this call.
+
+        Also emits ``:REFERENCES_ENTITY`` edges for every wikilink that
+        resolves against the entity registry. This is the writer side
+        of the WikiPage→Entity bridge — without it the
+        ``get_wiki_graph`` reader has nothing to surface.
         """
         store = self._graph_store
         if store is None:
@@ -1849,6 +1856,7 @@ class WikiMaintainer:
                 title=page.title,
                 version=page.version,
                 last_updated=page.updated_at,
+                target_lang=target_lang,
             )
             for dst_slug in resolved_slugs:
                 if not dst_slug or dst_slug == self_slug:
@@ -1857,6 +1865,40 @@ class WikiMaintainer:
                     channel_id=page.channel_id,
                     src_slug=self_slug,
                     dst_slug=dst_slug,
+                    target_lang=target_lang,
+                )
+
+            # WikiPage → Entity bridge edges. For each wikilink title in
+            # the page body, try to resolve it against the entity
+            # registry; when it hits a real ``:Entity`` row, emit a
+            # ``:REFERENCES_ENTITY`` edge. A wikilink that resolves
+            # to a sibling wiki page (handled above) and ALSO matches a
+            # typed entity will produce both edges — that's intentional;
+            # the reader filters by edge kind.
+            if not hasattr(store, "upsert_wiki_reference_entity_edge"):
+                return
+            if not hasattr(store, "find_entity_by_name_or_alias"):
+                return
+            seen_titles: set[str] = set()
+            ordered_titles: list[str] = []
+            for section in page.sections:
+                for title in _parse_wikilinks(section.content_md):
+                    if title in seen_titles:
+                        continue
+                    seen_titles.add(title)
+                    ordered_titles.append(title)
+            for title in ordered_titles:
+                try:
+                    canonical = await store.find_entity_by_name_or_alias(title)
+                except Exception:  # noqa: BLE001 — never destabilise apply_update
+                    canonical = None
+                if not canonical:
+                    continue
+                await store.upsert_wiki_reference_entity_edge(
+                    channel_id=page.channel_id,
+                    target_lang=target_lang,
+                    src_slug=self_slug,
+                    entity_name=canonical,
                 )
         except Exception:  # noqa: BLE001 — best-effort
             logger.exception(

--- a/src/beever_atlas/stores/graph_protocol.py
+++ b/src/beever_atlas/stores/graph_protocol.py
@@ -94,6 +94,68 @@ class GraphStore(Protocol):
         """
         ...
 
+    async def list_co_mention_edges(
+        self,
+        channel_id: str,
+        min_shared: int = 2,
+        limit: int = 500,
+    ) -> list[GraphRelationship]:
+        """Return synthetic CO_MENTIONED relationships between entity
+        pairs that share at least *min_shared* Event nodes in the
+        channel. Surfaces implicit co-occurrence when explicit
+        LLM-extracted relationships are sparse.
+        """
+        ...
+
+    # ------------------------------------------------------------------
+    # Unresolved-classifier helpers (PR-A)
+    # ------------------------------------------------------------------
+
+    async def list_unresolved_stubs(
+        self,
+        channel_id: str | None = None,
+        limit: int = 500,
+    ) -> list[dict[str, Any]]:
+        """Return Unresolved stub entities awaiting type classification.
+
+        Per-channel pivot via ``MENTIONED_IN→Event{channel_id}`` so
+        workspace-wide stubs without an incident event in the channel
+        are filtered out. Excludes stubs whose ``classifier_attempts``
+        already exceeds the retry budget.
+        """
+        ...
+
+    async def fetch_incident_contexts_batch(
+        self,
+        names: list[str],
+        limit_per_name: int = 3,
+    ) -> dict[str, list[str]]:
+        """Return up to *limit_per_name* incident-edge contexts per
+        candidate name in a single round-trip. Used by the unresolved
+        classifier to gather disambiguating signal for each stub.
+        """
+        ...
+
+    async def mark_unresolved_attempt(
+        self,
+        name: str,
+        scope: str,
+        channel_id: str | None,
+    ) -> None:
+        """Bump ``classifier_attempts`` and stamp
+        ``classifier_low_confidence_at = now`` on the stub. Idempotent."""
+        ...
+
+    async def prune_stub_orphans(self, ttl_hours: int = 24) -> int:
+        """Delete ``Unresolved``-typed stub entities that never gained any
+        edges and are older than *ttl_hours*.
+
+        Stubs are written with ``status='active'`` (not ``pending``), so
+        ``prune_expired_pending`` does not catch them. Returns the number
+        of orphans purged.
+        """
+        ...
+
     # ------------------------------------------------------------------
     # Relationship CRUD
     # ------------------------------------------------------------------
@@ -191,6 +253,18 @@ class GraphStore(Protocol):
     async def delete_channel_data(self, channel_id: str) -> dict[str, int]:
         """Delete all entities, events, media, and relationships for a
         channel.  Returns counts of deleted items."""
+        ...
+
+    async def delete_channel_wiki_graph(self, channel_id: str) -> int:
+        """Delete ``:WikiPage`` nodes for a channel (and their relationships).
+
+        Per-channel reset (``POST /api/admin/channels/{id}/reset``) wipes
+        wiki-page rows from MongoDB; the matching nodes in the graph would
+        otherwise linger as dangling references. Kept separate from
+        :meth:`delete_channel_data` so the latter's semantics stay
+        unchanged. Returns the number of nodes deleted (zero on backends
+        that don't store WikiPage nodes — Nebula / NullGraph stubs).
+        """
         ...
 
     # ------------------------------------------------------------------

--- a/src/beever_atlas/stores/nebula_store.py
+++ b/src/beever_atlas/stores/nebula_store.py
@@ -907,6 +907,51 @@ class NebulaStore:
                 f'status = "active", pending_since = ""'
             )
 
+    async def list_co_mention_edges(
+        self,
+        channel_id: str,
+        min_shared: int = 2,
+        limit: int = 500,
+    ) -> list[GraphRelationship]:
+        # Nebula adapter does not currently model co-mention derivation;
+        # the Memory Graph view falls back to explicit relationships only.
+        return []
+
+    # ------------------------------------------------------------------
+    # Unresolved-classifier helpers (PR-A) — no-op for the Nebula backend
+    # ------------------------------------------------------------------
+
+    async def list_unresolved_stubs(
+        self,
+        channel_id: str | None = None,
+        limit: int = 500,
+    ) -> list[dict[str, Any]]:
+        # Nebula adapter does not currently surface Unresolved stub
+        # classification; the classifier service treats this as a no-op
+        # for non-Neo4j backends.
+        return []
+
+    async def fetch_incident_contexts_batch(
+        self,
+        names: list[str],
+        limit_per_name: int = 3,
+    ) -> dict[str, list[str]]:
+        return {}
+
+    async def mark_unresolved_attempt(
+        self,
+        name: str,
+        scope: str,
+        channel_id: str | None,
+    ) -> None:
+        return None
+
+    async def prune_stub_orphans(self, ttl_hours: int = 24) -> int:
+        # Nebula adapter does not currently distinguish Unresolved stubs from
+        # other pending entities — keep the orphan reconciler no-op-safe here
+        # and let prune_expired_pending handle the legacy ``pending`` path.
+        return 0
+
     async def prune_expired_pending(self, grace_period_days: int = 7) -> int:
         cutoff = (datetime.now(tz=UTC) - timedelta(days=grace_period_days)).isoformat()
         resp = await self._execute_with_space(
@@ -1412,6 +1457,12 @@ class NebulaStore:
             "media_deleted": media_deleted,
             "entities_deleted": entities_deleted + orphans_deleted,
         }
+
+    async def delete_channel_wiki_graph(self, channel_id: str) -> int:
+        # No-op for the Nebula backend — the unified wiki+graph redesign
+        # writes :WikiPage nodes only to Neo4j. Return 0 to satisfy the
+        # GraphStore protocol contract without issuing any nGQL.
+        return 0
 
     # ------------------------------------------------------------------
     # Entity-registry support

--- a/src/beever_atlas/stores/neo4j_store.py
+++ b/src/beever_atlas/stores/neo4j_store.py
@@ -588,9 +588,7 @@ class Neo4jStore:
                 # entities back) and as a top-level node property (for
                 # Cypher filtering by ``prune_stub_orphans`` and the
                 # heal-path). See ``upsert_entity`` heal-path for details.
-                stub_props = (
-                    '{"stub": true, "reason": "rel_endpoint", "awaiting_type": true}'
-                )
+                stub_props = '{"stub": true, "reason": "rel_endpoint", "awaiting_type": true}'
                 result = await session.run(
                     """
                     MERGE (a_raw:Entity {name: $source, type: 'Unresolved', scope: 'global'})
@@ -977,8 +975,7 @@ class Neo4jStore:
         """
         async with self._driver.session() as session:
             result = await session.run(
-                "MATCH (w:WikiPage {channel_id: $channel_id}) "
-                "DETACH DELETE w RETURN count(w) AS n",
+                "MATCH (w:WikiPage {channel_id: $channel_id}) DETACH DELETE w RETURN count(w) AS n",
                 channel_id=channel_id,
             )
             record = await result.single()
@@ -1292,13 +1289,10 @@ class Neo4jStore:
         RETURN target_name AS name, collect(ctx) AS contexts
         """
         async with self._driver.session() as session:
-            result = await session.run(
-                query, names=names, limit_per_name=limit_per_name
-            )
+            result = await session.run(query, names=names, limit_per_name=limit_per_name)
             records = await result.data()
         return {
-            row.get("name", ""): [c for c in (row.get("contexts") or []) if c]
-            for row in records
+            row.get("name", ""): [c for c in (row.get("contexts") or []) if c] for row in records
         }
 
     async def mark_unresolved_attempt(

--- a/src/beever_atlas/stores/neo4j_store.py
+++ b/src/beever_atlas/stores/neo4j_store.py
@@ -125,6 +125,15 @@ class Neo4jStore:
                 "CREATE INDEX event_weaviate_id IF NOT EXISTS FOR (ev:Event) ON (ev.weaviate_id)"
             )
             await session.run("CREATE INDEX media_url IF NOT EXISTS FOR (m:Media) ON (m.url)")
+            # Parallel index on the new ``(channel_id, target_lang, slug)``
+            # composite that upsert_wiki_page_node now MERGEs on, so the
+            # MERGE remains O(1). The legacy ``(channel_id, slug)`` index
+            # (if present from earlier deployments) is left alone — it
+            # still services any pre-existing rows.
+            await session.run(
+                "CREATE INDEX wiki_page_channel_lang_slug IF NOT EXISTS "
+                "FOR (w:WikiPage) ON (w.channel_id, w.target_lang, w.slug)"
+            )
             await session.run("MATCH (e:Entity) WHERE e.aliases IS NULL SET e.aliases = []")
             await session.run("MATCH (e:Entity) WHERE e.status IS NULL SET e.status = 'active'")
 
@@ -274,11 +283,127 @@ class Neo4jStore:
         """MERGE an Entity node by name+type (and channel_id for channel scope).
 
         Returns the node element ID.
+
+        Symmetric heal-path: for typed writes (``entity.type != 'Unresolved'``),
+        after the typed MERGE we look for every sibling row sharing
+        ``(name, scope)`` whose type is ``Unresolved`` or ``Topic`` and
+        absorb them into the typed row via
+        ``apoc.refactor.mergeNodes([typed] + sibs, {properties: 'discard',
+        mergeRels: true})``. This collapses parallel rows created by the
+        in-Cypher stub MERGE paths in
+        :meth:`_upsert_relationship_with_stub_flag` and
+        :meth:`batch_create_episodic_links`, regardless of which write
+        arrives first. ``mergeRels: true`` also dedupes parallel edges
+        (e.g., two ``MENTIONED_IN→Event(X)`` edges collapse into one).
+        ``properties: 'discard'`` keeps the typed row's properties
+        authoritative; stub flags such as ``awaiting_type`` get dropped.
         """
         now_iso = datetime.now(tz=UTC).isoformat()
         props_json = json.dumps(entity.properties)
 
         async with self._driver.session() as session:
+            if entity.type != "Unresolved":
+                # Symmetric heal: MERGE the typed row, then absorb every
+                # Unresolved/Topic sibling for the same (name, scope) into
+                # it via apoc.refactor.mergeNodes. The CASE guard avoids
+                # calling mergeNodes with a single-element list when no
+                # stubs exist (APOC emits a noisy log line otherwise).
+                if entity.scope == "channel" and entity.channel_id:
+                    heal_result = await session.run(
+                        """
+                        MERGE (typed:Entity {name: $name, type: $type, channel_id: $channel_id})
+                          ON CREATE SET
+                            typed.scope             = $scope,
+                            typed.properties        = $properties,
+                            typed.aliases           = $aliases,
+                            typed.source_message_id = $source_message_id,
+                            typed.message_ts        = $message_ts,
+                            typed.status            = $status,
+                            typed.pending_since     = $pending_since,
+                            typed.created_at        = $now,
+                            typed.updated_at        = $now
+                          ON MATCH SET
+                            typed.scope             = $scope,
+                            typed.properties        = $properties,
+                            typed.aliases           = $aliases,
+                            typed.source_message_id = $source_message_id,
+                            typed.message_ts        = $message_ts,
+                            typed.updated_at        = $now
+                        WITH typed
+                        OPTIONAL MATCH (sib:Entity {name: $name, scope: $scope})
+                          WHERE sib.type IN ['Unresolved', 'Topic']
+                            AND elementId(sib) <> elementId(typed)
+                        WITH typed, collect(sib) AS sibs
+                        CALL apoc.refactor.mergeNodes(
+                          CASE WHEN size(sibs) > 0 THEN [typed] + sibs ELSE [typed] END,
+                          {properties: 'discard', mergeRels: true}
+                        ) YIELD node
+                        RETURN elementId(node) AS eid
+                        """,
+                        name=entity.name,
+                        type=entity.type,
+                        channel_id=entity.channel_id,
+                        scope=entity.scope,
+                        properties=props_json,
+                        aliases=entity.aliases,
+                        source_message_id=entity.source_message_id,
+                        message_ts=entity.message_ts,
+                        status=entity.status,
+                        pending_since=entity.pending_since.isoformat()
+                        if entity.pending_since
+                        else None,
+                        now=now_iso,
+                    )
+                else:
+                    heal_result = await session.run(
+                        """
+                        MERGE (typed:Entity {name: $name, type: $type, scope: 'global'})
+                          ON CREATE SET
+                            typed.channel_id        = null,
+                            typed.properties        = $properties,
+                            typed.aliases           = $aliases,
+                            typed.source_message_id = $source_message_id,
+                            typed.message_ts        = $message_ts,
+                            typed.status            = $status,
+                            typed.pending_since     = $pending_since,
+                            typed.created_at        = $now,
+                            typed.updated_at        = $now
+                          ON MATCH SET
+                            typed.properties        = $properties,
+                            typed.aliases           = $aliases,
+                            typed.source_message_id = $source_message_id,
+                            typed.message_ts        = $message_ts,
+                            typed.updated_at        = $now
+                        WITH typed
+                        OPTIONAL MATCH (sib:Entity {name: $name, scope: 'global'})
+                          WHERE sib.type IN ['Unresolved', 'Topic']
+                            AND elementId(sib) <> elementId(typed)
+                        WITH typed, collect(sib) AS sibs
+                        CALL apoc.refactor.mergeNodes(
+                          CASE WHEN size(sibs) > 0 THEN [typed] + sibs ELSE [typed] END,
+                          {properties: 'discard', mergeRels: true}
+                        ) YIELD node
+                        RETURN elementId(node) AS eid
+                        """,
+                        name=entity.name,
+                        type=entity.type,
+                        properties=props_json,
+                        aliases=entity.aliases,
+                        source_message_id=entity.source_message_id,
+                        message_ts=entity.message_ts,
+                        status=entity.status,
+                        pending_since=entity.pending_since.isoformat()
+                        if entity.pending_since
+                        else None,
+                        now=now_iso,
+                    )
+                record = await heal_result.single()
+                return record["eid"]  # type: ignore[index]
+
+            # Unresolved write — preserve the legacy stub-creation MERGE so
+            # the in-Cypher relationship/episodic-link stub paths keep
+            # working. Typed writes will later absorb these via the
+            # symmetric heal above.
             if entity.scope == "channel" and entity.channel_id:
                 result = await session.run(
                     """
@@ -417,11 +542,14 @@ class Neo4jStore:
         flag (PR-2):
 
         * ``true`` (default) — uses ``MERGE`` on both endpoint entities. If
-          an endpoint name does not exist as ``(name, 'Topic', 'global')``
+          an endpoint name does not exist as ``(name, 'Unresolved', 'global')``
           a stub Entity is auto-created with ``properties`` containing
-          ``"stub": true, "reason": "rel_endpoint"``. The composite UNIQUE
-          constraint at ``(name, type, scope)`` serialises concurrent stub
-          creation under racing batches.
+          ``"stub": true, "reason": "rel_endpoint", "awaiting_type": true``
+          plus a top-level ``awaiting_type=true`` node property. A later
+          typed ``upsert_entity`` for the same name promotes the row in
+          place via the heal-path (see :meth:`upsert_entity`). The
+          composite UNIQUE constraint at ``(name, type, scope)``
+          serialises concurrent stub creation under racing batches.
         * ``false`` — legacy ``MATCH`` semantics; relationships referencing
           unknown endpoints are silently skipped and a warning is logged.
         """
@@ -451,28 +579,59 @@ class Neo4jStore:
                 # REMOVE) tripped a Neo4j 5+ Cypher syntax error around the
                 # WITH/REMOVE/CALL fence. This pure-MERGE form avoids that
                 # by computing the count from a property already being set.
-                stub_props = '{"stub": true, "reason": "rel_endpoint"}'
+                # Stubs are typed ``Unresolved`` (backend-only synthetic
+                # type, never emitted by the LLM) plus
+                # ``awaiting_type=true`` so a subsequent typed
+                # ``upsert_entity`` for the same name can promote the row
+                # in place. The flag lives BOTH inside the JSON
+                # ``properties`` string (for application code that reads
+                # entities back) and as a top-level node property (for
+                # Cypher filtering by ``prune_stub_orphans`` and the
+                # heal-path). See ``upsert_entity`` heal-path for details.
+                stub_props = (
+                    '{"stub": true, "reason": "rel_endpoint", "awaiting_type": true}'
+                )
                 result = await session.run(
                     """
-                    MERGE (a:Entity {name: $source, type: 'Topic', scope: 'global'})
+                    MERGE (a_raw:Entity {name: $source, type: 'Unresolved', scope: 'global'})
                       ON CREATE SET
-                        a.channel_id = null,
-                        a.properties = $stub_props,
-                        a.aliases    = [],
-                        a.status     = 'active',
-                        a.created_at = $now,
-                        a.updated_at = $now
-                    MERGE (b:Entity {name: $target, type: 'Topic', scope: 'global'})
+                        a_raw.channel_id = null,
+                        a_raw.properties = $stub_props,
+                        a_raw.aliases    = [],
+                        a_raw.status     = 'active',
+                        a_raw.awaiting_type = true,
+                        a_raw.created_at = $now,
+                        a_raw.updated_at = $now
+                    WITH a_raw
+                    OPTIONAL MATCH (a_typed:Entity {name: $source, scope: 'global'})
+                      WHERE NOT a_typed.type IN ['Unresolved', 'Topic']
+                        AND elementId(a_typed) <> elementId(a_raw)
+                    WITH a_raw, head(collect(a_typed)) AS a_typed_pick
+                    CALL apoc.refactor.mergeNodes(
+                      CASE WHEN a_typed_pick IS NOT NULL THEN [a_typed_pick, a_raw] ELSE [a_raw] END,
+                      {properties: 'discard', mergeRels: true}
+                    ) YIELD node AS a
+                    MERGE (b_raw:Entity {name: $target, type: 'Unresolved', scope: 'global'})
                       ON CREATE SET
-                        b.channel_id = null,
-                        b.properties = $stub_props,
-                        b.aliases    = [],
-                        b.status     = 'active',
-                        b.created_at = $now,
-                        b.updated_at = $now
+                        b_raw.channel_id = null,
+                        b_raw.properties = $stub_props,
+                        b_raw.aliases    = [],
+                        b_raw.status     = 'active',
+                        b_raw.awaiting_type = true,
+                        b_raw.created_at = $now,
+                        b_raw.updated_at = $now
+                    WITH a, b_raw
+                    OPTIONAL MATCH (b_typed:Entity {name: $target, scope: 'global'})
+                      WHERE NOT b_typed.type IN ['Unresolved', 'Topic']
+                        AND elementId(b_typed) <> elementId(b_raw)
+                    WITH a, b_raw, head(collect(b_typed)) AS b_typed_pick
+                    CALL apoc.refactor.mergeNodes(
+                      CASE WHEN b_typed_pick IS NOT NULL THEN [b_typed_pick, b_raw] ELSE [b_raw] END,
+                      {properties: 'discard', mergeRels: true}
+                    ) YIELD node AS b
                     WITH a, b,
-                         (CASE WHEN a.created_at = $now THEN 1 ELSE 0 END
-                          + CASE WHEN b.created_at = $now THEN 1 ELSE 0 END) AS stubs_created
+                         (CASE WHEN a.type = 'Unresolved' AND a.created_at = $now THEN 1 ELSE 0 END
+                          + CASE WHEN b.type = 'Unresolved' AND b.created_at = $now THEN 1 ELSE 0 END) AS stubs_created
                     CALL apoc.merge.relationship(
                         a,
                         $rel_type,
@@ -806,6 +965,25 @@ class Neo4jStore:
             "entities_deleted": entities_deleted + orphans_deleted,
         }
 
+    async def delete_channel_wiki_graph(self, channel_id: str) -> int:
+        """Drop ``:WikiPage`` nodes (and their relationships) for a channel.
+
+        Per-channel reset wipes wiki rows in MongoDB; the matching graph
+        nodes (with their ``REFERENCES_ENTITY`` / ``REFERENCES`` edges)
+        would otherwise linger as dangling references. ``DETACH DELETE``
+        removes the page node plus every incident edge in one statement.
+        Kept separate from :meth:`delete_channel_data` so that method's
+        Entity/Event/Media semantics stay unchanged.
+        """
+        async with self._driver.session() as session:
+            result = await session.run(
+                "MATCH (w:WikiPage {channel_id: $channel_id}) "
+                "DETACH DELETE w RETURN count(w) AS n",
+                channel_id=channel_id,
+            )
+            record = await result.single()
+            return int(record["n"]) if record else 0
+
     # ------------------------------------------------------------------
     # Read
     # ------------------------------------------------------------------
@@ -928,7 +1106,7 @@ class Neo4jStore:
     async def list_relationships(
         self,
         channel_id: str | None = None,
-        limit: int = 200,
+        limit: int = 1000,
     ) -> list[GraphRelationship]:
         """Return relationships between entities, optionally scoped to a channel.
 
@@ -949,7 +1127,8 @@ class Neo4jStore:
         query = (
             f"MATCH (a:Entity)-[r]->(b:Entity) {where} "  # noqa: S608
             "RETURN a.name AS src, b.name AS tgt, type(r) AS rel_type, "
-            "r.confidence AS confidence, r.context AS context "
+            "r.confidence AS confidence, r.context AS context, "
+            "r.valid_from AS valid_from "
             "LIMIT $limit"
         )
         async with self._driver.session() as session:
@@ -964,9 +1143,197 @@ class Neo4jStore:
                     target=row.get("tgt", ""),
                     confidence=float(row.get("confidence") or 0.0),
                     context=row.get("context") or "",
+                    valid_from=row.get("valid_from"),
                 )
             )
         return rels
+
+    async def list_co_mention_edges(
+        self,
+        channel_id: str,
+        min_shared: int = 2,
+        limit: int = 500,
+    ) -> list[GraphRelationship]:
+        """Return synthetic CO_MENTIONED edges between entity pairs that
+        share at least ``min_shared`` ``Event`` nodes in this channel.
+
+        Used by the Memory Graph UI to surface implicit co-occurrence
+        between entities when explicit LLM-extracted relationships are
+        sparse (common in casual channels). Each pair appears once,
+        ordered by ``elementId(a) < elementId(b)`` so the same pair is
+        not returned in both directions.
+
+        Confidence is set to ``min(1.0, shared / 5.0)`` so the UI can
+        scale opacity / edge weight. Verb is the synthetic constant
+        ``CO_MENTIONED``. ``valid_from`` is the most-recent shared event
+        timestamp (so the time-window filter still drops stale pairs).
+        """
+        if not channel_id:
+            return []
+        async with self._driver.session() as session:
+            result = await session.run(
+                """
+                MATCH (a:Entity)-[:MENTIONED_IN]->(ev:Event {channel_id: $channel_id})
+                MATCH (b:Entity)-[:MENTIONED_IN]->(ev)
+                WHERE elementId(a) < elementId(b)
+                WITH a, b, count(ev) AS shared, max(ev.message_ts) AS most_recent
+                WHERE shared >= $min_shared
+                RETURN a.name AS src, b.name AS tgt, shared, most_recent
+                ORDER BY shared DESC
+                LIMIT $limit
+                """,
+                channel_id=channel_id,
+                min_shared=min_shared,
+                limit=limit,
+            )
+            records = await result.data()
+        out: list[GraphRelationship] = []
+        for row in records:
+            shared = int(row.get("shared") or 0)
+            confidence = min(1.0, shared / 5.0)
+            out.append(
+                GraphRelationship(
+                    type="CO_MENTIONED",
+                    source=row.get("src", ""),
+                    target=row.get("tgt", ""),
+                    confidence=confidence,
+                    context=f"co-mentioned in {shared} events",
+                    valid_from=row.get("most_recent"),
+                )
+            )
+        return out
+
+    # ------------------------------------------------------------------
+    # Unresolved-classifier helpers (PR-A)
+    # ------------------------------------------------------------------
+
+    async def list_unresolved_stubs(
+        self,
+        channel_id: str | None = None,
+        limit: int = 500,
+    ) -> list[dict[str, Any]]:
+        """Return Unresolved stub entities awaiting type classification.
+
+        Scoping (A-2 fix): when ``channel_id`` is provided, accepts a
+        stub that either has ``channel_id`` set directly OR is reachable
+        via a ``MENTIONED_IN→Event{channel_id}`` edge — mirrors the
+        per-channel pivot in :meth:`list_relationships` so workspace-
+        wide stubs without an incident event in the channel are filtered
+        out.
+
+        Excludes stubs with ``classifier_attempts >= 2`` (idempotency
+        gate — see :meth:`mark_unresolved_attempt`). Caller layers a
+        ``classifier_low_confidence_at`` recency check in Python so the
+        7-day TTL stays operator-tunable without a redeploy.
+        """
+        if channel_id is not None:
+            where = (
+                "WHERE e.type = 'Unresolved' "
+                "AND e.awaiting_type = true "
+                "AND coalesce(e.classifier_attempts, 0) < 2 "
+                "AND (e.channel_id = $channel_id "
+                "OR EXISTS { MATCH (e)-[:MENTIONED_IN]->(ev:Event) "
+                "WHERE ev.channel_id = $channel_id })"
+            )
+            params: dict[str, Any] = {"channel_id": channel_id, "limit": limit}
+        else:
+            where = (
+                "WHERE e.type = 'Unresolved' "
+                "AND e.awaiting_type = true "
+                "AND coalesce(e.classifier_attempts, 0) < 2"
+            )
+            params = {"limit": limit}
+        query = (
+            f"MATCH (e:Entity) {where} "  # noqa: S608
+            "RETURN e.name AS name, e.scope AS scope, "
+            "e.channel_id AS channel_id, "
+            "coalesce(e.classifier_attempts, 0) AS attempts, "
+            "e.classifier_low_confidence_at AS low_confidence_at "
+            "ORDER BY e.created_at ASC "
+            "LIMIT $limit"
+        )
+        async with self._driver.session() as session:
+            result = await session.run(query, **params)
+            records = await result.data()
+        return [
+            {
+                "name": row.get("name", ""),
+                "scope": row.get("scope") or "global",
+                "channel_id": row.get("channel_id"),
+                "attempts": int(row.get("attempts") or 0),
+                "low_confidence_at": row.get("low_confidence_at"),
+            }
+            for row in records
+        ]
+
+    async def fetch_incident_contexts_batch(
+        self,
+        names: list[str],
+        limit_per_name: int = 3,
+    ) -> dict[str, list[str]]:
+        """Return up to ``limit_per_name`` incident-edge contexts per
+        candidate name in a SINGLE Cypher round-trip (A-4 fix).
+
+        Used by the unresolved classifier to gather the disambiguating
+        signal for each stub.  Empty/missing contexts are filtered out
+        in Cypher so the LLM never sees zero-signal rows.
+        """
+        if not names:
+            return {}
+        query = """
+        UNWIND $names AS target_name
+        CALL (target_name) {
+          MATCH (e:Entity {name: target_name})-[r]-(other:Entity)
+          WHERE r.context IS NOT NULL AND r.context <> ''
+          RETURN r.context AS ctx
+          ORDER BY coalesce(r.valid_from, '') DESC
+          LIMIT $limit_per_name
+        }
+        RETURN target_name AS name, collect(ctx) AS contexts
+        """
+        async with self._driver.session() as session:
+            result = await session.run(
+                query, names=names, limit_per_name=limit_per_name
+            )
+            records = await result.data()
+        return {
+            row.get("name", ""): [c for c in (row.get("contexts") or []) if c]
+            for row in records
+        }
+
+    async def mark_unresolved_attempt(
+        self,
+        name: str,
+        scope: str,
+        channel_id: str | None,
+    ) -> None:
+        """Bump ``classifier_attempts`` and stamp
+        ``classifier_low_confidence_at = now`` on the stub.
+
+        Idempotent — repeated calls just increment. Channel-scoped
+        stubs match by ``(name, scope='channel', channel_id)``; global
+        stubs match by ``(name, scope='global')``.
+        """
+        now_iso = datetime.now(tz=UTC).isoformat()
+        if scope == "channel" and channel_id:
+            query = (
+                "MATCH (e:Entity {name: $name, scope: 'channel', "
+                "channel_id: $channel_id}) "
+                "WHERE e.type = 'Unresolved' "
+                "SET e.classifier_attempts = coalesce(e.classifier_attempts, 0) + 1, "
+                "e.classifier_low_confidence_at = $now"
+            )
+            params = {"name": name, "channel_id": channel_id, "now": now_iso}
+        else:
+            query = (
+                "MATCH (e:Entity {name: $name, scope: 'global'}) "
+                "WHERE e.type = 'Unresolved' "
+                "SET e.classifier_attempts = coalesce(e.classifier_attempts, 0) + 1, "
+                "e.classifier_low_confidence_at = $now"
+            )
+            params = {"name": name, "now": now_iso}
+        async with self._driver.session() as session:
+            await session.run(query, **params)
 
     async def list_media_relationships(
         self,
@@ -1274,6 +1641,40 @@ class Neo4jStore:
             record = await result.single()
         return int(record["n"]) if record else 0
 
+    async def prune_stub_orphans(self, ttl_hours: int = 24) -> int:
+        """Delete Unresolved stub entities that have no edges and are older than ``ttl_hours``.
+
+        Stubs are created by :meth:`_upsert_relationship_with_stub_flag`
+        and :meth:`batch_create_episodic_links` for unknown endpoint
+        names. They are typed ``Unresolved`` or (in legacy syncs) ``Topic``
+        with ``status='active'`` (so ``prune_expired_pending`` does not
+        catch them). Once a stub has any incident edge it is kept — a
+        later typed write absorbs it via the ``upsert_entity`` symmetric
+        heal-path. Only truly orphaned Unresolved-or-Topic stubs older
+        than the TTL are purged.
+
+        Note: the ``awaiting_type`` flag is intentionally NOT required —
+        legacy Topic stubs from pre-fix syncs do not have that flag set.
+        The remaining filters (no edges, older than cutoff) are
+        sufficient guard rails for edge-less stubs.
+
+        Returns the number purged.
+        """
+        from datetime import timedelta
+
+        cutoff = (datetime.now(tz=UTC) - timedelta(hours=ttl_hours)).isoformat()
+        async with self._driver.session() as session:
+            result = await session.run(
+                "MATCH (e:Entity) "
+                "WHERE e.type IN ['Unresolved', 'Topic'] "
+                "AND NOT EXISTS { MATCH (e)--() } "
+                "AND e.created_at < $cutoff "
+                "DETACH DELETE e RETURN count(e) AS n",
+                cutoff=cutoff,
+            )
+            record = await result.single()
+        return int(record["n"]) if record else 0
+
     async def fuzzy_match_entity(self, name: str, threshold: float = 0.8) -> list[GraphEntity]:
         """Find entities whose name is similar to `name` using Jaro-Winkler distance.
 
@@ -1300,12 +1701,20 @@ class Neo4jStore:
     # ------------------------------------------------------------------
 
     async def find_entity_by_name_or_alias(self, name: str) -> str | None:
-        """Find an entity by exact name or alias.  Returns canonical name."""
+        """Find an entity by exact name or alias.  Returns canonical name.
+
+        Prefers typed siblings over Unresolved/Topic stubs so that wiki
+        citation resolution paths bind to the authoritative row when both
+        a typed entity and a stub coexist for the same name.
+        """
         async with self._driver.session() as session:
             result = await session.run(
                 "MATCH (e:Entity) "
                 "WHERE e.name = $name OR $name IN coalesce(e.aliases, []) "
-                "RETURN e.name AS canonical LIMIT 1",
+                "RETURN e.name AS canonical "
+                "ORDER BY CASE WHEN e.type IN ['Unresolved', 'Topic'] THEN 1 ELSE 0 END, "
+                "         e.updated_at DESC "
+                "LIMIT 1",
                 name=name,
             )
             record = await result.single()
@@ -1418,10 +1827,12 @@ class Neo4jStore:
         flag (PR-2):
 
         * ``true`` (default) — MERGEs the Entity by
-          ``(name, 'Topic', 'global')`` so unknown entity_tags from a
+          ``(name, 'Unresolved', 'global')`` so unknown entity_tags from a
           fact (whose owning entity may not have committed yet) still
           link to the Event via a stub Entity. Stubs are tagged
-          ``{"stub": true, "reason": "episodic_link"}``.
+          ``{"stub": true, "reason": "episodic_link", "awaiting_type": true}``.
+          A later typed ``upsert_entity`` for the same name promotes
+          the row in place via the heal-path.
         * ``false`` — legacy MATCH semantics; links to unknown entity
           names are silently dropped.
         """
@@ -1432,16 +1843,33 @@ class Neo4jStore:
         use_merge = get_settings().neo4j_relationship_stub_endpoints
         async with self._driver.session() as session:
             if use_merge:
+                # Per link: MERGE the Unresolved stub, then immediately
+                # absorb it into any existing typed sibling for the same
+                # name via apoc.refactor.mergeNodes — same symmetric-heal
+                # pattern as upsert_entity and _upsert_relationship_with_stub_flag.
+                # The MENTIONED_IN edge then attaches to the surviving node
+                # (typed sibling if present, else the just-created stub),
+                # keeping the channel-scoped view consistent.
                 result = await session.run(
                     "UNWIND $links AS link "
-                    "MERGE (e:Entity {name: link.entity_name, type: 'Topic', scope: 'global'}) "
+                    "MERGE (e_raw:Entity {name: link.entity_name, type: 'Unresolved', scope: 'global'}) "
                     "  ON CREATE SET "
-                    "    e.channel_id = null, "
-                    '    e.properties = \'{"stub": true, "reason": "episodic_link"}\', '
-                    "    e.aliases    = [], "
-                    "    e.status     = 'active', "
-                    "    e.created_at = toString(datetime()), "
-                    "    e.updated_at = toString(datetime()) "
+                    "    e_raw.channel_id = null, "
+                    '    e_raw.properties = \'{"stub": true, "reason": "episodic_link", "awaiting_type": true}\', '
+                    "    e_raw.aliases    = [], "
+                    "    e_raw.status     = 'active', "
+                    "    e_raw.awaiting_type = true, "
+                    "    e_raw.created_at = toString(datetime()), "
+                    "    e_raw.updated_at = toString(datetime()) "
+                    "WITH link, e_raw "
+                    "OPTIONAL MATCH (e_typed:Entity {name: link.entity_name, scope: 'global'}) "
+                    "  WHERE NOT e_typed.type IN ['Unresolved', 'Topic'] "
+                    "    AND elementId(e_typed) <> elementId(e_raw) "
+                    "WITH link, e_raw, head(collect(e_typed)) AS e_typed_pick "
+                    "CALL apoc.refactor.mergeNodes( "
+                    "  CASE WHEN e_typed_pick IS NOT NULL THEN [e_typed_pick, e_raw] ELSE [e_raw] END, "
+                    "  {properties: 'discard', mergeRels: true} "
+                    ") YIELD node AS e "
                     "MERGE (ep:Event {weaviate_id: link.weaviate_fact_id}) "
                     "  ON CREATE SET ep.message_ts = link.message_ts, ep.channel_id = link.channel_id "
                     "MERGE (e)-[:MENTIONED_IN]->(ep) "
@@ -1531,13 +1959,16 @@ class Neo4jStore:
         title: str,
         version: int,
         last_updated: datetime,
+        target_lang: str = "en",
     ) -> str:
-        """MERGE a WikiPage node keyed by ``(channel_id, slug)``.
+        """MERGE a WikiPage node keyed by ``(channel_id, target_lang, slug)``.
 
         Returns the node element ID. Idempotent — the maintainer calls
         this on every successful ``apply_update`` so existing nodes
         update their ``kind``/``title``/``version``/``last_updated``
-        in place.
+        in place. ``target_lang`` is part of the MERGE key so ``:en``
+        and ``:zh-HK`` runs against the same ``page_id`` do not stomp
+        each other.
         """
         now_iso = datetime.now(tz=UTC).isoformat()
         last_updated_iso = (
@@ -1546,7 +1977,7 @@ class Neo4jStore:
         async with self._driver.session() as session:
             result = await session.run(
                 """
-                MERGE (w:WikiPage {channel_id: $channel_id, slug: $slug})
+                MERGE (w:WikiPage {channel_id: $channel_id, target_lang: $target_lang, slug: $slug})
                 ON CREATE SET
                     w.kind         = $kind,
                     w.title        = $title,
@@ -1563,6 +1994,7 @@ class Neo4jStore:
                 RETURN elementId(w) AS eid
                 """,
                 channel_id=channel_id,
+                target_lang=target_lang,
                 slug=slug,
                 kind=kind,
                 title=title,
@@ -1579,25 +2011,60 @@ class Neo4jStore:
         channel_id: str,
         src_slug: str,
         dst_slug: str,
+        target_lang: str = "en",
     ) -> None:
         """MERGE a (:WikiPage)-[:REFERENCES]->(:WikiPage) edge.
 
-        Idempotent. Both endpoints are MERGEd by ``(channel_id, slug)``
-        so calling this with a destination slug whose node does not yet
-        exist still succeeds — Neo4j creates a placeholder node that
-        ``upsert_wiki_page_node`` will subsequently enrich on the next
-        apply_update against that page.
+        Idempotent. Both endpoints are MERGEd by
+        ``(channel_id, target_lang, slug)`` so calling this with a
+        destination slug whose node does not yet exist still succeeds —
+        Neo4j creates a placeholder node that ``upsert_wiki_page_node``
+        will subsequently enrich on the next apply_update against that
+        page.
         """
         async with self._driver.session() as session:
             await session.run(
                 """
-                MERGE (src:WikiPage {channel_id: $channel_id, slug: $src_slug})
-                MERGE (dst:WikiPage {channel_id: $channel_id, slug: $dst_slug})
+                MERGE (src:WikiPage {channel_id: $channel_id, target_lang: $target_lang, slug: $src_slug})
+                MERGE (dst:WikiPage {channel_id: $channel_id, target_lang: $target_lang, slug: $dst_slug})
                 MERGE (src)-[:REFERENCES]->(dst)
                 """,
                 channel_id=channel_id,
+                target_lang=target_lang,
                 src_slug=src_slug,
                 dst_slug=dst_slug,
+            )
+
+    async def upsert_wiki_reference_entity_edge(
+        self,
+        *,
+        channel_id: str,
+        target_lang: str,
+        src_slug: str,
+        entity_name: str,
+    ) -> None:
+        """MERGE a (:WikiPage)-[:REFERENCES_ENTITY]->(:Entity) edge.
+
+        Idempotent. The WikiPage is MATCHed by
+        ``(channel_id, target_lang, slug)`` — it must already exist
+        (the caller invokes :meth:`upsert_wiki_page_node` first). The
+        Entity is also MATCHed (not MERGEd) so a wikilink targeting a
+        name with no real entity behind it does not manufacture a stub
+        — the edge is silently dropped instead. The caller is expected
+        to resolve the title via :meth:`find_entity_by_name_or_alias`
+        before invoking this method.
+        """
+        async with self._driver.session() as session:
+            await session.run(
+                """
+                MATCH (src:WikiPage {channel_id: $channel_id, target_lang: $target_lang, slug: $src_slug})
+                MATCH (e:Entity {name: $entity_name})
+                MERGE (src)-[:REFERENCES_ENTITY]->(e)
+                """,
+                channel_id=channel_id,
+                target_lang=target_lang,
+                src_slug=src_slug,
+                entity_name=entity_name,
             )
 
     async def get_wiki_graph(self, channel_id: str) -> dict[str, Any]:

--- a/src/beever_atlas/stores/null_graph.py
+++ b/src/beever_atlas/stores/null_graph.py
@@ -61,6 +61,43 @@ class NullGraphStore:
     async def prune_expired_pending(self, grace_period_days: int = 7) -> int:
         return 0
 
+    async def prune_stub_orphans(self, ttl_hours: int = 24) -> int:
+        return 0
+
+    async def list_co_mention_edges(
+        self,
+        channel_id: str,
+        min_shared: int = 2,
+        limit: int = 500,
+    ) -> list[GraphRelationship]:
+        return []
+
+    # ------------------------------------------------------------------
+    # Unresolved-classifier helpers (PR-A) — no-op for the null backend
+    # ------------------------------------------------------------------
+
+    async def list_unresolved_stubs(
+        self,
+        channel_id: str | None = None,
+        limit: int = 500,
+    ) -> list[dict[str, Any]]:
+        return []
+
+    async def fetch_incident_contexts_batch(
+        self,
+        names: list[str],
+        limit_per_name: int = 3,
+    ) -> dict[str, list[str]]:
+        return {}
+
+    async def mark_unresolved_attempt(
+        self,
+        name: str,
+        scope: str,
+        channel_id: str | None,
+    ) -> None:
+        return None
+
     # ------------------------------------------------------------------
     # Relationship CRUD
     # ------------------------------------------------------------------
@@ -162,6 +199,10 @@ class NullGraphStore:
         # uses DETACH DELETE so it has no separate `relationships_deleted`
         # key — the null shape mirrors that.
         return {"entities_deleted": 0, "events_deleted": 0, "media_deleted": 0}
+
+    async def delete_channel_wiki_graph(self, channel_id: str) -> int:
+        # No-op — the null backend stores no WikiPage nodes.
+        return 0
 
     # ------------------------------------------------------------------
     # Entity-registry support

--- a/tests/agents/ingestion/test_persister_stub_gate.py
+++ b/tests/agents/ingestion/test_persister_stub_gate.py
@@ -1,0 +1,331 @@
+"""Tests for the persister stub-seeding gate.
+
+The gate lives inline at ``persister.py:~449-560`` (post-heal-path
+refactor). Three guarantees:
+
+  1. Relationships with confidence < 0.8 do not seed stubs (gate floor).
+  2. Relationships where BOTH endpoints are unknown (not in the typed
+     entity set) drop the rel and increment
+     ``relationships_dropped_total`` with reason ``both_endpoints_unknown``.
+  3. Relationships with one known + one unknown endpoint produce one
+     ``Unresolved`` stub for the unknown side; the counter is NOT
+     incremented for these rels.
+
+The tests exercise the gate by driving ``PersisterAgent._run_async_impl``
+with a minimal ``InvocationContext`` and fully mocked stores so we can
+assert exactly which ``batch_upsert_entities`` calls land.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+# ── helpers ─────────────────────────────────────────────────────────────────
+
+
+def _make_ctx(
+    *,
+    embedded_facts: list[dict[str, Any]] | None = None,
+    validated_entities: dict[str, Any] | None = None,
+) -> SimpleNamespace:
+    """Construct a minimal ``InvocationContext``-like object the
+    PersisterAgent expects. We only need the fields it reads.
+    """
+    state: dict[str, Any] = {
+        "sync_job_id": "job-test",
+        "channel_id": "C-test",
+        "batch_num": 1,
+        "source_language": "en",
+        "embedded_facts": embedded_facts or [],
+        "validated_entities": validated_entities or {"entities": [], "relationships": []},
+        "skip_graph_writes": False,
+    }
+    session = SimpleNamespace(state=state)
+    return SimpleNamespace(
+        session=session,
+        invocation_id="inv-test",
+    )
+
+
+def _make_stores_mock(
+    *,
+    existing_entity_names: set[str] | None = None,
+) -> tuple[MagicMock, dict[str, list]]:
+    """Build a stub ``StoreClients`` with the methods the persister
+    touches. Returns ``(stores, captured)`` where ``captured`` is a
+    dict-of-lists capturing the args of every interesting call.
+    """
+    existing = existing_entity_names or set()
+    captured: dict[str, list] = {
+        "batch_upsert_entities": [],
+        "batch_upsert_relationships": [],
+        "batch_create_episodic_links": [],
+        "batch_find_entities_by_name": [],
+    }
+
+    stores = MagicMock()
+    # Mongo / outbox path
+    stores.mongodb.create_write_intent = AsyncMock(return_value="intent-test")
+    stores.mongodb.mark_intent_weaviate_done = AsyncMock(return_value=None)
+    stores.mongodb.mark_intent_neo4j_done = AsyncMock(return_value=None)
+    stores.mongodb.mark_intent_complete = AsyncMock(return_value=None)
+
+    # Weaviate
+    async def fake_weaviate_upsert(facts):
+        return [f"wid-{i}" for i in range(len(facts))]
+
+    stores.weaviate.batch_upsert_facts = AsyncMock(side_effect=fake_weaviate_upsert)
+
+    # Entity registry
+    async def fake_compute_name_embeddings_batch(names):
+        return {}
+
+    async def fake_batch_store_name_vectors(items):
+        return 0
+
+    async def fake_store_name_vector(name, vec):
+        return None
+
+    stores.entity_registry.compute_name_embeddings_batch = AsyncMock(
+        side_effect=fake_compute_name_embeddings_batch
+    )
+    stores.entity_registry.batch_store_name_vectors = AsyncMock(
+        side_effect=fake_batch_store_name_vectors
+    )
+    stores.entity_registry.store_name_vector = AsyncMock(side_effect=fake_store_name_vector)
+
+    # Graph
+    async def fake_batch_upsert_entities(entities):
+        captured["batch_upsert_entities"].append(list(entities))
+        return [f"eid-{e.name}" for e in entities]
+
+    async def fake_batch_upsert_relationships(rels, **kwargs):
+        captured["batch_upsert_relationships"].append((list(rels), dict(kwargs)))
+        return [f"rid-{i}" for i in range(len(rels))]
+
+    async def fake_batch_create_episodic_links(links):
+        captured["batch_create_episodic_links"].append(list(links))
+        return len(links)
+
+    async def fake_batch_find_entities_by_name(names):
+        captured["batch_find_entities_by_name"].append(list(names))
+        return set(names) & existing
+
+    async def fake_batch_promote_pending(names):
+        return 0
+
+    async def fake_batch_upsert_media(items):
+        return 0
+
+    async def fake_batch_link_entities_to_media(links):
+        return 0
+
+    stores.graph.batch_upsert_entities = AsyncMock(side_effect=fake_batch_upsert_entities)
+    stores.graph.batch_upsert_relationships = AsyncMock(
+        side_effect=fake_batch_upsert_relationships
+    )
+    stores.graph.batch_create_episodic_links = AsyncMock(
+        side_effect=fake_batch_create_episodic_links
+    )
+    stores.graph.batch_find_entities_by_name = AsyncMock(
+        side_effect=fake_batch_find_entities_by_name
+    )
+    stores.graph.batch_promote_pending = AsyncMock(side_effect=fake_batch_promote_pending)
+    stores.graph.batch_upsert_media = AsyncMock(side_effect=fake_batch_upsert_media)
+    stores.graph.batch_link_entities_to_media = AsyncMock(
+        side_effect=fake_batch_link_entities_to_media
+    )
+
+    return stores, captured
+
+
+async def _run_persister(ctx, stores, monkeypatch):
+    """Wire ``get_stores()`` to the mock and drive the agent."""
+    from beever_atlas.agents.ingestion import persister as persister_mod
+
+    monkeypatch.setattr(persister_mod, "get_stores", lambda: stores)
+    # The persister also imports increment_sync_metric lazily — patch it.
+    captured_metrics: list[tuple[str, str, str, int]] = []
+
+    def fake_increment(channel_id, sync_job_id, metric, delta=1):
+        captured_metrics.append((channel_id, sync_job_id, metric, delta))
+
+    monkeypatch.setattr(
+        "beever_atlas.services.batch_processor.increment_sync_metric",
+        fake_increment,
+    )
+
+    agent = persister_mod.PersisterAgent(name="persister")
+    async for _ in agent._run_async_impl(ctx):
+        pass
+    return captured_metrics
+
+
+# ── 1. Low confidence rels do not seed stubs ────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_low_confidence_relationship_does_not_seed_stubs(monkeypatch):
+    """A relationship with confidence 0.5 is below the gate (0.8). Its
+    endpoint names must NOT be turned into stub entities, even if they
+    appear in fact ``entity_tags``.
+    """
+    facts = [
+        {
+            "memory_text": "Alice may use Redis someday",
+            "entity_tags": ["Alice", "Redis"],
+            "source_message_id": "m1",
+            "message_ts": "1000.0",
+            "channel_id": "C-test",
+            "fact_type": "observation",
+        }
+    ]
+    rels = [
+        {
+            "type": "USES",
+            "source": "Alice",
+            "target": "Redis",
+            "confidence": 0.5,
+        }
+    ]
+    ctx = _make_ctx(
+        embedded_facts=facts,
+        validated_entities={"entities": [], "relationships": rels},
+    )
+    stores, captured = _make_stores_mock()
+    metrics = await _run_persister(ctx, stores, monkeypatch)
+
+    # No stub batch_upsert_entities call: only the initial empty entities
+    # list. (When entities=[] the persister skips the call entirely.)
+    stub_calls = [
+        c for c in captured["batch_upsert_entities"] if any(getattr(e, "name", None) for e in c)
+    ]
+    assert stub_calls == [], (
+        f"expected no stub entities created for low-confidence rel; got: "
+        f"{[[(e.name, e.type) for e in batch] for batch in stub_calls]}"
+    )
+    # The counter for both_endpoints_unknown must NOT fire — the gate
+    # filtered the rel out before the unknown-endpoint check.
+    rel_drop_metrics = [m for m in metrics if m[2] == "relationships_dropped_total"]
+    assert rel_drop_metrics == []
+
+
+# ── 2. Both endpoints unknown drops the rel + increments counter ───────────
+
+
+@pytest.mark.asyncio
+async def test_two_unknown_endpoints_drop_rel_and_increment_counter(monkeypatch):
+    """A high-confidence relationship where both endpoints are unknown
+    (not in the typed entity set returned by extractor + not pre-existing
+    in Neo4j) is dropped from the stub-seed list and increments
+    ``relationships_dropped_total`` with reason ``both_endpoints_unknown``.
+
+    No stub entities should be created.
+    """
+    facts = [
+        {
+            "memory_text": "MysteryA decided MysteryB",
+            "entity_tags": ["MysteryA", "MysteryB"],
+            "source_message_id": "m1",
+            "message_ts": "1000.0",
+            "channel_id": "C-test",
+            "fact_type": "decision",
+        }
+    ]
+    rels = [
+        {
+            "type": "DECIDED",
+            "source": "MysteryA",
+            "target": "MysteryB",
+            "confidence": 0.9,
+        }
+    ]
+    ctx = _make_ctx(
+        embedded_facts=facts,
+        validated_entities={"entities": [], "relationships": rels},
+    )
+    stores, captured = _make_stores_mock(existing_entity_names=set())
+    metrics = await _run_persister(ctx, stores, monkeypatch)
+
+    # No entity created with name MysteryA or MysteryB.
+    all_created_names = {
+        e.name for batch in captured["batch_upsert_entities"] for e in batch
+    }
+    assert "MysteryA" not in all_created_names
+    assert "MysteryB" not in all_created_names
+
+    # The drop counter fired with reason both_endpoints_unknown — we
+    # bundle the reason into the metric name in this implementation.
+    rel_drop_metrics = [m for m in metrics if m[2] == "relationships_dropped_total"]
+    assert rel_drop_metrics, "expected relationships_dropped_total to be incremented"
+    # delta is the count of dropped rels.
+    assert rel_drop_metrics[0][3] >= 1
+
+
+# ── 3. One known + one unknown → one stub, no counter increment ───────────
+
+
+@pytest.mark.asyncio
+async def test_one_unknown_endpoint_creates_one_unresolved_stub(monkeypatch):
+    """A high-confidence relationship with one typed endpoint (Alice as
+    Person) and one unknown endpoint (UnknownProj) creates exactly one
+    stub Entity for the unknown side. The stub is typed ``Unresolved``.
+    The counter for both_endpoints_unknown is NOT incremented.
+    """
+    facts = [
+        {
+            "memory_text": "Alice works on UnknownProj",
+            "entity_tags": ["Alice", "UnknownProj"],
+            "source_message_id": "m1",
+            "message_ts": "1000.0",
+            "channel_id": "C-test",
+            "fact_type": "observation",
+        }
+    ]
+    rels = [
+        {
+            "type": "WORKS_ON",
+            "source": "Alice",
+            "target": "UnknownProj",
+            "confidence": 0.9,
+        }
+    ]
+    entities = [
+        {
+            "name": "Alice",
+            "type": "Person",
+            "scope": "global",
+        }
+    ]
+    ctx = _make_ctx(
+        embedded_facts=facts,
+        validated_entities={"entities": entities, "relationships": rels},
+    )
+    stores, captured = _make_stores_mock(existing_entity_names=set())
+    metrics = await _run_persister(ctx, stores, monkeypatch)
+
+    # The stub-seed call should produce exactly one stub Entity for
+    # ``UnknownProj`` typed ``Unresolved``. The first batch_upsert_entities
+    # call is the typed entities (Alice). The stub call comes later.
+    stub_entities = []
+    for batch in captured["batch_upsert_entities"]:
+        for e in batch:
+            if e.type == "Unresolved":
+                stub_entities.append(e)
+    assert len(stub_entities) == 1, (
+        f"expected exactly 1 Unresolved stub; got {[(e.name, e.type) for e in stub_entities]}"
+    )
+    assert stub_entities[0].name == "UnknownProj"
+    assert stub_entities[0].type == "Unresolved"
+    # Stub property markers.
+    assert stub_entities[0].properties.get("stub") is True
+    assert stub_entities[0].properties.get("awaiting_type") is True
+
+    # Counter NOT incremented for this rel (one endpoint is known).
+    rel_drop_metrics = [m for m in metrics if m[2] == "relationships_dropped_total"]
+    assert rel_drop_metrics == []

--- a/tests/agents/ingestion/test_persister_stub_gate.py
+++ b/tests/agents/ingestion/test_persister_stub_gate.py
@@ -126,9 +126,7 @@ def _make_stores_mock(
         return 0
 
     stores.graph.batch_upsert_entities = AsyncMock(side_effect=fake_batch_upsert_entities)
-    stores.graph.batch_upsert_relationships = AsyncMock(
-        side_effect=fake_batch_upsert_relationships
-    )
+    stores.graph.batch_upsert_relationships = AsyncMock(side_effect=fake_batch_upsert_relationships)
     stores.graph.batch_create_episodic_links = AsyncMock(
         side_effect=fake_batch_create_episodic_links
     )
@@ -253,9 +251,7 @@ async def test_two_unknown_endpoints_drop_rel_and_increment_counter(monkeypatch)
     metrics = await _run_persister(ctx, stores, monkeypatch)
 
     # No entity created with name MysteryA or MysteryB.
-    all_created_names = {
-        e.name for batch in captured["batch_upsert_entities"] for e in batch
-    }
+    all_created_names = {e.name for batch in captured["batch_upsert_entities"] for e in batch}
     assert "MysteryA" not in all_created_names
     assert "MysteryB" not in all_created_names
 

--- a/tests/agents/ingestion/test_verb_normalizer.py
+++ b/tests/agents/ingestion/test_verb_normalizer.py
@@ -1,0 +1,235 @@
+"""Tests for verb normalization (PR-B).
+
+Covers (v2 plan §B.6 + critique B-5, B-6):
+- 12 canonical verbs map to identity.
+- ~15 literal-table verbs map to the right canonical (direction preserved).
+- 5 regex-bucket verbs land in the right bucket (DISCUSSES before ACTS_ON).
+- 2 fallback-MENTIONS verbs hit the catch-all.
+- ``REFERENCES_MEDIA`` is identity (defensive guard).
+- ``BLOCKS`` and ``OWNED_BY`` are canonical (direction-flip rule
+  enforced).
+- Direction (source, target) is preserved across every literal mapping.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from beever_atlas.agents.ingestion.verb_normalizer import (
+    BUCKET_PATTERNS,
+    CANONICAL_VERBS,
+    VERB_NORMALIZATION,
+    NormalizationLog,
+    normalize_relationships,
+    normalize_verb,
+    summarize_normalizations,
+)
+from beever_atlas.models import GraphRelationship
+
+
+# ---------------------------------------------------------------------------
+# normalize_verb — single-input cases
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "DECIDED",
+        "WORKS_ON",
+        "USES",
+        "OWNS",
+        "OWNED_BY",  # promoted to canonical (B-5)
+        "BLOCKS",  # promoted to canonical (B-5)
+        "BLOCKED_BY",
+        "DEPENDS_ON",
+        "PART_OF",
+        "MENTIONS",
+        "DISCUSSES",
+        "ASKS",
+    ],
+)
+def test_canonical_verbs_pass_through_identity(raw: str) -> None:
+    """All canonical verbs are returned unchanged with rule=identity."""
+    canonical, rule = normalize_verb(raw)
+    assert canonical == raw
+    assert rule == "identity"
+    assert raw in CANONICAL_VERBS
+
+
+def test_references_media_is_identity() -> None:
+    """REFERENCES_MEDIA bypasses the normalizer defensively (the
+    real path that emits it never enters the normalizer at all, but
+    the guard protects against future refactors)."""
+    canonical, rule = normalize_verb("REFERENCES_MEDIA")
+    assert canonical == "REFERENCES_MEDIA"
+    assert rule == "identity"
+
+
+@pytest.mark.parametrize(
+    "raw,expected_canonical",
+    [
+        # USES family
+        ("INTENDS_TO_USE", "USES"),
+        ("PLANS_TO_USE", "USES"),
+        ("ADOPTED", "USES"),
+        ("MIGRATING_TO", "USES"),
+        # CREATED family
+        ("BUILT", "CREATED"),
+        ("AUTHORED", "CREATED"),
+        ("WROTE", "CREATED"),
+        # DEPLOYED family
+        ("SHIPPED", "DEPLOYED"),
+        ("RELEASED", "DEPLOYED"),
+        # REVIEWED family
+        ("APPROVED", "REVIEWED"),
+        ("REJECTED", "REVIEWED"),
+        # PART_OF family
+        ("MEMBER_OF", "PART_OF"),
+        ("BELONGS_TO", "PART_OF"),
+        # DEPENDS_ON family
+        ("DEPENDS_UPON", "DEPENDS_ON"),
+        ("RELIES_ON", "DEPENDS_ON"),
+        # SHARES / SUGGESTS communication
+        ("POSTED", "SHARES"),
+        ("RECOMMENDED", "SUGGESTS"),
+        ("PROPOSED", "SUGGESTS"),
+        # ADVISES_AGAINST polarity-aware
+        ("SUGGESTS_NOT_DISCLOSING", "ADVISES_AGAINST"),
+        ("ADVISES_NOT_TO", "ADVISES_AGAINST"),
+        # RESPONSIBLE_FOR (assigned_to direction-preserving)
+        ("ASSIGNED_TO", "RESPONSIBLE_FOR"),
+        # MENTIONS family
+        ("REFERENCES", "MENTIONS"),
+        # DISCUSSES family literal
+        ("TALKED_ABOUT", "DISCUSSES"),
+        ("BROUGHT_UP", "DISCUSSES"),
+    ],
+)
+def test_literal_mappings(raw: str, expected_canonical: str) -> None:
+    """Every literal-table entry produces the expected canonical verb
+    with rule=literal:<raw>."""
+    canonical, rule = normalize_verb(raw)
+    assert canonical == expected_canonical
+    assert rule == f"literal:{raw}"
+
+
+def test_discusses_bucket_wins_over_acts_on() -> None:
+    """PLANS_TO_DISCUSS_X must land in DISCUSSES (first-match wins;
+    ACTS_ON would also match the PLANS_TO_ prefix)."""
+    canonical, rule = normalize_verb("PLANS_TO_DISCUSS_PRICING")
+    assert canonical == "DISCUSSES"
+    assert rule == "regex:DISCUSSES"
+
+
+def test_acts_on_bucket_catches_intent_verbs() -> None:
+    """Verbs that match the ACTS_ON regex but not DISCUSSES land in
+    ACTS_ON."""
+    canonical, rule = normalize_verb("WILL_REVIEW_PROPOSAL")
+    assert canonical == "ACTS_ON"
+    assert rule == "regex:ACTS_ON"
+
+
+def test_acts_on_compound_by_to_with_from() -> None:
+    """Long-tail compounds like ``UPDATES_STATUS`` land in ACTS_ON."""
+    canonical, rule = normalize_verb("UPDATES_STATUS")
+    assert canonical == "ACTS_ON"
+    assert rule == "regex:ACTS_ON"
+
+
+def test_random_verb_falls_to_mentions() -> None:
+    """A verb that matches no literal and no semantic bucket lands in
+    MENTIONS via the catch-all."""
+    canonical, rule = normalize_verb("RANDOM_VERB_XYZ")
+    assert canonical == "MENTIONS"
+    assert rule == "fallback:MENTIONS"
+
+
+def test_empty_verb_falls_to_mentions() -> None:
+    """Defensive: empty string also lands in MENTIONS."""
+    canonical, rule = normalize_verb("")
+    assert canonical == "MENTIONS"
+    assert rule == "fallback:MENTIONS"
+
+
+# ---------------------------------------------------------------------------
+# Direction-preservation invariant (B-5 fix)
+# ---------------------------------------------------------------------------
+
+
+def test_every_literal_mapping_preserves_direction() -> None:
+    """For every literal mapping, applying the rule to a fake
+    relationship leaves (source, target) untouched. This protects
+    against the v1 plan's BLOCKS→BLOCKED_BY direction flip.
+    """
+    for raw, _canonical in VERB_NORMALIZATION.items():
+        rel = GraphRelationship(type=raw, source="Alice", target="Bob")
+        out, _log = normalize_relationships([rel])
+        assert len(out) == 1
+        assert out[0].source == "Alice", f"source flipped for {raw}"
+        assert out[0].target == "Bob", f"target flipped for {raw}"
+
+
+def test_blocks_stays_blocks_owned_by_stays_owned_by() -> None:
+    """Explicit regression for the v1 BLOCKS→BLOCKED_BY direction-flip
+    bug.  Both verbs are now canonical."""
+    canonical_blocks, _ = normalize_verb("BLOCKS")
+    canonical_owned_by, _ = normalize_verb("OWNED_BY")
+    assert canonical_blocks == "BLOCKS"
+    assert canonical_owned_by == "OWNED_BY"
+
+
+# ---------------------------------------------------------------------------
+# normalize_relationships — batch path
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_relationships_mutates_in_place_and_logs() -> None:
+    """The batch path mutates ``rel.type`` and returns one ledger row
+    per (raw, canonical, rule) tuple seen."""
+    rels = [
+        GraphRelationship(type="PLANS_TO_USE", source="A", target="B"),
+        GraphRelationship(type="PLANS_TO_USE", source="A", target="C"),  # duplicate
+        GraphRelationship(type="BUILT", source="D", target="E"),
+        GraphRelationship(type="USES", source="F", target="G"),  # identity, no log
+    ]
+    out, log = normalize_relationships(rels, sync_job_id="job-1")
+    # All types mutated correctly
+    assert [r.type for r in out] == ["USES", "USES", "CREATED", "USES"]
+    # Log has 2 unique entries (PLANS_TO_USE + BUILT). Identity rows
+    # produce no log.
+    log_keys = {(row.raw_verb, row.canonical_verb, row.rule) for row in log}
+    assert ("PLANS_TO_USE", "USES", "literal:PLANS_TO_USE") in log_keys
+    assert ("BUILT", "CREATED", "literal:BUILT") in log_keys
+    assert len(log_keys) == 2
+
+
+def test_summarize_normalizations_counts_duplicates() -> None:
+    """When the same mapping appears multiple times in the ledger
+    (e.g. 200 PLANS_TO_USE edges in one sync), the roll-up rolls them
+    up into one row with the correct count."""
+    log = [
+        NormalizationLog(raw_verb="PLANS_TO_USE", canonical_verb="USES", rule="literal:PLANS_TO_USE"),
+        NormalizationLog(raw_verb="PLANS_TO_USE", canonical_verb="USES", rule="literal:PLANS_TO_USE"),
+        NormalizationLog(raw_verb="PLANS_TO_USE", canonical_verb="USES", rule="literal:PLANS_TO_USE"),
+        NormalizationLog(raw_verb="BUILT", canonical_verb="CREATED", rule="literal:BUILT"),
+    ]
+    rows = summarize_normalizations(log)
+    by_raw = {r["original_verb"]: r for r in rows}
+    assert by_raw["PLANS_TO_USE"]["count"] == 3
+    assert by_raw["BUILT"]["count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Bucket-ordering invariant
+# ---------------------------------------------------------------------------
+
+
+def test_bucket_patterns_ordered_discusses_before_acts_on() -> None:
+    """Structural assertion: BUCKET_PATTERNS must order DISCUSSES
+    before ACTS_ON, otherwise PLANS_TO_DISCUSS_X would mis-route."""
+    bucket_order = [bucket for _, bucket in BUCKET_PATTERNS]
+    discusses_idx = bucket_order.index("DISCUSSES")
+    acts_on_idx = bucket_order.index("ACTS_ON")
+    mentions_idx = bucket_order.index("MENTIONS")
+    assert discusses_idx < acts_on_idx < mentions_idx

--- a/tests/agents/ingestion/test_verb_normalizer.py
+++ b/tests/agents/ingestion/test_verb_normalizer.py
@@ -209,9 +209,15 @@ def test_summarize_normalizations_counts_duplicates() -> None:
     (e.g. 200 PLANS_TO_USE edges in one sync), the roll-up rolls them
     up into one row with the correct count."""
     log = [
-        NormalizationLog(raw_verb="PLANS_TO_USE", canonical_verb="USES", rule="literal:PLANS_TO_USE"),
-        NormalizationLog(raw_verb="PLANS_TO_USE", canonical_verb="USES", rule="literal:PLANS_TO_USE"),
-        NormalizationLog(raw_verb="PLANS_TO_USE", canonical_verb="USES", rule="literal:PLANS_TO_USE"),
+        NormalizationLog(
+            raw_verb="PLANS_TO_USE", canonical_verb="USES", rule="literal:PLANS_TO_USE"
+        ),
+        NormalizationLog(
+            raw_verb="PLANS_TO_USE", canonical_verb="USES", rule="literal:PLANS_TO_USE"
+        ),
+        NormalizationLog(
+            raw_verb="PLANS_TO_USE", canonical_verb="USES", rule="literal:PLANS_TO_USE"
+        ),
         NormalizationLog(raw_verb="BUILT", canonical_verb="CREATED", rule="literal:BUILT"),
     ]
     rows = summarize_normalizations(log)

--- a/tests/api/test_admin_channel_reset.py
+++ b/tests/api/test_admin_channel_reset.py
@@ -29,7 +29,6 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from beever_atlas.api import admin as admin_mod
 from beever_atlas.api.admin import router as admin_router
 from beever_atlas.infra import auth as auth_mod
 from beever_atlas.stores import init_stores

--- a/tests/api/test_admin_channel_reset.py
+++ b/tests/api/test_admin_channel_reset.py
@@ -1,0 +1,474 @@
+"""Tests for the per-channel reset endpoint.
+
+Covers ``POST /api/admin/channels/{channel_id}/reset`` — drops a single
+channel's derived memory (facts, entities, wiki pages, graph nodes,
+sync state) and optionally triggers a follow-up sync. The reset MUST:
+
+  1. Fan calls out to all five derived-data stores in fixed order.
+  2. Refuse with 409 when a sync is in flight (concurrent-sync gate).
+  3. Refuse with 400 when ``i_understand_data_loss != "yes"``.
+  4. Refuse with 401 when the admin token is missing or wrong.
+  5. Continue with the remaining stores when one raises — partial
+     failure surfaces in ``errors`` but the request returns 200.
+  6. Trigger ``SyncRunner.start_sync(sync_type="full")`` when
+     ``trigger_resync=true`` and echo the returned ``job_id``.
+  7. Be idempotent: a second call returns 200 with zero counts.
+
+The tests build a minimal FastAPI app with the admin router mounted and
+patch ``stores`` + ``get_sync_runner`` to in-memory fakes so the test
+suite does not require live Neo4j / Weaviate / Mongo / sync runner.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from beever_atlas.api import admin as admin_mod
+from beever_atlas.api.admin import router as admin_router
+from beever_atlas.infra import auth as auth_mod
+from beever_atlas.stores import init_stores
+
+
+_ADMIN_TOKEN = "admin-token-abc"
+_CHANNEL_ID = "C-test-reset"
+
+
+def _patch_admin(monkeypatch, token: str = _ADMIN_TOKEN) -> None:
+    fake = SimpleNamespace(admin_token=token)
+    monkeypatch.setattr(auth_mod, "get_settings", lambda: fake)
+
+
+def _admin_headers() -> dict[str, str]:
+    return {"X-Admin-Token": _ADMIN_TOKEN}
+
+
+class _FakeSyncRunner:
+    """Captures ``start_sync`` calls without touching real workers."""
+
+    def __init__(self, job_id: str = "resync-job-1") -> None:
+        self.job_id = job_id
+        self.calls: list[dict[str, Any]] = []
+
+    async def start_sync(
+        self,
+        channel_id: str,
+        *,
+        sync_type: str = "auto",
+        use_batch_api: bool = False,
+        connection_id: str | None = None,
+        owner_principal_id: str | None = None,
+    ) -> str:
+        self.calls.append(
+            {
+                "channel_id": channel_id,
+                "sync_type": sync_type,
+                "use_batch_api": use_batch_api,
+                "connection_id": connection_id,
+                "owner_principal_id": owner_principal_id,
+            }
+        )
+        return self.job_id
+
+
+class _FakePageStore:
+    """Captures ``delete_all_for_channel`` calls without touching MongoDB."""
+
+    def __init__(self, returns: dict[str, int] | int = 4) -> None:
+        # Accept either a per-lang dict or a single int (applied to every
+        # language) so tests can dial in fine-grained behaviour.
+        self._returns = returns
+        self.calls: list[tuple[str, str]] = []
+        self.bind_db_called = False
+
+    def __call__(self, db: Any = None) -> "_FakePageStore":
+        # ``WikiPageStore(db=stores.mongodb.db)`` constructs a fresh
+        # instance — our test fake is also callable so the production
+        # call site (``WikiPageStore(db=stores.mongodb.db)``) returns
+        # this same captured instance.
+        return self
+
+    async def delete_all_for_channel(self, channel_id: str, target_lang: str = "en") -> int:
+        self.calls.append((channel_id, target_lang))
+        if isinstance(self._returns, dict):
+            return int(self._returns.get(target_lang, 0))
+        return int(self._returns)
+
+
+@pytest.fixture
+def fake_page_store(monkeypatch) -> _FakePageStore:
+    """Patch ``WikiPageStore`` so the endpoint's import-and-instantiate
+    pattern returns our capturing fake.
+    """
+    fake = _FakePageStore(returns=4)
+    # The endpoint imports ``WikiPageStore`` from
+    # ``beever_atlas.wiki.page_store`` inside the request handler. Patch
+    # both module attribute and the symbol that the lazy import path
+    # will resolve to.
+    import beever_atlas.wiki.page_store as page_store_mod
+
+    monkeypatch.setattr(page_store_mod, "WikiPageStore", fake)
+    return fake
+
+
+@pytest.fixture
+def fake_runner(monkeypatch) -> _FakeSyncRunner:
+    runner = _FakeSyncRunner()
+    # The endpoint imports ``get_sync_runner`` lazily from
+    # ``beever_atlas.api.sync``. Patch the module attribute.
+    import beever_atlas.api.sync as sync_mod
+
+    monkeypatch.setattr(sync_mod, "get_sync_runner", lambda: runner)
+    return runner
+
+
+@pytest.fixture
+def fake_stores(monkeypatch):
+    """Wire up in-memory fakes for the five derived-data store entry points."""
+    graph = SimpleNamespace(
+        delete_channel_data=AsyncMock(
+            return_value={
+                "events_deleted": 12,
+                "media_deleted": 5,
+                "entities_deleted": 7,
+            }
+        ),
+    )
+    weaviate = SimpleNamespace(
+        delete_by_channel=AsyncMock(return_value=42),
+    )
+    # ``db["channel_messages"].update_many`` is called by the reset to flip
+    # ``extraction_status`` back to ``pending`` so the next sync re-extracts.
+    channel_messages_coll = SimpleNamespace(
+        update_many=AsyncMock(return_value=SimpleNamespace(modified_count=7)),
+    )
+    # ``db["wiki_cache"].delete_one`` is called per language to drop the
+    # cached wiki bundle keyed by ``<channel_id>:<lang>`` so the UI does
+    # not keep serving the pre-reset snapshot.
+    wiki_cache_coll = SimpleNamespace(
+        delete_one=AsyncMock(return_value=SimpleNamespace(deleted_count=1)),
+    )
+    mongodb = SimpleNamespace(
+        db={"channel_messages": channel_messages_coll, "wiki_cache": wiki_cache_coll},
+        get_latest_sync_job=AsyncMock(return_value=None),
+        clear_channel_sync_state=AsyncMock(return_value=None),
+    )
+    container = SimpleNamespace(graph=graph, weaviate=weaviate, mongodb=mongodb)
+    init_stores(container)  # type: ignore[arg-type]
+    return container
+
+
+@pytest.fixture
+def app(monkeypatch, fake_stores, fake_page_store):  # noqa: ARG001
+    _patch_admin(monkeypatch)
+    app = FastAPI()
+    app.include_router(admin_router)
+    return app
+
+
+@pytest.fixture
+def client(app) -> TestClient:
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# 1. Happy path
+# ---------------------------------------------------------------------------
+
+
+def test_reset_happy_path_calls_every_store(client: TestClient, fake_stores) -> None:
+    r = client.post(
+        f"/api/admin/channels/{_CHANNEL_ID}/reset",
+        headers=_admin_headers(),
+        params={"i_understand_data_loss": "yes"},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["status"] == "reset_complete"
+    assert body["channel_id"] == _CHANNEL_ID
+    assert body["errors"] == []
+    assert body["resync_job_id"] is None
+    counts = body["counts"]
+    assert counts["events_deleted"] == 12
+    assert counts["media_deleted"] == 5
+    assert counts["entities_deleted"] == 7
+    assert counts["weaviate_deleted"] == 42
+    assert counts["sync_state_cleared"] == 1
+    # Wiki is intentionally left untouched — the wiki subsystem owns its
+    # own reset path at ``POST /wiki/refresh?mode=rebuild`` (archives to
+    # version history first). No wiki keys appear in the reset response.
+    assert "wiki_graph_deleted" not in counts
+    assert "wiki_pages_deleted" not in counts
+    assert "wiki_bundle_cleared" not in counts
+    assert "wiki_generation_status_cleared" not in counts
+
+    fake_stores.graph.delete_channel_data.assert_awaited_once_with(_CHANNEL_ID)
+    fake_stores.weaviate.delete_by_channel.assert_awaited_once_with(_CHANNEL_ID)
+    fake_stores.mongodb.clear_channel_sync_state.assert_awaited_once_with(_CHANNEL_ID)
+
+
+def test_reset_does_not_touch_wiki(
+    client: TestClient,
+    fake_page_store: _FakePageStore,
+    fake_stores,
+) -> None:
+    """The reset endpoint must NOT delete wiki state. Wiki has its own
+    versioned rebuild path; doing it here would bypass version archiving.
+    """
+    r = client.post(
+        f"/api/admin/channels/{_CHANNEL_ID}/reset",
+        headers=_admin_headers(),
+        params=[
+            ("i_understand_data_loss", "yes"),
+            ("languages", "en"),
+            ("languages", "ja"),
+        ],
+    )
+    assert r.status_code == 200, r.text
+    assert fake_page_store.calls == []  # WikiPageStore was not invoked
+    # ``delete_channel_wiki_graph`` is not even present on the fake graph
+    # store — its absence proves the reset code never reached for it.
+    assert not hasattr(fake_stores.graph, "delete_channel_wiki_graph")
+
+
+# ---------------------------------------------------------------------------
+# 2. Missing confirmation token
+# ---------------------------------------------------------------------------
+
+
+def test_reset_rejects_missing_confirmation_token(client: TestClient) -> None:
+    r = client.post(
+        f"/api/admin/channels/{_CHANNEL_ID}/reset",
+        headers=_admin_headers(),
+    )
+    # ``i_understand_data_loss`` is a required Query param → FastAPI 422.
+    assert r.status_code == 422, r.text
+
+
+def test_reset_rejects_wrong_confirmation_token(client: TestClient) -> None:
+    r = client.post(
+        f"/api/admin/channels/{_CHANNEL_ID}/reset",
+        headers=_admin_headers(),
+        params={"i_understand_data_loss": "maybe"},
+    )
+    assert r.status_code == 400, r.text
+    assert "i_understand_data_loss" in r.json()["detail"]
+
+
+# ---------------------------------------------------------------------------
+# 3. Concurrent-sync gate
+# ---------------------------------------------------------------------------
+
+
+def test_reset_returns_409_when_sync_in_progress(
+    client: TestClient,
+    fake_stores,
+) -> None:
+    fake_stores.mongodb.get_latest_sync_job = AsyncMock(
+        return_value=SimpleNamespace(status="running", id="job-running-1")
+    )
+    r = client.post(
+        f"/api/admin/channels/{_CHANNEL_ID}/reset",
+        headers=_admin_headers(),
+        params={"i_understand_data_loss": "yes"},
+    )
+    assert r.status_code == 409, r.text
+    assert r.json()["detail"] == "sync in progress, cannot reset"
+    # None of the destructive stages ran.
+    fake_stores.graph.delete_channel_data.assert_not_called()
+    fake_stores.weaviate.delete_by_channel.assert_not_called()
+    fake_stores.mongodb.clear_channel_sync_state.assert_not_called()
+
+
+def test_reset_proceeds_when_latest_job_is_completed(
+    client: TestClient,
+    fake_stores,
+) -> None:
+    """A finished sync job does NOT gate a reset."""
+    fake_stores.mongodb.get_latest_sync_job = AsyncMock(
+        return_value=SimpleNamespace(status="completed", id="job-done-1")
+    )
+    r = client.post(
+        f"/api/admin/channels/{_CHANNEL_ID}/reset",
+        headers=_admin_headers(),
+        params={"i_understand_data_loss": "yes"},
+    )
+    assert r.status_code == 200, r.text
+
+
+# ---------------------------------------------------------------------------
+# 4. Auth — non-admin caller
+# ---------------------------------------------------------------------------
+
+
+def test_reset_rejects_missing_admin_token(client: TestClient) -> None:
+    r = client.post(
+        f"/api/admin/channels/{_CHANNEL_ID}/reset",
+        params={"i_understand_data_loss": "yes"},
+    )
+    assert r.status_code == 401, r.text
+
+
+def test_reset_rejects_wrong_admin_token(client: TestClient) -> None:
+    r = client.post(
+        f"/api/admin/channels/{_CHANNEL_ID}/reset",
+        headers={"X-Admin-Token": "wrong-token"},
+        params={"i_understand_data_loss": "yes"},
+    )
+    assert r.status_code == 401, r.text
+
+
+# ---------------------------------------------------------------------------
+# 5. Partial failure resilience
+# ---------------------------------------------------------------------------
+
+
+def test_reset_continues_when_one_store_raises(
+    client: TestClient,
+    fake_stores,
+) -> None:
+    """A single-store failure is surfaced in ``errors`` but does NOT
+    abort the remaining stages — the documented "no partial rollback"
+    contract.
+    """
+    fake_stores.weaviate.delete_by_channel = AsyncMock(side_effect=RuntimeError("boom"))
+    r = client.post(
+        f"/api/admin/channels/{_CHANNEL_ID}/reset",
+        headers=_admin_headers(),
+        params={"i_understand_data_loss": "yes"},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    # Weaviate failure surfaces in errors, no count.
+    assert any("weaviate.delete_by_channel" in e for e in body["errors"])
+    assert "weaviate_deleted" not in body["counts"]
+    # Other stages still ran.
+    assert body["counts"]["entities_deleted"] == 7
+    assert body["counts"]["sync_state_cleared"] == 1
+    fake_stores.mongodb.clear_channel_sync_state.assert_awaited_once_with(_CHANNEL_ID)
+
+
+# ---------------------------------------------------------------------------
+# 6. trigger_resync=true
+# ---------------------------------------------------------------------------
+
+
+def test_reset_with_trigger_resync_calls_sync_runner(
+    client: TestClient,
+    fake_runner: _FakeSyncRunner,
+) -> None:
+    r = client.post(
+        f"/api/admin/channels/{_CHANNEL_ID}/reset",
+        headers=_admin_headers(),
+        params={"i_understand_data_loss": "yes", "trigger_resync": "true"},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["resync_job_id"] == "resync-job-1"
+    assert len(fake_runner.calls) == 1
+    call = fake_runner.calls[0]
+    assert call["channel_id"] == _CHANNEL_ID
+    assert call["sync_type"] == "full"
+
+
+def test_reset_trigger_resync_failure_is_not_fatal(
+    client: TestClient,
+    monkeypatch,
+) -> None:
+    """A failing ``start_sync`` records an error but the request stays 200
+    — the deletions are already committed."""
+
+    class _BrokenRunner:
+        async def start_sync(self, *args, **kwargs):  # noqa: ARG002, ANN002, ANN003
+            raise RuntimeError("runner unavailable")
+
+    import beever_atlas.api.sync as sync_mod
+
+    monkeypatch.setattr(sync_mod, "get_sync_runner", lambda: _BrokenRunner())
+
+    r = client.post(
+        f"/api/admin/channels/{_CHANNEL_ID}/reset",
+        headers=_admin_headers(),
+        params={"i_understand_data_loss": "yes", "trigger_resync": "true"},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["resync_job_id"] is None
+    assert any("start_sync" in e for e in body["errors"])
+
+
+# ---------------------------------------------------------------------------
+# 7. Idempotency
+# ---------------------------------------------------------------------------
+
+
+def test_reset_is_idempotent_when_second_call_returns_zeros(
+    client: TestClient,
+    fake_stores,
+) -> None:
+    """The first call returns the seeded non-zero counts. The second
+    call returns 200 with every counter at zero — exactly the shape an
+    operator gets when re-running a reset on a freshly-wiped channel.
+    """
+    # First call uses the default non-zero seeds.
+    r1 = client.post(
+        f"/api/admin/channels/{_CHANNEL_ID}/reset",
+        headers=_admin_headers(),
+        params={"i_understand_data_loss": "yes"},
+    )
+    assert r1.status_code == 200, r1.text
+    body1 = r1.json()
+    assert body1["counts"]["entities_deleted"] == 7
+
+    # Re-bind the fake stores so the second call sees zeros across the
+    # board (the production stores would, by virtue of having just been
+    # drained, return the same).
+    fake_stores.graph.delete_channel_data = AsyncMock(
+        return_value={"events_deleted": 0, "media_deleted": 0, "entities_deleted": 0}
+    )
+    fake_stores.weaviate.delete_by_channel = AsyncMock(return_value=0)
+
+    r2 = client.post(
+        f"/api/admin/channels/{_CHANNEL_ID}/reset",
+        headers=_admin_headers(),
+        params={"i_understand_data_loss": "yes"},
+    )
+    assert r2.status_code == 200, r2.text
+    body2 = r2.json()
+    assert body2["counts"]["events_deleted"] == 0
+    assert body2["counts"]["media_deleted"] == 0
+    assert body2["counts"]["entities_deleted"] == 0
+    assert body2["counts"]["weaviate_deleted"] == 0
+    assert body2["errors"] == []
+
+
+# ---------------------------------------------------------------------------
+# 8. Zero-count happy path
+# ---------------------------------------------------------------------------
+
+
+def test_reset_returns_200_with_all_zero_counts(
+    client: TestClient,
+    fake_stores,
+) -> None:
+    fake_stores.graph.delete_channel_data = AsyncMock(
+        return_value={"events_deleted": 0, "media_deleted": 0, "entities_deleted": 0}
+    )
+    fake_stores.weaviate.delete_by_channel = AsyncMock(return_value=0)
+
+    r = client.post(
+        f"/api/admin/channels/{_CHANNEL_ID}/reset",
+        headers=_admin_headers(),
+        params={"i_understand_data_loss": "yes"},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["status"] == "reset_complete"
+    assert body["errors"] == []
+    assert body["counts"]["entities_deleted"] == 0
+    assert body["counts"]["weaviate_deleted"] == 0

--- a/tests/integration/test_relationship_stub_merge.py
+++ b/tests/integration/test_relationship_stub_merge.py
@@ -85,15 +85,16 @@ def _force_settings(monkeypatch, *, stub_endpoints: bool) -> None:
     # for the test and pytest re-imports Settings between sessions.
 
 
-# ── Test 1 — unknown endpoints create Topic stubs ──────────────────────────
+# ── Test 1 — unknown endpoints create Unresolved stubs ────────────────────
 
 
 @pytest.mark.asyncio
-async def test_unknown_endpoints_create_topic_stubs(monkeypatch):
+async def test_unknown_endpoints_create_unresolved_stubs(monkeypatch):
     """MERGE path: relationship with two unknown endpoint names creates 2
-    stub Entity nodes (type='Topic', scope='global'). Verified by:
+    stub Entity nodes (type='Unresolved', scope='global'). Verified by:
     (a) the Cypher contains the stub-MERGE clause; (b) the stub_props
-    parameter contains ``"stub": true, "reason": "rel_endpoint"``.
+    parameter contains ``"stub": true, "reason": "rel_endpoint",
+    "awaiting_type": true``.
     """
     _force_settings(monkeypatch, stub_endpoints=True)
 
@@ -114,11 +115,14 @@ async def test_unknown_endpoints_create_topic_stubs(monkeypatch):
     query = calls[0]["query"]
     kwargs = calls[0]["kwargs"]
     # Cypher uses MERGE for both endpoints with composite key.
-    assert "MERGE (a:Entity {name: $source, type: 'Topic', scope: 'global'})" in query
-    assert "MERGE (b:Entity {name: $target, type: 'Topic', scope: 'global'})" in query
+    assert "MERGE (a:Entity {name: $source, type: 'Unresolved', scope: 'global'})" in query
+    assert "MERGE (b:Entity {name: $target, type: 'Unresolved', scope: 'global'})" in query
     # ON CREATE SET writes the stub marker.
     assert "ON CREATE SET" in query
-    assert kwargs["stub_props"] == '{"stub": true, "reason": "rel_endpoint"}'
+    assert (
+        kwargs["stub_props"]
+        == '{"stub": true, "reason": "rel_endpoint", "awaiting_type": true}'
+    )
     assert kwargs["source"] == "UnknownA"
     assert kwargs["target"] == "UnknownB"
 
@@ -128,16 +132,17 @@ async def test_unknown_endpoints_create_topic_stubs(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_known_endpoints_unchanged(monkeypatch):
-    """When the endpoint Entity already exists at ``(name, 'Topic',
+    """When the endpoint Entity already exists at ``(name, 'Unresolved',
     'global')`` (i.e. real, not stub), ``ON CREATE SET`` does NOT fire
     so the existing properties remain intact. The Cypher we issue is
     the same; we assert the structure here and rely on the integration
     semantics of MERGE for the rewrite-prevention guarantee.
 
     The composite-key design intentionally creates a NEW
-    ``(name, 'Topic', 'global')`` stub when a real entity exists with a
-    richer type like ``Tool`` — tracked as Q-DUP-1 in
-    ``.omc/plans/pipeline-realign-v2.md``.
+    ``(name, 'Unresolved', 'global')`` stub when a real entity exists
+    with a richer type like ``Tool`` — the heal-path in
+    :meth:`Neo4jStore.upsert_entity` collapses the two on the next
+    typed write.
     """
     _force_settings(monkeypatch, stub_endpoints=True)
 
@@ -192,8 +197,12 @@ async def test_episodic_link_unknown_entity_creates_stub(monkeypatch):
     assert len(calls) == 1
     query = calls[0]["query"]
     # MERGE the Entity (not MATCH) with the composite key.
-    assert "MERGE (e:Entity {name: link.entity_name, type: 'Topic', scope: 'global'})" in query
+    assert (
+        "MERGE (e:Entity {name: link.entity_name, type: 'Unresolved', scope: 'global'})"
+        in query
+    )
     assert '"reason": "episodic_link"' in query
+    assert '"awaiting_type": true' in query
     # Event MERGE still present.
     assert "MERGE (ep:Event {weaviate_id: link.weaviate_fact_id})" in query
     assert "MERGE (e)-[:MENTIONED_IN]->(ep)" in query
@@ -283,31 +292,31 @@ async def test_stub_explosion_cap(monkeypatch, caplog):
     }
 
 
-# ── Test 5 — persister post-hoc stub uses Topic ────────────────────────────
+# ── Test 5 — persister post-hoc stub uses Unresolved ──────────────────────
 
 
-def test_persister_post_hoc_stub_type_is_topic():
-    """Regression test for criterion #7: the post-hoc stub at
-    ``persister.py:438`` must produce ``type='Topic'``. Implemented as
-    a static-source check — the function constructs a ``GraphEntity``
-    with the literal ``type=`` keyword and a static-source grep is the
-    cheapest reliable verification (the actual stub-creation path is
-    exercised by the full ingestion pipeline tests).
+def test_persister_post_hoc_stub_type_is_unresolved():
+    """Regression test: the post-hoc stub block in the persister must
+    produce ``type='Unresolved'`` so it aligns with the in-Cypher MERGE
+    default and can be healed by the ``upsert_entity`` heal-path. The
+    literal ``type="Topic"`` must NOT appear in the post-hoc stub block
+    (it would mismatch the in-Cypher MERGE default and leak Topic
+    monoculture back into the graph).
     """
     from pathlib import Path
 
     src = Path("src/beever_atlas/agents/ingestion/persister.py").read_text(encoding="utf-8")
-    # The persister builds the post-hoc stub list in the loop over
-    # ``missing_names``. The literal ``type="Project"`` must NOT appear
-    # in the post-hoc stub block (it would mismatch the in-Cypher
-    # MERGE default and trigger the Q-DUP-1 duplicate pattern).
     assert 'type="Project"' not in src, (
         'persister.py still constructs a stub with type="Project" — '
-        'must be "Topic" to align with the in-Cypher MERGE default.'
+        'must be "Unresolved" to align with the in-Cypher MERGE default.'
     )
-    # Positive assertion: the post-hoc loop now uses Topic.
-    assert 'type="Topic"' in src, (
-        'expected the post-hoc stub block to construct GraphEntity(type="Topic", ...)'
+    assert 'type="Topic"' not in src, (
+        'persister.py still constructs a stub with type="Topic" — '
+        'must be "Unresolved" to align with the in-Cypher MERGE default.'
+    )
+    # Positive assertion: the post-hoc loop now uses Unresolved.
+    assert 'type="Unresolved"' in src, (
+        'expected the post-hoc stub block to construct GraphEntity(type="Unresolved", ...)'
     )
 
 

--- a/tests/integration/test_relationship_stub_merge.py
+++ b/tests/integration/test_relationship_stub_merge.py
@@ -119,10 +119,7 @@ async def test_unknown_endpoints_create_unresolved_stubs(monkeypatch):
     assert "MERGE (b:Entity {name: $target, type: 'Unresolved', scope: 'global'})" in query
     # ON CREATE SET writes the stub marker.
     assert "ON CREATE SET" in query
-    assert (
-        kwargs["stub_props"]
-        == '{"stub": true, "reason": "rel_endpoint", "awaiting_type": true}'
-    )
+    assert kwargs["stub_props"] == '{"stub": true, "reason": "rel_endpoint", "awaiting_type": true}'
     assert kwargs["source"] == "UnknownA"
     assert kwargs["target"] == "UnknownB"
 
@@ -197,10 +194,7 @@ async def test_episodic_link_unknown_entity_creates_stub(monkeypatch):
     assert len(calls) == 1
     query = calls[0]["query"]
     # MERGE the Entity (not MATCH) with the composite key.
-    assert (
-        "MERGE (e:Entity {name: link.entity_name, type: 'Unresolved', scope: 'global'})"
-        in query
-    )
+    assert "MERGE (e:Entity {name: link.entity_name, type: 'Unresolved', scope: 'global'})" in query
     assert '"reason": "episodic_link"' in query
     assert '"awaiting_type": true' in query
     # Event MERGE still present.

--- a/tests/integration/test_relationship_stub_merge.py
+++ b/tests/integration/test_relationship_stub_merge.py
@@ -115,8 +115,11 @@ async def test_unknown_endpoints_create_unresolved_stubs(monkeypatch):
     query = calls[0]["query"]
     kwargs = calls[0]["kwargs"]
     # Cypher uses MERGE for both endpoints with composite key.
-    assert "MERGE (a:Entity {name: $source, type: 'Unresolved', scope: 'global'})" in query
-    assert "MERGE (b:Entity {name: $target, type: 'Unresolved', scope: 'global'})" in query
+    # Variables are ``a_raw`` / ``b_raw`` so the apoc.refactor.mergeNodes
+    # absorption step (symmetric heal) can replace them with the typed
+    # sibling without aliasing the relationship endpoints.
+    assert "MERGE (a_raw:Entity {name: $source, type: 'Unresolved', scope: 'global'})" in query
+    assert "MERGE (b_raw:Entity {name: $target, type: 'Unresolved', scope: 'global'})" in query
     # ON CREATE SET writes the stub marker.
     assert "ON CREATE SET" in query
     assert kwargs["stub_props"] == '{"stub": true, "reason": "rel_endpoint", "awaiting_type": true}'
@@ -193,8 +196,13 @@ async def test_episodic_link_unknown_entity_creates_stub(monkeypatch):
     assert created == 1
     assert len(calls) == 1
     query = calls[0]["query"]
-    # MERGE the Entity (not MATCH) with the composite key.
-    assert "MERGE (e:Entity {name: link.entity_name, type: 'Unresolved', scope: 'global'})" in query
+    # MERGE the Entity (not MATCH) with the composite key. Variable is
+    # ``e_raw`` so the apoc.refactor.mergeNodes absorption step can
+    # replace it with the typed sibling for the MENTIONED_IN edge.
+    assert (
+        "MERGE (e_raw:Entity {name: link.entity_name, type: 'Unresolved', scope: 'global'})"
+        in query
+    )
     assert '"reason": "episodic_link"' in query
     assert '"awaiting_type": true' in query
     # Event MERGE still present.

--- a/tests/services/test_wiki_maintainer_entity_edges.py
+++ b/tests/services/test_wiki_maintainer_entity_edges.py
@@ -1,0 +1,152 @@
+"""Tests for the WikiPage → Entity bridge edges.
+
+The writer side lives in :meth:`WikiMaintainer._upsert_wiki_graph` and
+emits a ``:REFERENCES_ENTITY`` edge for every wikilink in the page body
+that resolves against the entity registry. These tests drive
+``_upsert_wiki_graph`` directly with a fake graph store and assert
+the produced calls.
+
+Acceptance:
+  1. ``[[Redis]]`` + ``[[Alice]]`` → both edges land when those entities
+     exist in the registry.
+  2. ``[[Ghost]]`` (no entity) → no edge, no stub.
+  3. Re-running on the same page does NOT multiply edges (idempotency
+     comes from the underlying Cypher MERGE on the edge).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from beever_atlas.models.persistence import WikiPage, WikiPageSection
+from beever_atlas.services.wiki_maintainer import WikiMaintainer
+
+
+# ── fake graph store ────────────────────────────────────────────────────────
+
+
+def _make_fake_graph_store(known_entity_names: set[str] | None = None) -> MagicMock:
+    """Build a fake graph store with the methods ``_upsert_wiki_graph`` calls.
+
+    The fake records every ``upsert_wiki_reference_entity_edge`` invocation
+    so the test can count edges + assert idempotency.
+    """
+    known = known_entity_names or set()
+
+    store = MagicMock()
+    store.entity_edge_calls = []  # type: ignore[attr-defined]
+
+    async def fake_upsert_wiki_page_node(**kwargs):
+        return "wid-test"
+
+    async def fake_upsert_wiki_reference_edge(**kwargs):
+        return None
+
+    async def fake_find_entity_by_name_or_alias(name):
+        return name if name in known else None
+
+    async def fake_upsert_wiki_reference_entity_edge(**kwargs):
+        store.entity_edge_calls.append(dict(kwargs))  # type: ignore[attr-defined]
+        return None
+
+    store.upsert_wiki_page_node = AsyncMock(side_effect=fake_upsert_wiki_page_node)
+    store.upsert_wiki_reference_edge = AsyncMock(side_effect=fake_upsert_wiki_reference_edge)
+    store.find_entity_by_name_or_alias = AsyncMock(side_effect=fake_find_entity_by_name_or_alias)
+    store.upsert_wiki_reference_entity_edge = AsyncMock(
+        side_effect=fake_upsert_wiki_reference_entity_edge
+    )
+    return store
+
+
+def _make_page(content_md: str) -> WikiPage:
+    return WikiPage(
+        channel_id="C-test",
+        target_lang="en",
+        page_id="topic:auth",
+        title="Auth",
+        slug="topic-auth",
+        kind="topic",
+        version=1,
+        sections=[
+            WikiPageSection(
+                id="overview",
+                title="Overview",
+                content_md=content_md,
+            )
+        ],
+    )
+
+
+# ── 1. Both wikilinks resolve → both entity edges land ─────────────────────
+
+
+@pytest.mark.asyncio
+async def test_resolved_wikilinks_produce_entity_edges():
+    graph_store = _make_fake_graph_store(known_entity_names={"Redis", "Alice"})
+    maintainer = WikiMaintainer(page_store=AsyncMock(), graph_store=graph_store)
+    page = _make_page("Discussion of [[Redis]] adoption by [[Alice]] this week.")
+
+    page.updated_at = datetime.now(tz=UTC)
+    await maintainer._upsert_wiki_graph(page, resolved_slugs=[], target_lang="en")
+
+    # Both entities produced an edge.
+    edge_targets = {c["entity_name"] for c in graph_store.entity_edge_calls}
+    assert edge_targets == {"Redis", "Alice"}, (
+        f"expected edges for Redis and Alice; got {edge_targets}"
+    )
+    # Each call carries channel/lang/src_slug consistently.
+    for call in graph_store.entity_edge_calls:
+        assert call["channel_id"] == "C-test"
+        assert call["target_lang"] == "en"
+        assert call["src_slug"] == "topic-auth"
+
+
+# ── 2. Wikilink to non-existent entity → no edge, no stub ──────────────────
+
+
+@pytest.mark.asyncio
+async def test_unresolved_wikilink_does_not_create_edge():
+    graph_store = _make_fake_graph_store(known_entity_names=set())
+    maintainer = WikiMaintainer(page_store=AsyncMock(), graph_store=graph_store)
+    page = _make_page("Mention of [[Ghost]] (no entity behind it).")
+
+    page.updated_at = datetime.now(tz=UTC)
+    await maintainer._upsert_wiki_graph(page, resolved_slugs=[], target_lang="en")
+
+    # No edge produced; the maintainer doesn't manufacture stubs for
+    # bare wikilinks.
+    assert graph_store.entity_edge_calls == []
+
+
+# ── 3. Rebuilding the same page does not multiply edges ────────────────────
+
+
+@pytest.mark.asyncio
+async def test_idempotent_rebuild_does_not_multiply_edges():
+    """Calling ``_upsert_wiki_graph`` twice on the same page produces
+    the same edge writes twice — but each call is a Cypher MERGE on the
+    edge, so the graph itself does not gain duplicate edges. We assert
+    on the call shape (kwargs equal across the two invocations) which
+    is the contract the underlying Cypher MERGE relies on.
+    """
+    graph_store = _make_fake_graph_store(known_entity_names={"Redis"})
+    maintainer = WikiMaintainer(page_store=AsyncMock(), graph_store=graph_store)
+    page = _make_page("[[Redis]] adoption.")
+    page.updated_at = datetime.now(tz=UTC)
+
+    await maintainer._upsert_wiki_graph(page, resolved_slugs=[], target_lang="en")
+    first_calls = list(graph_store.entity_edge_calls)
+    # Second run on the same page.
+    await maintainer._upsert_wiki_graph(page, resolved_slugs=[], target_lang="en")
+    second_calls = list(graph_store.entity_edge_calls)
+
+    # First run produced exactly one edge.
+    assert len(first_calls) == 1
+    # Second run added one more (because we record every CALL, not every
+    # delta) — but the kwargs are identical, which is what makes the
+    # underlying Cypher MERGE idempotent.
+    assert len(second_calls) == 2
+    assert first_calls[0] == second_calls[1]

--- a/tests/stores/test_neo4j_store_heal_path.py
+++ b/tests/stores/test_neo4j_store_heal_path.py
@@ -1,0 +1,339 @@
+"""Tests for the Unresolved-stub heal-path in :mod:`neo4j_store`.
+
+Covers the four user-facing guarantees:
+
+  1. ``_upsert_relationship_with_stub_flag`` typed Unresolved (not Topic)
+     for both endpoints when both are unknown.
+  2. A subsequent typed ``upsert_entity`` promotes the Unresolved stub
+     in place — Cypher is a MATCH+SET, no second MERGE row.
+  3. ``prune_stub_orphans`` deletes Unresolved+awaiting_type+no-edges
+     entities older than the TTL; preserves ones with edges or younger.
+  4. ``upsert_wiki_reference_entity_edge`` is idempotent.
+
+All tests use the in-process mock driver pattern established by
+``tests/integration/test_relationship_stub_merge.py`` — no live Neo4j
+required.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from beever_atlas.models.domain import GraphEntity, GraphRelationship
+
+
+# ── shared mock-driver helpers (mirrors test_relationship_stub_merge) ──────
+
+
+def _make_neo4j_store_with_capture():
+    """Build a Neo4jStore with a mocked async driver and capture every
+    ``session.run`` call (query, kwargs).
+
+    Returns ``(store, calls, set_single_result)``.
+    """
+    from beever_atlas.stores.neo4j_store import Neo4jStore
+
+    store = Neo4jStore.__new__(Neo4jStore)
+    calls: list[dict] = []
+    next_single = {"value": None}
+    next_data = {"value": []}
+
+    mock_result = MagicMock()
+
+    async def _single():
+        return next_single["value"]
+
+    async def _data():
+        return next_data["value"]
+
+    mock_result.single = _single
+    mock_result.data = _data
+
+    mock_session = AsyncMock()
+
+    async def _run(query, **kwargs):
+        calls.append({"query": query, "kwargs": kwargs})
+        return mock_result
+
+    mock_session.run = _run
+    mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session.__aexit__ = AsyncMock(return_value=False)
+
+    mock_driver = MagicMock()
+    mock_driver.session = MagicMock(return_value=mock_session)
+    store._driver = mock_driver
+
+    def set_single_result(value):
+        next_single["value"] = value
+
+    return store, calls, set_single_result
+
+
+def _force_settings(monkeypatch, *, stub_endpoints: bool) -> None:
+    from beever_atlas.infra import config as _config_mod
+
+    real_settings = _config_mod.get_settings()
+    object.__setattr__(real_settings, "neo4j_relationship_stub_endpoints", stub_endpoints)
+
+
+# ── 1. Unknown endpoints create Unresolved stubs ───────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_relationship_two_unknown_endpoints_create_unresolved_stubs(monkeypatch):
+    """Both endpoints unknown → 2 stubs typed ``Unresolved`` (not
+    ``Topic``) with ``awaiting_type`` in stub_props.
+    """
+    _force_settings(monkeypatch, stub_endpoints=True)
+    store, calls, set_single = _make_neo4j_store_with_capture()
+    set_single({"eid": "rel-heal-1", "stubs_created": 2})
+
+    rel = GraphRelationship(
+        source="MysteryA",
+        target="MysteryB",
+        type="MENTIONS",
+        confidence=0.9,
+    )
+    eid, stub_count = await store._upsert_relationship_with_stub_flag(rel)
+
+    assert eid == "rel-heal-1"
+    assert stub_count == 2
+    assert len(calls) == 1
+    query = calls[0]["query"]
+    kwargs = calls[0]["kwargs"]
+    # Both endpoints MERGEd as Unresolved (variables renamed to _raw
+    # because they may be merged into a typed sibling immediately via
+    # apoc.refactor.mergeNodes — the symmetric heal pattern).
+    assert "MERGE (a_raw:Entity {name: $source, type: 'Unresolved', scope: 'global'})" in query
+    assert "MERGE (b_raw:Entity {name: $target, type: 'Unresolved', scope: 'global'})" in query
+    # The new symmetric-heal step references 'Topic' in the WHERE
+    # NOT IN clause that finds typed siblings to absorb the stub into.
+    # That's expected — what we do NOT want is creating a Topic stub.
+    assert "MERGE (a_raw:Entity {name: $source, type: 'Topic'" not in query
+    assert "MERGE (b_raw:Entity {name: $target, type: 'Topic'" not in query
+    # awaiting_type set both inside stub_props JSON and as a top-level
+    # node property (so prune/heal Cypher can filter on it).
+    assert kwargs["stub_props"] == (
+        '{"stub": true, "reason": "rel_endpoint", "awaiting_type": true}'
+    )
+    assert "a_raw.awaiting_type = true" in query
+    assert "b_raw.awaiting_type = true" in query
+    # Symmetric-heal step: OPTIONAL MATCH for typed siblings, then
+    # apoc.refactor.mergeNodes absorbs the stub into the typed row.
+    assert "apoc.refactor.mergeNodes" in query
+    assert "WHERE NOT a_typed.type IN ['Unresolved', 'Topic']" in query
+    assert "WHERE NOT b_typed.type IN ['Unresolved', 'Topic']" in query
+
+
+# ── 2. Typed upsert_entity promotes Unresolved stub in place ───────────────
+
+
+@pytest.mark.asyncio
+async def test_upsert_entity_heal_path_promotes_unresolved(monkeypatch):
+    """A typed ``upsert_entity`` (e.g. Person) for a name that already
+    has an Unresolved stub now emits ONE Cypher block: MERGE the typed
+    row, then ``apoc.refactor.mergeNodes`` absorbs the stub sibling
+    (and any legacy Topic sibling). The mock can't distinguish "merged
+    stub" from "fresh typed write" — it just verifies the new shape.
+    """
+    store, calls, set_single = _make_neo4j_store_with_capture()
+    set_single({"eid": "ent-healed-1"})
+
+    entity = GraphEntity(
+        name="Alice",
+        type="Person",
+        scope="global",
+    )
+    eid = await store.upsert_entity(entity)
+
+    assert eid == "ent-healed-1"
+    # Exactly one query — the symmetric heal runs MERGE + sibling
+    # absorption in a single Cypher block.
+    assert len(calls) == 1
+    query = calls[0]["query"]
+    assert "MERGE (typed:Entity {name: $name, type: $type, scope: 'global'})" in query
+    # Sibling absorption ladder: OPTIONAL MATCH for Unresolved/Topic
+    # siblings, then CALL apoc.refactor.mergeNodes.
+    assert "OPTIONAL MATCH (sib:Entity {name: $name, scope: 'global'})" in query
+    assert "sib.type IN ['Unresolved', 'Topic']" in query
+    assert "elementId(sib) <> elementId(typed)" in query
+    assert "apoc.refactor.mergeNodes" in query
+    assert "mergeRels: true" in query
+    # Old SET-only heal pattern is gone.
+    assert "SET e.type = $type" not in query
+    assert "REMOVE e.awaiting_type" not in query
+
+
+@pytest.mark.asyncio
+async def test_upsert_entity_heal_path_no_stub_creates_typed_row(monkeypatch):
+    """When no Unresolved/Topic stub exists for this name, the same
+    single Cypher block still runs — mergeNodes is a no-op on a
+    single-element list (the CASE guard avoids the call entirely)."""
+    store, calls, set_single = _make_neo4j_store_with_capture()
+    set_single({"eid": "ent-fresh-1"})
+
+    entity = GraphEntity(
+        name="Bob",
+        type="Person",
+        scope="global",
+    )
+    eid = await store.upsert_entity(entity)
+
+    assert eid == "ent-fresh-1"
+    # Single query — no fall-through to a separate typed MERGE block.
+    assert len(calls) == 1
+    query = calls[0]["query"]
+    assert "MERGE (typed:Entity {name: $name, type: $type, scope: 'global'})" in query
+    assert "apoc.refactor.mergeNodes" in query
+    # The CASE guard ensures mergeNodes isn't called noisily on an
+    # empty sibling list — the [typed] + sibs ladder appears.
+    assert "CASE WHEN size(sibs) > 0 THEN [typed] + sibs ELSE [typed] END" in query
+
+
+@pytest.mark.asyncio
+async def test_upsert_entity_with_unresolved_type_skips_heal_pre_check(monkeypatch):
+    """When the new entity itself is typed ``Unresolved`` (defensive —
+    should not happen from the LLM), the heal pre-check is skipped so
+    we don't infinite-loop healing ourselves.
+    """
+    store, calls, set_single = _make_neo4j_store_with_capture()
+    set_single({"eid": "ent-unresolved-1"})
+
+    entity = GraphEntity(
+        name="MaybeName",
+        type="Unresolved",
+        scope="global",
+    )
+    eid = await store.upsert_entity(entity)
+    assert eid == "ent-unresolved-1"
+    # Only one query — the typed MERGE, not the heal MATCH.
+    assert len(calls) == 1
+    query = calls[0]["query"]
+    # No heal MATCH — straight to the MERGE.
+    assert "MATCH (e:Entity {name: $name, scope: 'global', type: 'Unresolved'})" not in query
+    assert "MERGE (e:Entity {name: $name, type: $type, scope: 'global'})" in query
+
+
+# ── 3. prune_stub_orphans ──────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_prune_stub_orphans_returns_count(monkeypatch):
+    """``prune_stub_orphans`` returns the count from the Cypher query
+    and issues the expected predicate (type IN Unresolved/Topic,
+    no edges, older than cutoff). The ``awaiting_type`` filter was
+    dropped so legacy Topic stubs (which never carried the flag) are
+    also reaped once edge-less.
+    """
+    store, calls, set_single = _make_neo4j_store_with_capture()
+    set_single({"n": 3})
+
+    purged = await store.prune_stub_orphans(ttl_hours=24)
+
+    assert purged == 3
+    assert len(calls) == 1
+    query = calls[0]["query"]
+    assert "e.type IN ['Unresolved', 'Topic']" in query
+    assert "NOT EXISTS { MATCH (e)--() }" in query
+    assert "e.created_at < $cutoff" in query
+    assert "DETACH DELETE e" in query
+    # The cutoff kwarg should be an ISO timestamp string.
+    assert "cutoff" in calls[0]["kwargs"]
+    assert isinstance(calls[0]["kwargs"]["cutoff"], str)
+
+
+@pytest.mark.asyncio
+async def test_prune_stub_orphans_returns_zero_when_nothing_matches(monkeypatch):
+    """When no rows match the predicate, ``count(e)`` is 0 and the
+    function returns 0 — not None."""
+    store, _calls, set_single = _make_neo4j_store_with_capture()
+    set_single({"n": 0})
+
+    purged = await store.prune_stub_orphans(ttl_hours=24)
+    assert purged == 0
+
+
+# ── 4. upsert_wiki_reference_entity_edge idempotency ──────────────────────
+
+
+@pytest.mark.asyncio
+async def test_upsert_wiki_reference_entity_edge_idempotent(monkeypatch):
+    """Calling the entity-edge writer twice produces the same Cypher
+    (MERGE) so the second invocation does not create a duplicate edge.
+    Both invocations land identical kwargs.
+    """
+    store, calls, set_single = _make_neo4j_store_with_capture()
+    set_single(None)
+
+    await store.upsert_wiki_reference_entity_edge(
+        channel_id="C-test",
+        target_lang="en",
+        src_slug="topic:auth",
+        entity_name="Alice",
+    )
+    await store.upsert_wiki_reference_entity_edge(
+        channel_id="C-test",
+        target_lang="en",
+        src_slug="topic:auth",
+        entity_name="Alice",
+    )
+
+    assert len(calls) == 2
+    # Same Cypher for both calls.
+    assert calls[0]["query"] == calls[1]["query"]
+    # Same kwargs.
+    assert calls[0]["kwargs"] == calls[1]["kwargs"]
+    # MERGE is used for the edge (idempotency in Neo4j's terms).
+    query = calls[0]["query"]
+    assert "MERGE (src)-[:REFERENCES_ENTITY]->(e)" in query
+    # WikiPage is MATCHed (must exist), Entity is MATCHed (no stub creation).
+    assert "MATCH (src:WikiPage {channel_id: $channel_id, target_lang: $target_lang, slug: $src_slug})" in query
+    assert "MATCH (e:Entity {name: $entity_name})" in query
+
+
+# ── 5. delete_channel_wiki_graph ─────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_delete_channel_wiki_graph_returns_count():
+    """``delete_channel_wiki_graph`` issues a DETACH DELETE on WikiPage
+    nodes filtered by channel_id and returns the count from the single
+    record.
+    """
+    store, calls, set_single = _make_neo4j_store_with_capture()
+    set_single({"n": 7})
+
+    deleted = await store.delete_channel_wiki_graph("C-reset")
+
+    assert deleted == 7
+    assert len(calls) == 1
+    query = calls[0]["query"]
+    assert "WikiPage" in query
+    assert "DETACH DELETE" in query
+    assert calls[0]["kwargs"] == {"channel_id": "C-reset"}
+
+
+@pytest.mark.asyncio
+async def test_delete_channel_wiki_graph_returns_zero_when_empty():
+    """When no rows match, ``count(w)=0`` and the method returns 0
+    (not None) so callers can sum counts without conditional logic.
+    """
+    store, _calls, set_single = _make_neo4j_store_with_capture()
+    set_single({"n": 0})
+
+    deleted = await store.delete_channel_wiki_graph("C-empty")
+    assert deleted == 0
+
+
+@pytest.mark.asyncio
+async def test_delete_channel_wiki_graph_handles_missing_record():
+    """``result.single()`` may return None on an empty cursor; the
+    method must still return 0 rather than blow up.
+    """
+    store, _calls, set_single = _make_neo4j_store_with_capture()
+    set_single(None)
+
+    deleted = await store.delete_channel_wiki_graph("C-no-record")
+    assert deleted == 0

--- a/tests/stores/test_neo4j_store_heal_path.py
+++ b/tests/stores/test_neo4j_store_heal_path.py
@@ -289,7 +289,10 @@ async def test_upsert_wiki_reference_entity_edge_idempotent(monkeypatch):
     query = calls[0]["query"]
     assert "MERGE (src)-[:REFERENCES_ENTITY]->(e)" in query
     # WikiPage is MATCHed (must exist), Entity is MATCHed (no stub creation).
-    assert "MATCH (src:WikiPage {channel_id: $channel_id, target_lang: $target_lang, slug: $src_slug})" in query
+    assert (
+        "MATCH (src:WikiPage {channel_id: $channel_id, target_lang: $target_lang, slug: $src_slug})"
+        in query
+    )
     assert "MATCH (e:Entity {name: $entity_name})" in query
 
 

--- a/tests/test_graph_protocol.py
+++ b/tests/test_graph_protocol.py
@@ -124,6 +124,58 @@ class MockGraphStore:
             self._id_map.pop(entity.id, None)
         return len(to_remove)
 
+    async def prune_stub_orphans(self, ttl_hours: int = 24) -> int:
+        from datetime import timedelta
+
+        cutoff = datetime.now(tz=UTC) - timedelta(hours=ttl_hours)
+        connected = {r.source for r in self._relationships} | {r.target for r in self._relationships}
+        to_remove = [
+            name
+            for name, e in self._entities.items()
+            if e.type == "Unresolved"
+            and getattr(e, "awaiting_type", False)
+            and name not in connected
+            and getattr(e, "created_at", None) is not None
+            and e.created_at < cutoff
+        ]
+        for name in to_remove:
+            entity = self._entities.pop(name)
+            self._id_map.pop(entity.id, None)
+        return len(to_remove)
+
+    async def list_co_mention_edges(
+        self,
+        channel_id: str,
+        min_shared: int = 2,
+        limit: int = 500,
+    ) -> list[GraphRelationship]:
+        # MockGraphStore does not model Event nodes / MENTIONED_IN edges,
+        # so no synthetic co-mention pairs can be derived. Returning []
+        # matches the production behaviour for channels with no facts.
+        return []
+
+    async def list_unresolved_stubs(
+        self,
+        channel_id: str | None = None,
+        limit: int = 500,
+    ) -> list[dict[str, Any]]:
+        return []
+
+    async def fetch_incident_contexts_batch(
+        self,
+        names: list[str],
+        limit_per_name: int = 3,
+    ) -> dict[str, list[str]]:
+        return {}
+
+    async def mark_unresolved_attempt(
+        self,
+        name: str,
+        scope: str,
+        channel_id: str | None,
+    ) -> None:
+        return None
+
     # -- Relationship CRUD ---------------------------------------------------
 
     async def upsert_relationship(self, rel: GraphRelationship) -> str:
@@ -232,6 +284,11 @@ class MockGraphStore:
             entity = self._entities.pop(name)
             self._id_map.pop(entity.id, None)
         return {"entities_deleted": len(to_remove), "events_deleted": 0, "media_deleted": 0}
+
+    async def delete_channel_wiki_graph(self, channel_id: str) -> int:
+        # The mock does not model :WikiPage nodes — return 0 to satisfy
+        # the protocol contract.
+        return 0
 
     # -- Entity-registry support ---------------------------------------------
 

--- a/tests/test_graph_protocol.py
+++ b/tests/test_graph_protocol.py
@@ -128,7 +128,9 @@ class MockGraphStore:
         from datetime import timedelta
 
         cutoff = datetime.now(tz=UTC) - timedelta(hours=ttl_hours)
-        connected = {r.source for r in self._relationships} | {r.target for r in self._relationships}
+        connected = {r.source for r in self._relationships} | {
+            r.target for r in self._relationships
+        }
         to_remove = [
             name
             for name, e in self._entities.items()

--- a/web/src/components/channel/ChannelSettingsTab.tsx
+++ b/web/src/components/channel/ChannelSettingsTab.tsx
@@ -1,7 +1,11 @@
 import { useState, useEffect } from "react";
-import { useParams } from "react-router-dom";
-import { Loader2, Clock, Zap, Calendar, Hand, ChevronDown, ChevronRight, Settings2, Info, Sparkles, FolderTree, BookOpen } from "lucide-react";
+import { useParams, useNavigate } from "react-router-dom";
+import { Loader2, Clock, Zap, Calendar, Hand, ChevronDown, ChevronRight, Settings2, Info, Sparkles, FolderTree, BookOpen, AlertTriangle, RefreshCw, X as XIcon } from "lucide-react";
 import { useChannelPolicy } from "@/hooks/useChannelPolicy";
+import { useChannelSummary } from "@/hooks/useChannelSummary";
+import { useToast } from "@/hooks/useToast";
+import { ToastViewport } from "@/components/settings/ToastViewport";
+import { API_BASE, ApiError, adminHeaders, authFetch } from "@/lib/api";
 import { cn } from "@/lib/utils";
 import type { SyncConfig, IngestionConfig, ConsolidationConfig, ConsolidationStrategy, WikiConfig, WikiGenerationStrategy, WikiMaintenanceMode } from "@/lib/types";
 
@@ -114,7 +118,10 @@ function Toggle({ checked, onChange }: { checked: boolean; onChange: (v: boolean
 export function ChannelSettingsTab() {
   const { id } = useParams<{ id: string }>();
   const channelId = id ?? "";
+  const navigate = useNavigate();
   const { policy, isLoading, savePolicy, deletePolicy } = useChannelPolicy(channelId);
+  const { summary } = useChannelSummary(channelId);
+  const toast = useToast();
 
   const [sync, setSync] = useState<SyncConfig>(DEFAULT_SYNC);
   const [ingestion, setIngestion] = useState<IngestionConfig>(DEFAULT_INGESTION);
@@ -124,6 +131,125 @@ export function ChannelSettingsTab() {
   const [resetting, setResetting] = useState(false);
   const [feedback, setFeedback] = useState<{ kind: "success" | "error"; message: string } | null>(null);
   const [showMore, setShowMore] = useState(false);
+
+  // Danger Zone — Reset & Re-sync dialog state.
+  const [dangerOpen, setDangerOpen] = useState(false);
+  const [confirmText, setConfirmText] = useState("");
+  const [dangerSubmitting, setDangerSubmitting] = useState(false);
+  // Use the summary's display name when available, otherwise fall back
+  // to the channel id so the user can still confirm even before the
+  // summary endpoint resolves.
+  const channelDisplayName = summary?.channel_name || channelId;
+  const dangerMatch = confirmText.trim() === channelDisplayName.trim() && confirmText.trim().length > 0;
+
+  async function handleDangerConfirm() {
+    if (!dangerMatch || dangerSubmitting) return;
+    setDangerSubmitting(true);
+    try {
+      // Three-step sequence so each subsystem owns its own reset path
+      // without one endpoint reimplementing another:
+      //   1. /admin/.../reset    — wipes derived knowledge (entities,
+      //                            facts, sync state, message status).
+      //                            Wiki is intentionally untouched.
+      //   2. /wiki/refresh       — archives current wiki to version
+      //      ?mode=rebuild        history (rollback preserved) then
+      //                            wipes + schedules regeneration.
+      //   3. /sync               — kicks the full re-extraction; the
+      //      ?sync_type=full      wiki maintainer rebuilds pages
+      //                            incrementally as memories land.
+      const resetParams = new URLSearchParams({
+        i_understand_data_loss: "yes",
+        trigger_resync: "false",
+      });
+      const resetResp = await authFetch(
+        `${API_BASE}/api/admin/channels/${encodeURIComponent(channelId)}/reset?${resetParams.toString()}`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            ...adminHeaders(),
+          },
+        },
+      );
+      if (resetResp.status === 409) {
+        toast.show("A sync is already running. Cancel or wait, then try again.", "error");
+        setDangerSubmitting(false);
+        return;
+      }
+      if (!resetResp.ok) {
+        let msg = `Reset failed (${resetResp.status})`;
+        try {
+          const body = await resetResp.json();
+          if (typeof body?.detail === "string") msg = body.detail;
+        } catch {
+          // ignore JSON parse errors
+        }
+        toast.show(msg, "error");
+        setDangerSubmitting(false);
+        return;
+      }
+
+      // Step 2: archive current wiki → wipe → schedule regeneration.
+      // Non-fatal: a failure here leaves the reset committed but the
+      // wiki untouched (user can manually trigger a rebuild later).
+      try {
+        const wikiResp = await authFetch(
+          `${API_BASE}/api/channels/${encodeURIComponent(channelId)}/wiki/refresh?mode=rebuild`,
+          { method: "POST" },
+        );
+        if (!wikiResp.ok) {
+          toast.show(
+            `Reset succeeded, but wiki rebuild trigger returned ${wikiResp.status}.`,
+            "error",
+          );
+        }
+      } catch {
+        toast.show("Reset succeeded, but wiki rebuild trigger failed.", "error");
+      }
+
+      // Step 3: kick the full sync so messages are re-extracted.
+      try {
+        const syncResp = await authFetch(
+          `${API_BASE}/api/channels/${encodeURIComponent(channelId)}/sync?sync_type=full`,
+          { method: "POST" },
+        );
+        if (!syncResp.ok) {
+          toast.show(`Sync trigger returned ${syncResp.status}.`, "error");
+        }
+      } catch {
+        toast.show("Reset succeeded, but sync trigger failed — click Sync Channel.", "error");
+      }
+
+      toast.show("Channel reset complete. Wiki rebuild + full re-sync started.", "info");
+      setDangerOpen(false);
+      setConfirmText("");
+      setDangerSubmitting(false);
+      // Navigate to the sync-history tab so the user sees the freshly
+      // triggered job progress (route from ``App.tsx`` is
+      // ``/channels/:id/sync-history``).
+      navigate(`/channels/${encodeURIComponent(channelId)}/sync-history`);
+    } catch (err: unknown) {
+      const msg =
+        err instanceof ApiError
+          ? err.message
+          : err instanceof Error
+            ? err.message
+            : "Reset request failed";
+      toast.show(msg, "error");
+      setDangerSubmitting(false);
+    }
+  }
+
+  function openDangerDialog() {
+    setConfirmText("");
+    setDangerOpen(true);
+  }
+
+  function closeDangerDialog() {
+    if (dangerSubmitting) return;
+    setDangerOpen(false);
+    setConfirmText("");
+  }
 
   const selectedFreq = detectFrequency(sync);
   const deepAnalysis = !(ingestion.skip_entity_extraction ?? false);
@@ -568,7 +694,106 @@ export function ChannelSettingsTab() {
           {resetting ? "Resetting..." : "Reset to defaults"}
         </button>
       </div>
+
+      {/* ── Danger Zone ──────────────────────────────────── */}
+      <div className="mt-8 rounded-2xl border border-destructive/40 bg-destructive/5 px-5 py-4 space-y-3">
+        <div className="flex items-center gap-2">
+          <AlertTriangle className="h-4 w-4 text-destructive" />
+          <h4 className="text-sm font-semibold text-destructive">Danger Zone</h4>
+        </div>
+        <p className="text-[12px] leading-relaxed text-muted-foreground">
+          Drops this channel&apos;s extracted memory, wiki, and graph. Messages stay intact;
+          the next sync will re-extract everything with the current pipeline. Use this
+          after pipeline changes.
+        </p>
+        <div>
+          <button
+            type="button"
+            onClick={openDangerDialog}
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-destructive/15 text-destructive border border-destructive/30 text-sm font-medium hover:bg-destructive/25 transition-colors"
+          >
+            <RefreshCw className="h-3.5 w-3.5" />
+            Reset &amp; Re-sync
+          </button>
+        </div>
       </div>
+      </div>
+
+      {/* ── Confirm dialog ───────────────────────────────── */}
+      {dangerOpen && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="danger-zone-title"
+          className="fixed inset-0 z-40 flex items-center justify-center bg-background/80 backdrop-blur-sm"
+          onClick={closeDangerDialog}
+        >
+          <div
+            className="w-full max-w-md mx-4 rounded-2xl border border-border bg-card shadow-xl p-5 space-y-4"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="flex items-start justify-between gap-2">
+              <div className="flex items-center gap-2">
+                <AlertTriangle className="h-4 w-4 text-destructive" />
+                <h3 id="danger-zone-title" className="text-sm font-semibold text-foreground">
+                  Reset &amp; Re-sync this channel?
+                </h3>
+              </div>
+              <button
+                type="button"
+                onClick={closeDangerDialog}
+                disabled={dangerSubmitting}
+                aria-label="Close"
+                className="opacity-70 hover:opacity-100 disabled:opacity-30"
+              >
+                <XIcon className="h-4 w-4" />
+              </button>
+            </div>
+            <p className="text-[12px] leading-relaxed text-muted-foreground">
+              This drops <strong>{channelDisplayName}</strong>&apos;s extracted memory,
+              wiki pages, and graph. Messages stay intact. A full re-sync starts
+              immediately and rebuilds everything with the current pipeline.
+            </p>
+            <div className="space-y-1.5">
+              <label className="text-[11px] text-muted-foreground" htmlFor="danger-confirm-input">
+                Type the channel name to confirm:{" "}
+                <span className="font-mono text-foreground">{channelDisplayName}</span>
+              </label>
+              <input
+                id="danger-confirm-input"
+                type="text"
+                value={confirmText}
+                onChange={(e) => setConfirmText(e.target.value)}
+                disabled={dangerSubmitting}
+                placeholder={channelDisplayName}
+                autoFocus
+                className="w-full rounded-lg border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-destructive/40"
+              />
+            </div>
+            <div className="flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={closeDangerDialog}
+                disabled={dangerSubmitting}
+                className="px-3 py-1.5 rounded-lg border border-border text-sm text-muted-foreground hover:bg-muted hover:text-foreground transition-colors disabled:opacity-50"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={handleDangerConfirm}
+                disabled={!dangerMatch || dangerSubmitting}
+                className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-destructive text-destructive-foreground text-sm font-medium hover:bg-destructive/90 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+              >
+                {dangerSubmitting && <Loader2 size={14} className="animate-spin" />}
+                {dangerSubmitting ? "Resetting..." : "Reset & Re-sync"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      <ToastViewport toasts={toast.toasts} onDismiss={toast.dismiss} />
     </div>
   );
 }

--- a/web/src/components/graph/EntityPanel.tsx
+++ b/web/src/components/graph/EntityPanel.tsx
@@ -2,9 +2,12 @@ import { useState, useEffect } from "react";
 import { X } from "lucide-react";
 import type { GraphEntity, GraphRelationship } from "@/hooks/useGraph";
 import { useEntityFacts } from "@/hooks/useEntityFacts";
+import { useEntityCard } from "@/hooks/useEntityCard";
 import { FactCard } from "@/components/memories/FactCard";
 import { cn } from "@/lib/utils";
 import { getTypeColors } from "./GraphFilters";
+
+type PanelTab = "card" | "details" | "facts";
 
 interface EntityPanelProps {
   entity: GraphEntity;
@@ -12,6 +15,13 @@ interface EntityPanelProps {
   allEntities: GraphEntity[];
   channelId: string;
   onClose: () => void;
+  /** Optional: clicking a related entity in the Card tab pivots the
+   *  parent's selectedId to a new entity (by name). The parent is
+   *  responsible for name→id resolution; this panel just announces. */
+  onNavigate?: (name: string) => void;
+  /** Which tab opens first; defaults to "card" since graph-click is the
+   *  primary entry point and the card is the headline content. */
+  defaultTab?: PanelTab;
 }
 
 export function EntityPanel({
@@ -20,13 +30,33 @@ export function EntityPanel({
   allEntities,
   channelId,
   onClose,
+  onNavigate,
+  defaultTab = "card",
 }: EntityPanelProps) {
-  const [activeTab, setActiveTab] = useState<"details" | "facts">("details");
+  const [activeTab, setActiveTab] = useState<PanelTab>(defaultTab);
 
   // Reset tab when entity changes
   useEffect(() => {
-    setActiveTab("details");
-  }, [entity.id]);
+    setActiveTab(defaultTab);
+  }, [entity.id, defaultTab]);
+
+  // ESC closes the panel (document-level listener, scoped to mount).
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        onClose();
+      }
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  const {
+    card,
+    loading: cardLoading,
+    error: cardError,
+    notFound: cardNotFound,
+  } = useEntityCard(activeTab === "card" ? entity.name : null);
 
   const { facts, total, loading: factsLoading } = useEntityFacts(
     channelId,
@@ -47,6 +77,10 @@ export function EntityPanel({
     : [];
 
   const aliases = entity.aliases ?? [];
+
+  // Build a lower-case name set so we can flag related-entity links as
+  // "cross-channel" (not loaded in the current canvas).
+  const loadedNameSet = new Set(allEntities.map((e) => e.name.toLowerCase()));
 
   return (
     <div className="w-full sm:w-96 shrink-0 border-l border-border bg-card flex flex-col overflow-hidden absolute sm:relative inset-0 sm:inset-auto z-10 sm:z-auto">
@@ -83,6 +117,17 @@ export function EntityPanel({
       {/* Tab bar */}
       <div className="flex border-b border-border">
         <button
+          onClick={() => setActiveTab("card")}
+          className={cn(
+            "flex-1 px-3 py-2 text-xs font-medium transition-colors",
+            activeTab === "card"
+              ? "text-foreground border-b-2 border-primary"
+              : "text-muted-foreground hover:text-foreground",
+          )}
+        >
+          Card
+        </button>
+        <button
           onClick={() => setActiveTab("details")}
           className={cn(
             "flex-1 px-3 py-2 text-xs font-medium transition-colors",
@@ -108,6 +153,157 @@ export function EntityPanel({
 
       {/* Tab content */}
       <div className="flex-1 overflow-y-auto">
+        {activeTab === "card" && (
+          <div className="divide-y divide-border">
+            {cardLoading && (
+              <div className="px-4 py-4 space-y-2" aria-label="Loading entity card">
+                <div className="h-3 rounded bg-muted animate-pulse" />
+                <div className="h-3 rounded bg-muted animate-pulse w-5/6" />
+                <div className="h-3 rounded bg-muted animate-pulse w-4/6" />
+              </div>
+            )}
+
+            {!cardLoading && cardNotFound && (
+              <div className="px-4 py-6 text-center">
+                <p className="text-xs text-muted-foreground">
+                  No knowledge card has been generated for this entity yet.
+                </p>
+              </div>
+            )}
+
+            {!cardLoading && cardError && (
+              <div className="px-4 py-6 text-center">
+                <p className="text-xs text-destructive">{cardError}</p>
+              </div>
+            )}
+
+            {!cardLoading && card && (
+              <>
+                {/* Summary / bio */}
+                {card.summary && (
+                  <section className="px-4 py-3">
+                    <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-2">
+                      Summary
+                    </p>
+                    <p className="text-xs text-foreground leading-relaxed whitespace-pre-wrap">
+                      {card.summary}
+                    </p>
+                  </section>
+                )}
+
+                {/* Aliases (also surfaced here for parity with the Details tab) */}
+                {aliases.length > 0 && (
+                  <section className="px-4 py-3">
+                    <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-2">
+                      Aliases
+                    </p>
+                    <div className="flex flex-wrap gap-1">
+                      {aliases.map((alias) => (
+                        <span
+                          key={alias}
+                          className="px-2 py-0.5 rounded-md bg-muted text-xs text-muted-foreground"
+                        >
+                          {alias}
+                        </span>
+                      ))}
+                    </div>
+                  </section>
+                )}
+
+                {/* Key facts */}
+                {card.key_facts.length > 0 && (
+                  <section className="px-4 py-3">
+                    <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-2">
+                      Key facts
+                    </p>
+                    <ul className="space-y-1.5 list-disc list-inside">
+                      {card.key_facts.map((fact, i) => (
+                        <li key={i} className="text-xs text-foreground leading-snug">
+                          {fact}
+                        </li>
+                      ))}
+                    </ul>
+                  </section>
+                )}
+
+                {/* Related entities */}
+                {card.related_entities.length > 0 && (
+                  <section className="px-4 py-3">
+                    <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-2">
+                      Related entities
+                    </p>
+                    <ul className="space-y-1">
+                      {card.related_entities.map((rel, i) => {
+                        const name = typeof rel.name === "string" ? rel.name : null;
+                        const type = typeof rel.type === "string" ? rel.type : null;
+                        if (!name) return null;
+                        const isLoaded = loadedNameSet.has(name.toLowerCase());
+                        return (
+                          <li key={`${name}-${i}`} className="flex items-center gap-2">
+                            <button
+                              type="button"
+                              onClick={() => isLoaded && onNavigate?.(name)}
+                              disabled={!isLoaded}
+                              className={cn(
+                                "text-left text-xs flex-1 min-w-0 truncate transition-colors",
+                                isLoaded
+                                  ? "text-foreground hover:text-primary cursor-pointer underline-offset-2 hover:underline"
+                                  : "text-muted-foreground cursor-not-allowed",
+                              )}
+                              title={
+                                isLoaded
+                                  ? `Open ${name}`
+                                  : `${name} is not loaded in the current channel`
+                              }
+                            >
+                              {name}
+                            </button>
+                            {type && (
+                              <span className="text-[10px] text-muted-foreground shrink-0">
+                                {type}
+                              </span>
+                            )}
+                          </li>
+                        );
+                      })}
+                    </ul>
+                  </section>
+                )}
+
+                {/* Citations: surfaced via fact_count + breakdown for now;
+                    `source_message_id` links are out-of-scope until the
+                    fact extractor pins a citation token format (see plan
+                    §C.4.2 C-2 deferral). */}
+                {card.fact_count > 0 && (
+                  <section className="px-4 py-3">
+                    <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-2">
+                      Citations
+                    </p>
+                    <p className="text-xs text-muted-foreground">
+                      {card.fact_count} supporting fact
+                      {card.fact_count === 1 ? "" : "s"}
+                      {card.last_mentioned_at
+                        ? ` · last mentioned ${card.last_mentioned_at.slice(0, 10)}`
+                        : ""}
+                    </p>
+                  </section>
+                )}
+
+                {!card.summary &&
+                  card.key_facts.length === 0 &&
+                  card.related_entities.length === 0 &&
+                  aliases.length === 0 && (
+                    <div className="px-4 py-6 text-center">
+                      <p className="text-xs text-muted-foreground">
+                        This entity has a card but no summary or related entities yet.
+                      </p>
+                    </div>
+                  )}
+              </>
+            )}
+          </div>
+        )}
+
         {activeTab === "details" && (
           <div className="divide-y divide-border">
             {/* Aliases */}

--- a/web/src/components/graph/EntitySearchPalette.tsx
+++ b/web/src/components/graph/EntitySearchPalette.tsx
@@ -1,0 +1,208 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Search } from "lucide-react";
+import type { GraphEntity } from "@/hooks/useGraph";
+import { cn } from "@/lib/utils";
+import { getTypeColors } from "./GraphFilters";
+
+interface EntitySearchPaletteProps {
+  entities: GraphEntity[];
+  open: boolean;
+  onClose: () => void;
+  /** Fires with the selected entity ID; the parent forwards to the canvas
+   *  ref's imperative `focusNode`. */
+  onSelect: (id: string) => void;
+}
+
+const MAX_RESULTS = 25;
+
+/**
+ * cmd-K (or ctrl-K) search palette for entities. Document-level hotkey
+ * binding lives in `MemoryGraphView`; this component owns the modal,
+ * input focus, keyboard nav (up/down/Enter), and ESC-to-close.
+ *
+ * Filter: case-insensitive substring on entity name and aliases. Simple
+ * but enough for v1 (per plan §E.4). No external fuzzy library.
+ */
+export function EntitySearchPalette({
+  entities,
+  open,
+  onClose,
+  onSelect,
+}: EntitySearchPaletteProps) {
+  const [query, setQuery] = useState("");
+  const [activeIdx, setActiveIdx] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLUListElement>(null);
+
+  // Reset state on open
+  useEffect(() => {
+    if (open) {
+      setQuery("");
+      setActiveIdx(0);
+      // Autofocus after the modal mounts.
+      const t = window.setTimeout(() => inputRef.current?.focus(), 0);
+      return () => window.clearTimeout(t);
+    }
+  }, [open]);
+
+  const results = useMemo(() => {
+    if (!open) return [];
+    const q = query.trim().toLowerCase();
+    if (!q) {
+      // Empty query → show the first N by name asc, so the palette is
+      // useful even on cmd-K with no typing.
+      return [...entities]
+        .sort((a, b) => a.name.localeCompare(b.name))
+        .slice(0, MAX_RESULTS);
+    }
+    const filtered = entities.filter((e) => {
+      if (e.name.toLowerCase().includes(q)) return true;
+      const aliases = e.aliases ?? [];
+      return aliases.some((a) => a.toLowerCase().includes(q));
+    });
+    // Rank: prefix matches first, then substring matches.
+    filtered.sort((a, b) => {
+      const aPrefix = a.name.toLowerCase().startsWith(q) ? 0 : 1;
+      const bPrefix = b.name.toLowerCase().startsWith(q) ? 0 : 1;
+      if (aPrefix !== bPrefix) return aPrefix - bPrefix;
+      return a.name.localeCompare(b.name);
+    });
+    return filtered.slice(0, MAX_RESULTS);
+  }, [entities, query, open]);
+
+  // Clamp the active index when results change.
+  useEffect(() => {
+    setActiveIdx((i) => {
+      if (results.length === 0) return 0;
+      if (i >= results.length) return results.length - 1;
+      return i;
+    });
+  }, [results]);
+
+  // Keep the active row in view on arrow-nav.
+  useEffect(() => {
+    const list = listRef.current;
+    if (!list) return;
+    const child = list.children.item(activeIdx) as HTMLElement | null;
+    child?.scrollIntoView({ block: "nearest" });
+  }, [activeIdx]);
+
+  if (!open) return null;
+
+  const handleKey = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setActiveIdx((i) => Math.min(i + 1, Math.max(0, results.length - 1)));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setActiveIdx((i) => Math.max(i - 1, 0));
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      const chosen = results[activeIdx];
+      if (chosen) {
+        onSelect(chosen.id);
+        onClose();
+      }
+    } else if (e.key === "Escape") {
+      // Stop propagation so the EntityPanel's document-level ESC handler
+      // (in EntityPanel.tsx) doesn't also fire and close the panel.
+      e.preventDefault();
+      e.stopPropagation();
+      onClose();
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-start justify-center pt-[15vh] px-4"
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Search entities"
+    >
+      {/* Backdrop */}
+      <div className="absolute inset-0 bg-background/70 backdrop-blur-sm" />
+
+      {/* Modal */}
+      <div
+        className="relative w-full max-w-lg rounded-xl border border-border bg-card shadow-2xl overflow-hidden"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center gap-2 px-3 py-2.5 border-b border-border">
+          <Search className="w-4 h-4 text-muted-foreground shrink-0" />
+          <input
+            ref={inputRef}
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onKeyDown={handleKey}
+            placeholder="Search entities..."
+            className="flex-1 bg-transparent text-sm text-foreground placeholder:text-muted-foreground focus:outline-none"
+            aria-label="Entity search query"
+          />
+          <kbd className="hidden sm:inline-flex items-center px-1.5 py-0.5 rounded border border-border/70 text-[10px] font-mono text-muted-foreground">
+            esc
+          </kbd>
+        </div>
+
+        {results.length === 0 ? (
+          <div className="px-4 py-6 text-center">
+            <p className="text-xs text-muted-foreground">
+              {query.trim() ? "No entities match your search." : "No entities loaded."}
+            </p>
+          </div>
+        ) : (
+          <ul
+            ref={listRef}
+            className="max-h-[50vh] overflow-y-auto py-1"
+            role="listbox"
+            aria-label="Search results"
+          >
+            {results.map((e, idx) => {
+              const colors = getTypeColors(e.type);
+              const isActive = idx === activeIdx;
+              return (
+                <li
+                  key={e.id}
+                  role="option"
+                  aria-selected={isActive}
+                  onMouseEnter={() => setActiveIdx(idx)}
+                  onClick={() => {
+                    onSelect(e.id);
+                    onClose();
+                  }}
+                  className={cn(
+                    "flex items-center gap-2 px-3 py-2 cursor-pointer transition-colors",
+                    isActive ? "bg-muted" : "hover:bg-muted/60",
+                  )}
+                >
+                  <span
+                    className="w-2 h-2 rounded-full shrink-0"
+                    style={{ backgroundColor: colors.node }}
+                  />
+                  <span className="text-sm text-foreground truncate flex-1 min-w-0">
+                    {e.name}
+                  </span>
+                  <span className="text-[10px] text-muted-foreground shrink-0">
+                    {e.type}
+                  </span>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+
+        <div className="flex items-center gap-3 px-3 py-1.5 border-t border-border bg-muted/30 text-[10px] text-muted-foreground">
+          <span className="inline-flex items-center gap-1">
+            <kbd className="px-1 py-0.5 rounded border border-border/70 font-mono">↑↓</kbd>
+            navigate
+          </span>
+          <span className="inline-flex items-center gap-1">
+            <kbd className="px-1 py-0.5 rounded border border-border/70 font-mono">↵</kbd>
+            select
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/graph/GraphCanvas.tsx
+++ b/web/src/components/graph/GraphCanvas.tsx
@@ -1,4 +1,10 @@
-import { useEffect, useLayoutEffect, useRef } from "react";
+import {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useLayoutEffect,
+  useRef,
+} from "react";
 import cytoscape, { type Core, type ElementDefinition } from "cytoscape";
 // fcose: better organic spread than vanilla cose. Drop-in extension
 // — register once at module load, then use ``layout: { name: "fcose" }``.
@@ -36,6 +42,29 @@ interface GraphCanvasProps {
   /** Callback so parent can read the current orphan count for the
    *  pill. Optional for the same reason as ``showOrphans``. */
   onOrphanCount?: (count: number) => void;
+  /** Nodes with fewer connections than this are rendered without their
+   *  label until hovered or selected. Default 3 hides ~70% of labels
+   *  in the typical hairball. Set to 0 to always show all labels. */
+  labelMinDegree?: number;
+  /** Min/max opacity for the recency ramp on edges with a `valid_from`
+   *  timestamp. Edges without `valid_from` render at `edgeOpacityMin`. */
+  edgeOpacityMin?: number;
+  edgeOpacityMax?: number;
+}
+
+/**
+ * Imperative handle exposed to the parent via `ref`. Used by the cmd-K
+ * palette to pan/zoom to a chosen entity without round-tripping through
+ * React state.
+ *
+ * NOTE: this is the first `useImperativeHandle` in `web/src/components/graph/`.
+ * The pattern is justified here because the palette → graph call is a
+ * one-shot animation, not a state-derived render — modeling it as state
+ * would create a temporary "focused" prop that races with the cytoscape
+ * animation lifecycle.
+ */
+export interface GraphCanvasHandle {
+  focusNode: (id: string) => void;
 }
 
 /** Cache of node positions keyed by entity ID for deterministic layout */
@@ -65,6 +94,7 @@ function buildNode(
   e: GraphEntity,
   connectionCount: Map<string, number>,
   filteredIds: Set<string>,
+  labelMinDegree: number,
 ): ElementDefinition {
   const colors = getTypeColors(e.type);
   const conns = connectionCount.get(e.id) ?? 0;
@@ -77,10 +107,16 @@ function buildNode(
   // Larger label font so the user doesn't have to zoom in to read each
   // node — 11 px base for orphans, scaling up to 14 px for hubs.
   const fontSize = conns === 0 ? 11 : Math.min(14, 11 + Math.floor(conns / 2));
+  const label = prepareLabel(e.name);
+  // E-2: hide labels for low-degree nodes by default; the `.hovered` /
+  // `.focused` / selection classes override via cytoscape style and bind
+  // back to `data(label)` to reveal.
+  const visibleLabel = conns >= labelMinDegree ? label : "";
   return {
     data: {
       id: e.id,
-      label: prepareLabel(e.name),
+      label,
+      visibleLabel,
       type: e.type,
       bgColor: colors.node,
       borderColor: colors.nodeBorder,
@@ -95,15 +131,27 @@ function buildNode(
   };
 }
 
-export function GraphCanvas({
-  entities,
-  relationships,
-  visibleTypes,
-  showOrphans = false,
-  onSelectEntity,
-  selectedEntityId,
-  onOrphanCount,
-}: GraphCanvasProps) {
+export const GraphCanvas = forwardRef<GraphCanvasHandle, GraphCanvasProps>(function GraphCanvas(
+  {
+    entities,
+    relationships,
+    visibleTypes,
+    showOrphans = false,
+    onSelectEntity,
+    selectedEntityId,
+    onOrphanCount,
+    // Default threshold ≥1 — every node with at least one edge keeps its
+    // label visible. Truly isolated (degree 0) nodes still rely on the
+    // hover/.neighbor/.selected rules to reveal on demand. Originally
+    // tuned to ≥3 for the dense 470-node `biz-consumer-council` graph,
+    // but that hid most labels in sparse channels (e.g. 29-node casual
+    // channels) where degree-1 nodes are the norm.
+    labelMinDegree = 1,
+    edgeOpacityMin = 0.3,
+    edgeOpacityMax = 1.0,
+  },
+  ref,
+) {
   // Stable no-op so the count callback is always callable without
   // a per-render undefined check. Consumers that DO pass a real
   // callback get the count; consumers that omit it silently drop it.
@@ -125,15 +173,52 @@ export function GraphCanvas({
     onOrphanCountRef.current = safeOnOrphanCount;
   });
 
+  // Imperative API for the cmd-K palette → fit-to-node animation.
+  // Held in a ref so consumers can call it from inside `onSelect`
+  // without going through React state. `useImperativeHandle`
+  // re-binds on every render because the closure captures `cyRef`.
+  useImperativeHandle(ref, () => ({
+    focusNode(id: string) {
+      const cy = cyRef.current;
+      if (!cy) return;
+      const node = cy.getElementById(id);
+      if (node.length === 0) return;
+      // Clear any prior dimming/highlighting so the user sees the
+      // focused node + its neighborhood clearly. Mirrors the tap path.
+      const neighborhood = node.closedNeighborhood();
+      cy.elements().removeClass("dimmed highlighted hover neighbor focused");
+      cy.elements().addClass("dimmed");
+      neighborhood.removeClass("dimmed");
+      neighborhood.nodes().addClass("neighbor");
+      neighborhood.edges().addClass("highlighted");
+      // Propagate the selection up so the EntityPanel opens for the
+      // chosen entity, matching the cytoscape-tap behaviour.
+      onSelectRef.current(id);
+      cy.animate({
+        fit: { eles: node, padding: 80 },
+        duration: 400,
+        easing: "ease-in-out-cubic" as cytoscape.Css.TransitionTimingFunction,
+      });
+      // Temporary `.focused` class for ~2 seconds so the chosen node
+      // pulses visually even after the fit completes.
+      node.addClass("focused");
+      window.setTimeout(() => {
+        node.removeClass("focused");
+      }, 2000);
+    },
+  }));
+
   // Main build effect — fires when data or type filter changes.
   // Never adds orphan nodes here; the showOrphans effect handles that.
   useEffect(() => {
     if (!containerRef.current) return;
 
     const visibleSet = new Set(visibleTypes);
+    // Cap raised to 2000 (effectively unlimited at our scale). The .slice
+    // form is preserved so we never accidentally feed undefined to cytoscape.
     const filtered = entities
       .filter((e) => visibleSet.has(e.type))
-      .slice(0, 80);
+      .slice(0, 2000);
 
     const filteredIds = new Set(filtered.map((e) => e.id));
 
@@ -163,19 +248,58 @@ export function GraphCanvas({
     const hasCachedPositions = renderableEntities.some((e) => positionCache.has(e.id));
 
     const nodes: ElementDefinition[] = renderableEntities.map((e) =>
-      buildNode(e, connectionCount, filteredIds),
+      buildNode(e, connectionCount, filteredIds, labelMinDegree),
     );
 
-    const edges: ElementDefinition[] = relationships
-      .filter((r) => filteredIds.has(r.source_id) && filteredIds.has(r.target_id))
-      .map((r, i) => ({
+    // D — compute the min/max valid_from timestamps over the visible edges
+    // for the recency ramp. Falls back to a flat opacity if no edge has a
+    // usable timestamp (e.g. a graph composed entirely of legacy rels).
+    const visibleRels = relationships.filter(
+      (r) => filteredIds.has(r.source_id) && filteredIds.has(r.target_id),
+    );
+    const validFromTs = visibleRels
+      .map((r) => (r.valid_from ? Date.parse(r.valid_from) : NaN))
+      .filter((t) => Number.isFinite(t)) as number[];
+    const tMin = validFromTs.length > 0 ? Math.min(...validFromTs) : null;
+    const tMax = validFromTs.length > 0 ? Math.max(...validFromTs) : null;
+
+    const edges: ElementDefinition[] = visibleRels.map((r, i) => {
+      const t = r.valid_from ? Date.parse(r.valid_from) : NaN;
+      // D-2: null valid_from → edgeOpacityMin (treat as oldest).
+      let opacity = edgeOpacityMin;
+      if (
+        tMin !== null &&
+        tMax !== null &&
+        tMax > tMin &&
+        Number.isFinite(t)
+      ) {
+        const frac = (t - tMin) / (tMax - tMin);
+        opacity = edgeOpacityMin + frac * (edgeOpacityMax - edgeOpacityMin);
+      } else if (Number.isFinite(t)) {
+        // All edges share a single timestamp → render at max so they read
+        // as "current" rather than uniformly dim.
+        opacity = edgeOpacityMax;
+      }
+      const isCoMention = r.type === "CO_MENTIONED";
+      return {
+        // Tag synthetic co-mention edges via cytoscape class so the
+        // dashed/dimmer style block can pick them up without inspecting
+        // data attributes in the selector.
+        classes: isCoMention ? "co-mention" : "",
         data: {
           id: r.id || `edge-${i}`,
           source: r.source_id,
           target: r.target_id,
-          label: r.type.replace(/_/g, " "),
+          // Co-mention edges carry a tiny "co-mentioned" hint instead of
+          // a verb, so users can tell what the dashed line means. Real
+          // relationships keep their LLM-emitted verb (snake_case → space).
+          label: isCoMention ? "co-mentioned" : r.type.replace(/_/g, " "),
+          // Co-mention opacity is anchored low — they're contextual hints,
+          // not first-class relationships.
+          opacity: isCoMention ? Math.min(0.35, opacity) : opacity,
         },
-      }));
+      };
+    });
 
     const isDark = document.documentElement.classList.contains("dark");
     const labelColor = isDark ? "#e2e8f0" : "#1e293b";
@@ -203,8 +327,11 @@ export function GraphCanvas({
             "background-color": "data(bgColor)",
             "border-color": "data(borderColor)",
             "border-width": 1.5,
-            // Label sits below the node, not inside
-            label: "data(label)",
+            // E-2: hide labels for low-degree nodes via the
+            // `visibleLabel` data attribute (empty string for hidden).
+            // Hover/selection/focus classes below re-bind to the full
+            // `label` to reveal.
+            label: "data(visibleLabel)",
             color: labelColor,
             "font-size": "data(fontSize)",
             "font-weight": 500,
@@ -242,6 +369,9 @@ export function GraphCanvas({
             "border-color": "#ffffff",
             "overlay-color": "#0B4F6C",
             "overlay-opacity": 0.15,
+            // Always show label when selected — overrides the
+            // E-2 visibleLabel hiding for low-degree nodes.
+            label: "data(label)",
           },
         },
         {
@@ -251,6 +381,20 @@ export function GraphCanvas({
             "border-color": "#ffffff",
             "overlay-color": "#0B4F6C",
             "overlay-opacity": 0.1,
+            // Reveal full label on hover even when E-2 hid it.
+            label: "data(label)",
+          },
+        },
+        {
+          // cmd-K palette focus pulse: 2-second class added in
+          // `focusNode`. Bright yellow border + visible label.
+          selector: "node.focused",
+          style: {
+            "border-width": 3,
+            "border-color": "#facc15",
+            "overlay-color": "#facc15",
+            "overlay-opacity": 0.15,
+            label: "data(label)",
           },
         },
         {
@@ -272,10 +416,14 @@ export function GraphCanvas({
           style: { opacity: 0.2 },
         },
         {
+          // Neighborhood reveal — when a node is tapped, its closed
+          // neighborhood gets `.neighbor`. Show their labels too so
+          // the user can read what they just lit up (overrides E-2).
           selector: "node.neighbor",
           style: {
             "border-width": 2.5,
             "border-color": "#facc15",
+            label: "data(label)",
           },
         },
         // ─── Edge styles ──────────────────────────────────────────────
@@ -297,9 +445,27 @@ export function GraphCanvas({
             "text-background-opacity": 0.85,
             "text-background-padding": "2px",
             "line-style": "solid",
-            opacity: 0.55,
+            // D — per-edge opacity computed from `valid_from` recency
+            // (see the buildEdges block above). Edges without a
+            // timestamp use `edgeOpacityMin` (treated as oldest).
+            opacity: "data(opacity)",
             "transition-property": "width, line-color, opacity",
             "transition-duration": "0.2s",
+          } as unknown as cytoscape.Css.Edge,
+        },
+        {
+          // Synthetic co-mention edges — derived from shared :Event
+          // nodes between entity pairs (see `list_co_mention_edges` on
+          // the store). Render as a faint dashed line with no arrow and
+          // no verb label so they fall behind real LLM-extracted
+          // relationships visually but still convey "these entities
+          // appear together".
+          selector: "edge.co-mention",
+          style: {
+            "line-style": "dashed" as const,
+            "line-dash-pattern": [4, 4],
+            "target-arrow-shape": "none",
+            width: 0.6,
           } as unknown as cytoscape.Css.Edge,
         },
         {
@@ -368,20 +534,34 @@ export function GraphCanvas({
             nodeDimensionsIncludeLabels: true,
             uniformNodeDimensions: false,
             packComponents: true,
-            // Bumped for less central collapse — multiple hub nodes
-            // (highly-connected) were sitting on top of each other.
-            // nodeSeparation 100→150 + idealEdgeLength 120→170
-            // forces hub-region clearance without scattering peripherals.
-            // nodeRepulsion 8500→12500 strengthens the overall push.
-            nodeSeparation: 150,
-            idealEdgeLength: 170,
-            edgeElasticity: 0.4,
-            nodeRepulsion: 12500,
-            gravity: 0.12,
+            // More-open layout tuning (round 2 — user feedback "too dense").
+            // Goal: meaningfully more breathing room around hubs and across
+            // the whole canvas. Strategy:
+            //   • nodeSeparation 150 → 240 — extra space between neighbours
+            //   • idealEdgeLength 170 → 260 — longer edges spread the cluster
+            //   • nodeRepulsion 12500 → 28000 — much stronger global push
+            //   • gravity 0.12 → 0.05 — much weaker central pull so the
+            //     peripheries don't bounce back toward the centre
+            //   • edgeElasticity 0.4 → 0.3 — edges hold their length longer
+            //     instead of contracting under repulsion
+            //   • numIter 3000 → 4500 — extra iterations for the stronger
+            //     forces to converge cleanly
+            //   • tile: true with generous padding — pack disconnected
+            //     components into tidy tiles instead of having them
+            //     compete with the main connected component for canvas
+            //     real-estate. Keeps the orphan/low-degree leaves out of
+            //     the way of the readable hub-and-spoke structure.
+            nodeSeparation: 240,
+            idealEdgeLength: 260,
+            edgeElasticity: 0.3,
+            nodeRepulsion: 28000,
+            gravity: 0.05,
             gravityRange: 3.8,
-            numIter: 3000,
-            tile: false,
-            padding: 60,
+            numIter: 4500,
+            tile: true,
+            tilingPaddingVertical: 60,
+            tilingPaddingHorizontal: 60,
+            padding: 80,
             fit: true,
           } as unknown as cytoscape.LayoutOptions,
       // Lower minZoom so the aggressively-spread layout doesn't get
@@ -575,7 +755,7 @@ export function GraphCanvas({
       cyRef.current = null;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [entities, relationships, visibleTypes]);
+  }, [entities, relationships, visibleTypes, labelMinDegree, edgeOpacityMin, edgeOpacityMax]);
 
   // ─── Show / hide orphan nodes without remounting cytoscape ──────────
   // When showOrphans flips true we cy.add() the orphan nodes with preset
@@ -605,7 +785,11 @@ export function GraphCanvas({
     const emptyIds = new Set<string>();
 
     const newElements: ElementDefinition[] = orphans.map((e, i) => {
-      const node = buildNode(e, emptyCount, emptyIds);
+      // Orphans have zero edges, so they would always be label-hidden
+      // under the E-2 threshold. Pass `labelMinDegree=0` here so orphan
+      // labels remain visible (they're already filtered + injected into
+      // a dedicated column where the label is the only context).
+      const node = buildNode(e, emptyCount, emptyIds, 0);
       const cachedPos = positionCache.get(e.id);
       return {
         ...node,
@@ -666,4 +850,4 @@ export function GraphCanvas({
       className="flex-1 min-h-0 bg-muted/5 overflow-hidden"
     />
   );
-}
+});

--- a/web/src/components/graph/GraphFilters.tsx
+++ b/web/src/components/graph/GraphFilters.tsx
@@ -6,20 +6,24 @@ import { cn } from "@/lib/utils";
  * a consistent color derived from a hash of the type name.
  */
 const KNOWN_TYPE_COLORS: Record<string, { pill: string; pillActive: string; node: string; nodeBorder: string }> = {
-  Person:     { pill: "bg-teal-500/10 text-teal-700 dark:text-teal-300 border-teal-500/20", pillActive: "bg-teal-600 text-white border-teal-600", node: "#0B4F6C", nodeBorder: "#083d54" },
-  Technology: { pill: "bg-indigo-500/10 text-indigo-700 dark:text-indigo-300 border-indigo-500/20", pillActive: "bg-indigo-600 text-white border-indigo-600", node: "#4F46E5", nodeBorder: "#3730A3" },
-  Project:    { pill: "bg-emerald-500/10 text-emerald-700 dark:text-emerald-300 border-emerald-500/20", pillActive: "bg-emerald-600 text-white border-emerald-600", node: "#059669", nodeBorder: "#047857" },
-  Decision:   { pill: "bg-amber-500/10 text-amber-700 dark:text-amber-300 border-amber-500/20", pillActive: "bg-amber-600 text-white border-amber-600", node: "#D97706", nodeBorder: "#B45309" },
-  Team:       { pill: "bg-cyan-500/10 text-cyan-700 dark:text-cyan-300 border-cyan-500/20", pillActive: "bg-cyan-600 text-white border-cyan-600", node: "#0891B2", nodeBorder: "#0E7490" },
-  Meeting:    { pill: "bg-slate-500/10 text-slate-700 dark:text-slate-300 border-slate-500/20", pillActive: "bg-slate-600 text-white border-slate-600", node: "#475569", nodeBorder: "#334155" },
-  Artifact:   { pill: "bg-rose-500/10 text-rose-700 dark:text-rose-300 border-rose-500/20", pillActive: "bg-rose-600 text-white border-rose-600", node: "#E11D48", nodeBorder: "#BE123C" },
-  Document:   { pill: "bg-orange-500/10 text-orange-700 dark:text-orange-300 border-orange-500/20", pillActive: "bg-orange-600 text-white border-orange-600", node: "#EA580C", nodeBorder: "#C2410C" },
-  Image:      { pill: "bg-sky-500/10 text-sky-700 dark:text-sky-300 border-sky-500/20", pillActive: "bg-sky-600 text-white border-sky-600", node: "#0284C7", nodeBorder: "#0369A1" },
-  Link:       { pill: "bg-green-500/10 text-green-700 dark:text-green-300 border-green-500/20", pillActive: "bg-green-600 text-white border-green-600", node: "#16A34A", nodeBorder: "#15803D" },
-  Media:      { pill: "bg-violet-500/10 text-violet-700 dark:text-violet-300 border-violet-500/20", pillActive: "bg-violet-600 text-white border-violet-600", node: "#7C3AED", nodeBorder: "#6D28D9" },
-  Client:     { pill: "bg-pink-500/10 text-pink-700 dark:text-pink-300 border-pink-500/20", pillActive: "bg-pink-600 text-white border-pink-600", node: "#DB2777", nodeBorder: "#BE185D" },
-  Channel:    { pill: "bg-fuchsia-500/10 text-fuchsia-700 dark:text-fuchsia-300 border-fuchsia-500/20", pillActive: "bg-fuchsia-600 text-white border-fuchsia-600", node: "#C026D3", nodeBorder: "#A21CAF" },
-  Location:   { pill: "bg-lime-500/10 text-lime-700 dark:text-lime-300 border-lime-500/20", pillActive: "bg-lime-600 text-white border-lime-600", node: "#65A30D", nodeBorder: "#4D7C0F" },
+  Person:       { pill: "bg-teal-500/10 text-teal-700 dark:text-teal-300 border-teal-500/20", pillActive: "bg-teal-600 text-white border-teal-600", node: "#0B4F6C", nodeBorder: "#083d54" },
+  Technology:   { pill: "bg-indigo-500/10 text-indigo-700 dark:text-indigo-300 border-indigo-500/20", pillActive: "bg-indigo-600 text-white border-indigo-600", node: "#4F46E5", nodeBorder: "#3730A3" },
+  Project:      { pill: "bg-emerald-500/10 text-emerald-700 dark:text-emerald-300 border-emerald-500/20", pillActive: "bg-emerald-600 text-white border-emerald-600", node: "#059669", nodeBorder: "#047857" },
+  Decision:     { pill: "bg-amber-500/10 text-amber-700 dark:text-amber-300 border-amber-500/20", pillActive: "bg-amber-600 text-white border-amber-600", node: "#D97706", nodeBorder: "#B45309" },
+  Team:         { pill: "bg-cyan-500/10 text-cyan-700 dark:text-cyan-300 border-cyan-500/20", pillActive: "bg-cyan-600 text-white border-cyan-600", node: "#0891B2", nodeBorder: "#0E7490" },
+  Meeting:      { pill: "bg-slate-500/10 text-slate-700 dark:text-slate-300 border-slate-500/20", pillActive: "bg-slate-600 text-white border-slate-600", node: "#475569", nodeBorder: "#334155" },
+  Artifact:     { pill: "bg-rose-500/10 text-rose-700 dark:text-rose-300 border-rose-500/20", pillActive: "bg-rose-600 text-white border-rose-600", node: "#E11D48", nodeBorder: "#BE123C" },
+  Organization: { pill: "bg-teal-500/10 text-teal-700 dark:text-teal-300 border-teal-500/20", pillActive: "bg-teal-600 text-white border-teal-600", node: "#14b8a6", nodeBorder: "#0d9488" },
+  Concept:      { pill: "bg-violet-500/10 text-violet-700 dark:text-violet-300 border-violet-500/20", pillActive: "bg-violet-600 text-white border-violet-600", node: "#a855f7", nodeBorder: "#9333ea" },
+  Location:     { pill: "bg-cyan-500/10 text-cyan-700 dark:text-cyan-300 border-cyan-500/20", pillActive: "bg-cyan-600 text-white border-cyan-600", node: "#06b6d4", nodeBorder: "#0891b2" },
+  Event:        { pill: "bg-amber-500/10 text-amber-700 dark:text-amber-300 border-amber-500/20", pillActive: "bg-amber-600 text-white border-amber-600", node: "#f59e0b", nodeBorder: "#d97706" },
+  Unresolved:   { pill: "bg-slate-500/10 text-slate-700 dark:text-slate-300 border-slate-500/20", pillActive: "bg-slate-600 text-white border-slate-600", node: "#94a3b8", nodeBorder: "#64748b" },
+  Document:     { pill: "bg-orange-500/10 text-orange-700 dark:text-orange-300 border-orange-500/20", pillActive: "bg-orange-600 text-white border-orange-600", node: "#EA580C", nodeBorder: "#C2410C" },
+  Image:        { pill: "bg-sky-500/10 text-sky-700 dark:text-sky-300 border-sky-500/20", pillActive: "bg-sky-600 text-white border-sky-600", node: "#0284C7", nodeBorder: "#0369A1" },
+  Link:         { pill: "bg-green-500/10 text-green-700 dark:text-green-300 border-green-500/20", pillActive: "bg-green-600 text-white border-green-600", node: "#16A34A", nodeBorder: "#15803D" },
+  Media:        { pill: "bg-violet-500/10 text-violet-700 dark:text-violet-300 border-violet-500/20", pillActive: "bg-violet-600 text-white border-violet-600", node: "#7C3AED", nodeBorder: "#6D28D9" },
+  Client:       { pill: "bg-pink-500/10 text-pink-700 dark:text-pink-300 border-pink-500/20", pillActive: "bg-pink-600 text-white border-pink-600", node: "#DB2777", nodeBorder: "#BE185D" },
+  Channel:      { pill: "bg-fuchsia-500/10 text-fuchsia-700 dark:text-fuchsia-300 border-fuchsia-500/20", pillActive: "bg-fuchsia-600 text-white border-fuchsia-600", node: "#C026D3", nodeBorder: "#A21CAF" },
 };
 
 // Generate a deterministic color from a string hash for unknown types

--- a/web/src/components/memories/MemoryGraphView.tsx
+++ b/web/src/components/memories/MemoryGraphView.tsx
@@ -1,12 +1,22 @@
-import { useEffect, useState } from "react";
-import { FolderSync, Loader2, Network, Sparkles, SlidersHorizontal, ChevronLeft } from "lucide-react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  ChevronLeft,
+  FolderSync,
+  Loader2,
+  Network,
+  Search,
+  SlidersHorizontal,
+  Sparkles,
+  Waypoints,
+} from "lucide-react";
 import { useGraph } from "@/hooks/useGraph";
 import { useChannelMemoryCount } from "@/hooks/useChannelMemoryCount";
 import { PipelineEmptyState } from "@/components/shared/PipelineEmptyState";
 import { getTypeColors } from "@/components/graph/GraphFilters";
-import { GraphCanvas } from "@/components/graph/GraphCanvas";
+import { GraphCanvas, type GraphCanvasHandle } from "@/components/graph/GraphCanvas";
 import { EntityPanel } from "@/components/graph/EntityPanel";
 import { MediaModal } from "@/components/graph/MediaModal";
+import { EntitySearchPalette } from "@/components/graph/EntitySearchPalette";
 import { FullscreenWrapper } from "@/components/shared/FullscreenWrapper";
 import { cn } from "@/lib/utils";
 
@@ -19,6 +29,17 @@ interface Props {
   isSyncing?: boolean;
   onViewSyncHistory?: () => void;
 }
+
+/** Possible time-window values for the D-track filter pills. `null`
+ *  represents "All time" (the default — pre-D behavior). */
+type TimeWindow = 7 | 30 | 90 | null;
+
+const TIME_WINDOWS: { value: TimeWindow; label: string }[] = [
+  { value: 7, label: "7d" },
+  { value: 30, label: "30d" },
+  { value: 90, label: "90d" },
+  { value: null, label: "All" },
+];
 
 // ─── TypePill ────────────────────────────────────────────────────────────────
 // Compact row pill for the floating filter panel.
@@ -53,6 +74,35 @@ function TypePill({
   );
 }
 
+// ─── TimePill ────────────────────────────────────────────────────────────────
+// Compact pill for the time-window row. Active pill is filled.
+
+function TimePill({
+  label,
+  active,
+  onClick,
+}: {
+  label: string;
+  active: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "px-2.5 py-1 rounded-lg text-[11px] font-medium border transition-colors",
+        active
+          ? "border-border/70 text-foreground bg-muted"
+          : "border-border/40 text-muted-foreground/60 bg-transparent hover:border-border hover:text-foreground",
+      )}
+      aria-pressed={active}
+    >
+      {label}
+    </button>
+  );
+}
+
 // ─── MemoryGraphView ──────────────────────────────────────────────────────────
 
 /**
@@ -70,7 +120,15 @@ export function MemoryGraphView({
   isSyncing = false,
   onViewSyncHistory,
 }: Props) {
-  const { entities, relationships, loading, error, refetch } = useGraph(channelId);
+  // Loose-connections toggle: when on, the relationships endpoint
+  // surfaces co-mention edges at the weakest threshold (shared >= 1
+  // event between two entities). Helps sparse channels where the
+  // default shared >= 2 leaves many entities isolated. Defaults off
+  // so dense channels stay visually clean.
+  const [looseConnections, setLooseConnections] = useState(false);
+  const { entities, relationships, loading, error, refetch } = useGraph(channelId, {
+    looseConnections,
+  });
   const { hasMemories, isLoading: isMemoryCountLoading } = useChannelMemoryCount(channelId);
   const [visibleTypes, setVisibleTypes] = useState<string[]>([]);
   const [selectedId, setSelectedId] = useState<string | null>(null);
@@ -80,11 +138,23 @@ export function MemoryGraphView({
     mediaType: string;
   } | null>(null);
 
+  // D — time-window pills. `null` means "all time" (pre-D behavior).
+  const [timeWindow, setTimeWindow] = useState<TimeWindow>(null);
+
+  // E-3 — cmd-K palette open/close
+  const [paletteOpen, setPaletteOpen] = useState(false);
+
+  // Imperative ref into the canvas — used by the palette to pan/zoom
+  // to the selected entity.
+  const canvasRef = useRef<GraphCanvasHandle | null>(null);
+
   // Floating filter panel open/close
   // Filter panel defaults open — the user said the floating pill is too
   // hidden as a slim vertical strip. The panel still collapses on
   // click; the user can dismiss when they want canvas real-estate.
-  const [filtersOpen, setFiltersOpen] = useState(true);
+  // Default collapsed so the panel doesn't steal canvas real estate on
+  // first paint. Users can open it via the slim left rail.
+  const [filtersOpen, setFiltersOpen] = useState(false);
 
   // Orphan node toggle — GraphCanvas handles the cy.add/remove internally;
   // we just pass the boolean down.
@@ -104,6 +174,33 @@ export function MemoryGraphView({
     }
   }, [refreshNonce, refetch]);
 
+  // E-3 (E-1 fix) — document-level cmd-K (or ctrl-K) hotkey toggle.
+  // Bound at document level so it works regardless of focus target.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      const isHotkey = (e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k";
+      if (!isHotkey) return;
+      e.preventDefault();
+      setPaletteOpen((open) => !open);
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, []);
+
+  // D — client-side time filter. Null timeWindow keeps everything; for
+  // other windows, edges WITHOUT a `valid_from` stay visible (treated
+  // as "always visible" / "legacy"), edges with a stale timestamp drop.
+  const filteredRelationships = useMemo(() => {
+    if (timeWindow === null) return relationships;
+    const cutoff = Date.now() - timeWindow * 86400_000;
+    return relationships.filter((r) => {
+      if (!r.valid_from) return true; // null = always visible
+      const t = Date.parse(r.valid_from);
+      if (!Number.isFinite(t)) return true;
+      return t >= cutoff;
+    });
+  }, [relationships, timeWindow]);
+
   const selectedEntity = selectedId
     ? entities.find((e) => e.id === selectedId) ?? null
     : null;
@@ -122,6 +219,24 @@ export function MemoryGraphView({
       }
     }
     setSelectedId(id);
+  };
+
+  // C — navigate by name (from EntityPanel's Card tab's related entities)
+  const handleNavigate = (name: string) => {
+    const target = entities.find(
+      (e) => e.name.toLowerCase() === name.toLowerCase(),
+    );
+    if (target) {
+      setSelectedId(target.id);
+      // Pan the canvas to the new entity so the user has visual context.
+      canvasRef.current?.focusNode(target.id);
+    }
+  };
+
+  // E-3 — palette selection routes through focusNode + selection state.
+  const handlePaletteSelect = (id: string) => {
+    setSelectedId(id);
+    canvasRef.current?.focusNode(id);
   };
 
   if (loading) {
@@ -171,13 +286,19 @@ export function MemoryGraphView({
     );
   }
 
+  const timeFilterEmpty =
+    timeWindow !== null &&
+    filteredRelationships.length === 0 &&
+    relationships.length > 0;
+
   return (
     // No top filter bar — canvas fills full height below Memory↔Graph toggle.
     <FullscreenWrapper label="Enlarge graph" className="flex-1 min-h-0">
       <div className="relative flex h-full w-full min-h-0 overflow-hidden">
         <GraphCanvas
+          ref={canvasRef}
           entities={entities}
-          relationships={relationships}
+          relationships={filteredRelationships}
           visibleTypes={visibleTypes}
           showOrphans={showOrphans}
           selectedEntityId={selectedId}
@@ -188,12 +309,106 @@ export function MemoryGraphView({
         {selectedEntity && (
           <EntityPanel
             entity={selectedEntity}
-            relationships={relationships}
+            relationships={filteredRelationships}
             allEntities={entities}
             channelId={channelId}
             onClose={() => setSelectedId(null)}
+            onNavigate={handleNavigate}
           />
         )}
+
+        {/* ── Top-right toolbar: search + time-window pills ──────────── */}
+        <div className="absolute top-3 right-3 z-20 flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => setPaletteOpen(true)}
+            aria-label="Search entities (⌘K)"
+            title="Search entities (⌘K)"
+            className={cn(
+              "inline-flex items-center justify-center w-8 h-8 rounded-xl",
+              "border border-border/60 bg-card/85 backdrop-blur-sm shadow-sm",
+              "text-muted-foreground hover:text-foreground hover:bg-card transition-colors",
+            )}
+          >
+            <Search className="w-3.5 h-3.5" />
+          </button>
+          {/* Co-mention toggle. When ON, the server surfaces co-mention
+              edges at the weakest threshold (shared >= 1) so sparse
+              channels show a more connected graph. Labeled "Show all
+              co-mentions" with explanatory tooltip so users don't have
+              to guess what "Loose" means. */}
+          <button
+            type="button"
+            onClick={() => setLooseConnections((v) => !v)}
+            aria-pressed={looseConnections}
+            aria-label={
+              looseConnections
+                ? "Hide weak co-mention edges"
+                : "Show all co-mention edges, including single-mention pairs"
+            }
+            title={
+              looseConnections
+                ? (
+                  "Showing ALL co-mentions: any two entities that appear " +
+                  "in the same fact get a dashed link. Click to hide weak " +
+                  "ones (only show pairs appearing in 2+ shared facts)."
+                )
+                : (
+                  "Click to include weak co-mentions: link any two entities " +
+                  "that ever appear in the same fact. Useful for sparse " +
+                  "channels where most entities look isolated."
+                )
+            }
+            className={cn(
+              "inline-flex items-center gap-1.5 px-2.5 h-8 rounded-xl border shadow-sm",
+              "backdrop-blur-sm transition-colors text-[11px] font-medium",
+              looseConnections
+                ? "border-primary/60 bg-primary/15 text-primary hover:bg-primary/20"
+                : "border-border/60 bg-card/85 text-muted-foreground hover:text-foreground hover:bg-card",
+            )}
+          >
+            <Waypoints className="w-3.5 h-3.5" aria-hidden="true" />
+            <span>{looseConnections ? "All co-mentions" : "Show weak ties"}</span>
+          </button>
+          <div
+            className={cn(
+              "inline-flex items-center gap-1 rounded-xl border border-border/60",
+              "bg-card/85 backdrop-blur-sm px-1.5 py-1 shadow-sm",
+            )}
+          >
+            {TIME_WINDOWS.map((w) => (
+              <TimePill
+                key={w.label}
+                label={w.label}
+                active={timeWindow === w.value}
+                onClick={() => setTimeWindow(w.value)}
+              />
+            ))}
+          </div>
+        </div>
+        {/* ── End top-right toolbar ─────────────────────────────────── */}
+
+        {/* ── Empty-window overlay ───────────────────────────────────── */}
+        {timeFilterEmpty && (
+          <div className="absolute inset-0 z-20 flex items-center justify-center pointer-events-none">
+            <div className="pointer-events-auto rounded-xl border border-border/60 bg-card/95 backdrop-blur-sm shadow-md px-5 py-4 max-w-sm text-center">
+              <p className="text-sm font-medium text-foreground mb-1">
+                No activity in the last {timeWindow} days
+              </p>
+              <p className="text-xs text-muted-foreground mb-3">
+                Try a longer window to see older relationships.
+              </p>
+              <button
+                type="button"
+                onClick={() => setTimeWindow(null)}
+                className="inline-flex items-center px-3 py-1.5 rounded-lg text-xs font-medium border border-border/70 text-foreground bg-muted hover:bg-muted/80 transition-colors"
+              >
+                Show all time
+              </button>
+            </div>
+          </div>
+        )}
+        {/* ── End empty-window overlay ──────────────────────────────── */}
 
         {/* ── Floating left filter panel ─────────────────────────────── */}
         <div className="absolute left-3 top-1/2 -translate-y-1/2 z-20">
@@ -303,6 +518,25 @@ export function MemoryGraphView({
           )}
         </div>
         {/* ── End floating filter panel ──────────────────────────────── */}
+
+        {/* ── Footer count pill ─────────────────────────────────────── */}
+        <div className="absolute bottom-3 right-3 z-20 pointer-events-none">
+          <div
+            className={cn(
+              "inline-flex items-center gap-1 rounded-full border border-border/60",
+              "bg-card/85 backdrop-blur-sm px-2.5 py-1 shadow-sm",
+              "text-[10px] font-medium text-muted-foreground/80",
+            )}
+          >
+            {entities.length} entities · {filteredRelationships.length} relationships
+            {timeWindow !== null && (
+              <span className="ml-1 text-muted-foreground/60">
+                · last {timeWindow}d
+              </span>
+            )}
+          </div>
+        </div>
+        {/* ── End footer count pill ─────────────────────────────────── */}
       </div>
 
       {mediaModal && (
@@ -313,6 +547,13 @@ export function MemoryGraphView({
           onClose={() => setMediaModal(null)}
         />
       )}
+
+      <EntitySearchPalette
+        entities={entities}
+        open={paletteOpen}
+        onClose={() => setPaletteOpen(false)}
+        onSelect={handlePaletteSelect}
+      />
     </FullscreenWrapper>
   );
 }

--- a/web/src/hooks/useEntityCard.ts
+++ b/web/src/hooks/useEntityCard.ts
@@ -1,0 +1,94 @@
+import { useState, useEffect, useRef } from "react";
+import { api, ApiError } from "@/lib/api";
+
+/**
+ * Shape of the `/api/entities/{name}/card` response (see
+ * `src/beever_atlas/api/topics.py:232-258`'s EntityCardResponse).
+ * Mirrored here so the FE doesn't import server-side schemas.
+ */
+export interface EntityCardData {
+  entity_name: string;
+  entity_type: string;
+  channel_ids: string[];
+  cluster_ids: string[];
+  fact_count: number;
+  fact_type_breakdown: Record<string, number>;
+  key_facts: string[];
+  related_entities: Array<{ name?: string; type?: string; [key: string]: unknown }>;
+  last_mentioned_at: string;
+  staleness_score: number;
+  summary: string;
+}
+
+interface UseEntityCardReturn {
+  card: EntityCardData | null;
+  loading: boolean;
+  /** "not_found" indicates the 404 empty-state branch; other errors keep
+   *  their server message. */
+  error: string | null;
+  notFound: boolean;
+}
+
+/**
+ * Fetch the workspace-wide knowledge card for an entity. Skips when
+ * `entityName` is null (panel closed) and memoizes per-name to avoid
+ * refetching on tab toggles / rerenders.
+ */
+export function useEntityCard(entityName: string | null): UseEntityCardReturn {
+  const [card, setCard] = useState<EntityCardData | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [notFound, setNotFound] = useState(false);
+  const cacheRef = useRef<Map<string, EntityCardData>>(new Map());
+
+  useEffect(() => {
+    if (!entityName) {
+      setCard(null);
+      setError(null);
+      setNotFound(false);
+      setLoading(false);
+      return;
+    }
+
+    const cached = cacheRef.current.get(entityName);
+    if (cached) {
+      setCard(cached);
+      setError(null);
+      setNotFound(false);
+      setLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    setNotFound(false);
+
+    api
+      .get<EntityCardData>(`/api/entities/${encodeURIComponent(entityName)}/card`)
+      .then((data) => {
+        if (cancelled) return;
+        cacheRef.current.set(entityName, data);
+        setCard(data);
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        if (err instanceof ApiError && err.status === 404) {
+          setNotFound(true);
+          setCard(null);
+        } else {
+          setError(err instanceof Error ? err.message : "Failed to load entity card");
+          setCard(null);
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [entityName]);
+
+  return { card, loading, error, notFound };
+}

--- a/web/src/hooks/useGraph.ts
+++ b/web/src/hooks/useGraph.ts
@@ -17,6 +17,10 @@ export interface GraphRelationship {
   target_id: string;
   type: string;
   properties?: Record<string, unknown>;
+  /** ISO timestamp of when the relationship became valid; null/absent for
+   *  legacy edges. Used by the time-window filter (D) and edge-opacity
+   *  recency ramp in `GraphCanvas`. */
+  valid_from?: string | null;
 }
 
 export interface GraphData {
@@ -39,22 +43,39 @@ interface MediaNode {
   title: string;
 }
 
-export function useGraph(channelId: string): UseGraphReturn {
+/** Options that change what the hook asks the backend for. */
+export interface UseGraphOptions {
+  /** When true, request co-mention edges at the weakest threshold
+   *  (`shared >= 1`) so sparse channels show a more connected graph.
+   *  Defaults to false — server-side default is `shared >= 2`. */
+  looseConnections?: boolean;
+}
+
+export function useGraph(channelId: string, options: UseGraphOptions = {}): UseGraphReturn {
   const [entities, setEntities] = useState<GraphEntity[]>([]);
   const [relationships, setRelationships] = useState<GraphRelationship[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  const { looseConnections = false } = options;
 
   const fetch = useCallback(async () => {
     if (!channelId) return;
     setLoading(true);
     setError(null);
     try {
+      // The relationships endpoint accepts `co_mention_min_shared` to
+      // tune how aggressively to surface synthetic CO_MENTIONED edges
+      // derived from shared :Event nodes. Default 2 = "shared in at
+      // least 2 facts"; loose mode = 1 = "any shared fact counts".
+      const relsUrl =
+        `/api/graph/relationships?channel_id=${channelId}` +
+        `&limit=1000&co_mention_min_shared=${looseConnections ? 1 : 2}`;
       // Fetch entities, relationships, and media nodes in parallel.
       const [entityData, relData, mediaData] = await Promise.all([
-        api.get<GraphEntity[]>(`/api/graph/entities?channel_id=${channelId}`),
-        api.get<{ source: string; target: string; type: string; id?: string }[]>(
-          `/api/graph/relationships?channel_id=${channelId}`,
+        api.get<GraphEntity[]>(`/api/graph/entities?channel_id=${channelId}&limit=500`),
+        api.get<{ source: string; target: string; type: string; id?: string; valid_from?: string | null }[]>(
+          relsUrl,
         ),
         api.get<MediaNode[]>(`/api/graph/media?channel_id=${channelId}`),
       ]);
@@ -104,6 +125,7 @@ export function useGraph(channelId: string): UseGraphReturn {
           source_id: nameToId.get(r.source) ?? "",
           target_id: nameToId.get(r.target) ?? "",
           type: r.type,
+          valid_from: r.valid_from ?? null,
         }))
         .filter((r) => r.source_id && r.target_id);
       setRelationships(rels);
@@ -112,7 +134,7 @@ export function useGraph(channelId: string): UseGraphReturn {
     } finally {
       setLoading(false);
     }
-  }, [channelId]);
+  }, [channelId, looseConnections]);
 
   useEffect(() => {
     fetch();


### PR DESCRIPTION
## Summary

Eliminates the "every entity is grey Topic" rendering bug and adds five graph-memory features. End-to-end: channel views now render 15+ typed entity colors with verb-labeled relationships, time-filtered edges, and a clickable entity-card panel.

**Before** (test channel `biz-consumer-council`, 417 messages): 434 entities, 424 typed `Unresolved` (97%), 1 typed entity-to-entity edge out of 344 relationships, all-grey hairball UI with 292 "unconnected".

**After**: 168 properly-typed entities across 15+ types (Person, Technology, Organization, Concept, Project, Decision, Meeting, Artifact, Event, Location, Chemical, Brand, Website, Email, Metric), 168 LLM-extracted relationships with normalized verbs, plus synthetic CO_MENTIONED edges so sparse channels read as connected, 0 typed-vs-stub coexistence.

## Backend — data quality

- **Symmetric heal-path** at all three Neo4j MERGE sites (`neo4j_store.py:282-401`, `:594-650`, `:1638-1670`): every typed write now calls `apoc.refactor.mergeNodes([typed]+stubs, mergeRels:true)` to absorb sibling Unresolved/Topic stubs in the same transaction. Eliminates the parallel typed-vs-stub rows that were owning split `MENTIONED_IN` edges.
- **Generic platform-connection resolver** (`sync_runner.py:662-744`) — falls back to a bridge probe when `selected_channels` is empty. Works for any platform; no regex-based detection.
- **`list_co_mention_edges`** derives synthetic CO_MENTIONED edges from shared `:Event` nodes. `/api/graph/relationships` exposes `include_co_mentions` + `co_mention_min_shared` query params.
- **`prune_stub_orphans`** now also catches legacy `Topic` stubs.
- **`find_entity_by_name_or_alias`** prefers typed siblings — wiki citations bind correctly.

## Backend — features

- **Unresolved classifier** fires on `memory_settled`, types Unresolved stubs via LLM with relationship-context grounding. Admin endpoint `POST /api/admin/channels/{id}/classify-unresolved` for ad-hoc runs. ~$0.005 per channel sub-cent in steady state.
- **Verb normalizer** maps 439+ LLM-emitted verbs to ~15 canonical via ordered first-match-wins. Direction-preserving (no `BLOCKS<->BLOCKED_BY` flips). Logs to `sync_summary.normalizations[]` for audit. 47 unit tests.
- **Per-channel reset endpoint** `POST /api/admin/channels/{id}/reset` wipes derived knowledge (entities, relationships, weaviate facts, sync_state, `channel_messages.extraction_status`) with concurrent-sync gate.
- **Entity-extractor prompt** adds 4 new types (Organization, Concept, Location, Event). LLM also invents Chemical/Website/Brand/Email/Metric via the existing PascalCase extension rule.

## Frontend — graph UX

- **Entity card panel on node click** (`useEntityCard` hook + `EntityPanel.tsx`). Renders bio, key facts, related entities (clickable navigation), citations.
- **Time-aware view**: 7d/30d/90d/All pills in the top-right toolbar; client-side filter on `relationship.valid_from`; per-edge opacity ramp from oldest to newest; empty-window overlay with "Show all time" reset.
- **cmd-K entity search palette** with document-level hotkey, arrow/Enter nav, imperative `focusNode` ref into Cytoscape.
- **Node-size proportional to degree** (8-32 px); label visibility ≥ 1 edge (every connected node shows its label).
- **Channel Settings → Danger Zone "Reset & Re-sync"** button chains `/reset` → `/wiki/refresh?mode=rebuild` → `/sync?sync_type=full`.
- **Loose-connections toggle** (Show weak ties / All co-mentions) in the top-right toolbar — passes `co_mention_min_shared=1` to surface every pair sharing a single event.
- Filter panel defaults collapsed; toolbar floats top-right.
- fcose layout tuned for less density (`nodeRepulsion 28000`, `idealEdgeLength 260`, `nodeSeparation 240`, tiled disconnected components).

## Tests

- New: `test_neo4j_store_heal_path.py`, `test_persister_stub_gate.py`, `test_verb_normalizer.py`, `test_admin_channel_reset.py`, `test_wiki_maintainer_entity_edges.py`.
- Updated: `test_relationship_stub_merge.py` (Topic→Unresolved assertions, symmetric-heal Cypher shape), `test_graph_protocol.py` (MockGraphStore covers new protocol methods).
- **888 passed, 11 skipped**, web typecheck clean.

## Constraints honored

- Neo4j composite UNIQUE on `(name, type, scope)` stays — the fix works under it via `mergeNodes`, **no schema migration required**.
- APOC `mergeNodes` already used at `neo4j_store.py:181` in the startup dedup gate; same primitive applied at write time.
- Adding a per-write Cypher `OPTIONAL MATCH` + `CALL` keeps the hot path inside one transaction so concurrent batches don't race.

## Alternatives considered & rejected

- **Drop the composite constraint to `(name, scope)`** — required a maintenance window for the EE deployment and risks merging legitimate homographs (Apple-company vs Apple-fruit).
- **Per-batch lookup ladder with nested UNION subqueries** — the Cypher doesn't compile in Neo4j 5; `mergeNodes` is the right primitive.
- **Auto-firing classifier with shorter retry budget** — over-types truly ambiguous names; idempotency at `classifier_attempts >= 2` is the intentional ceiling.

## Directives for future modifiers

- **Do not re-introduce hardcoded `type:'Topic'`** in any MERGE clause — the three sites at `neo4j_store.py:594-650` and `:1638-1670` now use `type:'Unresolved'` so the heal-path can promote them. Future stub writers must follow the same pattern.
- **When adding a new `GraphStore` consumer** that uses Unresolved-classifier helpers (`list_unresolved_stubs` / `fetch_incident_contexts_batch` / `mark_unresolved_attempt`), ensure `null_graph` / `nebula_store` stub implementations exist — the protocol now requires them.

## Risk / scope

- **Confidence**: high
- **Scope-risk**: broad — 31 files, 5057 insertions, touches data plane and read plane
- **Not tested**: cross-channel typed-vs-stub absorption when the typed sibling already lives under `scope='channel'` (heal-path covers global scope; channel scope is a documented pre-existing gap). Verb normalizer behavior for RTL or non-Latin verb tokens (LLM has never emitted any in practice).

## Test plan

- [x] `uv run pytest tests/stores tests/agents tests/services tests/test_graph_protocol.py tests/api/test_admin_channel_reset.py tests/test_sync_runner.py` — 888 passed
- [x] `cd web && npm run typecheck` — clean
- [x] Live verification: full Reset & Re-sync on `biz-consumer-council` produces typed entities, no coexistence pairs, populated wiki
- [x] Live verification: cmd-K search, time-filter pills, entity-card panel, Danger Zone all functional
- [ ] EE deployment: backend rebuild + restart on `3-134-230-101.nip.io` (op-side)

🤖 Generated with [Claude Code](https://claude.com/claude-code)