### PR TITLE
fix(bot): self-heal from chat-adapter-mattermost leak via scheduled recycle + restart policy (RES-286)

### DIFF
--- a/bot/src/bridge.caches.test.ts
+++ b/bot/src/bridge.caches.test.ts
@@ -1,0 +1,108 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import {
+  recordTeamsConversation,
+  recordTelegramChat,
+  pruneStaleTeamsConversations,
+  pruneStaleTelegramChats,
+  clearUserProfileCache,
+  clearMattermostUserCache,
+} from "./bridge.js";
+
+// ── Teams conversation registry prune (RES-286) ──────────────────────────────
+
+describe("pruneStaleTeamsConversations", () => {
+  it("returns 0 when registry is empty", () => {
+    // Make sure prior tests don't bleed in — empty the registry via a huge
+    // maxAge=0 (drops everything older than `now`).
+    pruneStaleTeamsConversations(0);
+    assert.strictEqual(pruneStaleTeamsConversations(0), 0);
+  });
+
+  it("does not prune entries within the maxAge window", () => {
+    pruneStaleTeamsConversations(0); // clear
+
+    recordTeamsConversation("conn-x", {
+      conversation: { id: "fresh-conv", conversationType: "channel" },
+      channelData: { team: { id: "t1", name: "TeamA" }, channel: { id: "c1", name: "general" } },
+    });
+
+    // 1-day maxAge: a just-inserted entry must NOT be pruned.
+    assert.strictEqual(pruneStaleTeamsConversations(24 * 60 * 60 * 1000), 0);
+    pruneStaleTeamsConversations(0); // tidy
+  });
+
+  it("removes empty connection buckets after prune", () => {
+    pruneStaleTeamsConversations(0); // clear all
+    recordTeamsConversation("conn-empty-after-prune", {
+      conversation: { id: "only", conversationType: "channel" },
+      channelData: { team: { name: "T" }, channel: { name: "c" } },
+    });
+    // Prune with maxAge=0 ms drops everything ≥1ms old. Wait 5ms to ensure.
+    return new Promise<void>((resolve) => {
+      setTimeout(() => {
+        const pruned = pruneStaleTeamsConversations(0);
+        assert.ok(pruned >= 1, `expected ≥1 pruned, got ${pruned}`);
+        // Subsequent prune is a no-op.
+        assert.strictEqual(pruneStaleTeamsConversations(0), 0);
+        resolve();
+      }, 5);
+    });
+  });
+});
+
+// ── Telegram chat registry prune (RES-286) ───────────────────────────────────
+
+describe("pruneStaleTelegramChats", () => {
+  it("returns 0 when registry is empty", () => {
+    pruneStaleTelegramChats(0); // empty it
+    assert.strictEqual(pruneStaleTelegramChats(0), 0);
+  });
+
+  it("ages out stale chats and keeps recent ones", () => {
+    pruneStaleTelegramChats(0); // clear
+
+    recordTelegramChat("conn-tg", {
+      id: 12345,
+      title: "Recent group",
+      type: "group",
+    });
+
+    // Wait 5 ms then prune anything older than now (maxAge=0). The single
+    // entry is at least 5 ms old.
+    return new Promise<void>((resolve) => {
+      setTimeout(() => {
+        const pruned = pruneStaleTelegramChats(0);
+        assert.ok(pruned >= 1);
+        // After prune the bucket should be empty; next call is a no-op.
+        assert.strictEqual(pruneStaleTelegramChats(0), 0);
+        resolve();
+      }, 5);
+    });
+  });
+
+  it("does not prune entries within the maxAge window", () => {
+    pruneStaleTelegramChats(0); // clear
+    recordTelegramChat("conn-tg-2", {
+      id: 67890,
+      title: "Active group",
+      type: "supergroup",
+    });
+    // maxAge of 1 day: the just-inserted entry should NOT be pruned.
+    assert.strictEqual(pruneStaleTelegramChats(24 * 60 * 60 * 1000), 0);
+    pruneStaleTelegramChats(0); // tidy
+  });
+});
+
+// ── Cache clearers ───────────────────────────────────────────────────────────
+
+describe("clearUserProfileCache / clearMattermostUserCache", () => {
+  it("are idempotent and safe to call when caches are empty", () => {
+    // We can't easily inject entries because the caches are module-private,
+    // but calling the clears must never throw and must be cheap.
+    assert.doesNotThrow(() => clearUserProfileCache());
+    assert.doesNotThrow(() => clearUserProfileCache());
+    assert.doesNotThrow(() => clearMattermostUserCache());
+    assert.doesNotThrow(() => clearMattermostUserCache());
+  });
+});

--- a/bot/src/bridge.ts
+++ b/bot/src/bridge.ts
@@ -339,6 +339,14 @@ function parseQuery(url: string): URLSearchParams {
 const userProfileCache = new Map<string, { name: string; image: string | null }>();
 const USER_LOOKUP_CONCURRENCY = 8;
 
+/** RES-286 — let callers (notably ChatManager's scheduled adapter recycle)
+ *  drop this cross-platform user-profile cache. Entries here are name+avatar
+ *  lookups against Slack/Discord/Teams/etc. — re-fetching is cheap and the
+ *  Map is otherwise unbounded over the bot's lifetime. */
+export function clearUserProfileCache(): void {
+  userProfileCache.clear();
+}
+
 // ── SlackBridge ──────────────────────────────────────────────────────────────
 
 /** Hosts allowed for token-bearing Slack file fetches (CodeQL alert #27).
@@ -1185,6 +1193,27 @@ interface TeamsConversationRecord {
 
 const teamsConversationRegistry = new Map<string, Map<string, TeamsConversationRecord>>();
 
+/** RES-286 — Teams "I've seen this conversation" registry is populated from
+ *  webhooks and is the only source of truth for `TeamsBridge.listChannels()`
+ *  (Bot Framework exposes no list API). It must NOT be wholesale-cleared on
+ *  adapter recycle — that would empty the sidebar until each conversation
+ *  posts again. Instead, drop only entries whose `lastSeenAt` is older than
+ *  `maxAgeMs` (default 30 days). Returns the number of entries pruned. */
+export function pruneStaleTeamsConversations(maxAgeMs: number = 30 * 24 * 60 * 60 * 1000): number {
+  const cutoff = Date.now() - maxAgeMs;
+  let pruned = 0;
+  for (const [connId, bucket] of teamsConversationRegistry.entries()) {
+    for (const [convId, rec] of bucket.entries()) {
+      if (rec.lastSeenAt < cutoff) {
+        bucket.delete(convId);
+        pruned++;
+      }
+    }
+    if (bucket.size === 0) teamsConversationRegistry.delete(connId);
+  }
+  return pruned;
+}
+
 export function recordTeamsConversation(
   connectionId: string,
   activity: {
@@ -1469,6 +1498,25 @@ interface TelegramChatEntry {
   lastSeenAt: number;
 }
 const telegramChatRegistry = new Map<string, Map<string, TelegramChatEntry>>();
+
+/** RES-286 — Telegram chat registry, populated from webhooks. Same shape as
+ *  `teamsConversationRegistry` (the only source of truth for
+ *  `TelegramBridge.listChannels()`), so we age out stale entries instead of
+ *  wholesale-clearing. Returns the number of entries pruned. */
+export function pruneStaleTelegramChats(maxAgeMs: number = 30 * 24 * 60 * 60 * 1000): number {
+  const cutoff = Date.now() - maxAgeMs;
+  let pruned = 0;
+  for (const [connId, bucket] of telegramChatRegistry.entries()) {
+    for (const [chatId, rec] of bucket.entries()) {
+      if (rec.lastSeenAt < cutoff) {
+        bucket.delete(chatId);
+        pruned++;
+      }
+    }
+    if (bucket.size === 0) telegramChatRegistry.delete(connId);
+  }
+  return pruned;
+}
 
 export function recordTelegramChat(
   connectionId: string,
@@ -2584,14 +2632,30 @@ export function registerBridgeRoutes(
   // wiring time. Moved out of module-load so tests can import the file.
   assertBridgeAuthReady();
 
-  // Subscribe to adapter rebuilds to clear bridge-level caches. This is
-  // critical for the RES-286 scheduled adapter recycle: every 6 h the
-  // ChatManager tears down and rebuilds the adapters, and these caches
-  // must be dropped in lockstep or they'd hold stale adapter references
-  // (bridgeCache) and unbounded user lookups (mattermostUserCache).
+  // Subscribe to adapter rebuilds to clear bridge-level caches. Critical
+  // for the RES-286 scheduled adapter recycle: every 6 h the ChatManager
+  // tears down and rebuilds adapters, and these caches must be dropped in
+  // lockstep — otherwise they hold stale adapter references (`bridgeCache`)
+  // or grow without bound across the bot's lifetime.
+  //
+  // Cache shape and what we do with each:
+  //  - `bridgeCache`              — stale singleton adapter refs   → clear
+  //  - `mattermostUserCache`      — per-user metadata, cheap to refetch → clear
+  //  - `userProfileCache`         — same shape, cross-platform     → clear
+  //  - `teamsConversationRegistry`/`telegramChatRegistry` — ONLY source of
+  //    truth for `listChannels()` on those platforms (populated from inbound
+  //    webhooks; no list API exists). Wholesale-clearing would empty the
+  //    sidebar until each conversation posts again, so we age out stale
+  //    entries instead (default 30 day TTL).
   chatManager.onRebuild(() => {
     clearBridgeCache();
     clearMattermostUserCache();
+    clearUserProfileCache();
+    const teamsPruned = pruneStaleTeamsConversations();
+    const telegramPruned = pruneStaleTelegramChats();
+    if (teamsPruned > 0 || telegramPruned > 0) {
+      console.log(`Bridge: rebuild pruned ${teamsPruned} stale Teams + ${telegramPruned} stale Telegram entries`);
+    }
   });
 
   return async (req: IncomingMessage, res: ServerResponse): Promise<boolean> => {

--- a/bot/src/bridge.ts
+++ b/bot/src/bridge.ts
@@ -1584,6 +1584,14 @@ class TelegramBridge implements PlatformBridge {
 
 const mattermostUserCache = new Map<string, { name: string; image: string | null }>();
 
+/** RES-286 — let callers (notably ChatManager's scheduled adapter recycle)
+ *  drop this module-level cache. Without this hook the Map grows unbounded
+ *  over the bot's lifetime since entries are added on every user lookup but
+ *  never expire. */
+export function clearMattermostUserCache(): void {
+  mattermostUserCache.clear();
+}
+
 class MattermostBridge implements PlatformBridge {
   private baseUrl: string;
   private botToken: string;
@@ -2576,10 +2584,14 @@ export function registerBridgeRoutes(
   // wiring time. Moved out of module-load so tests can import the file.
   assertBridgeAuthReady();
 
-  // Subscribe to adapter rebuilds to clear the bridge singleton cache.
-  // This ensures stale adapter references are never reused after unregister/reregister.
+  // Subscribe to adapter rebuilds to clear bridge-level caches. This is
+  // critical for the RES-286 scheduled adapter recycle: every 6 h the
+  // ChatManager tears down and rebuilds the adapters, and these caches
+  // must be dropped in lockstep or they'd hold stale adapter references
+  // (bridgeCache) and unbounded user lookups (mattermostUserCache).
   chatManager.onRebuild(() => {
     clearBridgeCache();
+    clearMattermostUserCache();
   });
 
   return async (req: IncomingMessage, res: ServerResponse): Promise<boolean> => {

--- a/bot/src/chat-manager.test.ts
+++ b/bot/src/chat-manager.test.ts
@@ -277,3 +277,123 @@ describe("ChatManager — isTransitioning flag", () => {
     assert.strictEqual(cm.isTransitioning(), false);
   });
 });
+
+// ── Scheduled adapter recycle (RES-286) ─────────────────────────────────────
+
+describe("ChatManager — scheduleAdapterRecycle()", () => {
+  it("fires rebuild() on the configured interval", async () => {
+    const cm = makeChatManager();
+    let rebuildCount = 0;
+    (cm as any).rebuild = async () => {
+      rebuildCount++;
+    };
+
+    // Seed an adapter so the recycle path doesn't early-return.
+    (cm as any).adapters.set("slack:conn-1", {
+      platform: "slack",
+      connectionId: "conn-1",
+      config: { botToken: "x", signingSecret: "y" },
+    });
+
+    cm.scheduleAdapterRecycle(20);
+    await new Promise((r) => setTimeout(r, 70));
+    cm.stopAdapterRecycle();
+
+    assert.ok(rebuildCount >= 2, `expected at least 2 rebuilds, got ${rebuildCount}`);
+  });
+
+  it("skips recycle when no adapters are registered", async () => {
+    const cm = makeChatManager();
+    let rebuildCount = 0;
+    (cm as any).rebuild = async () => {
+      rebuildCount++;
+    };
+
+    cm.scheduleAdapterRecycle(15);
+    await new Promise((r) => setTimeout(r, 60));
+    cm.stopAdapterRecycle();
+
+    assert.strictEqual(rebuildCount, 0);
+  });
+
+  it("skips recycle while transitioning to avoid concurrent rebuild", async () => {
+    const cm = makeChatManager();
+    let rebuildCount = 0;
+    (cm as any).rebuild = async () => {
+      rebuildCount++;
+    };
+    (cm as any).adapters.set("slack:conn-1", {
+      platform: "slack",
+      connectionId: "conn-1",
+      config: {},
+    });
+    (cm as any).transitioning = true;
+
+    cm.scheduleAdapterRecycle(15);
+    await new Promise((r) => setTimeout(r, 60));
+    cm.stopAdapterRecycle();
+
+    assert.strictEqual(rebuildCount, 0);
+  });
+
+  it("intervalMs <= 0 disables the timer (no recycle)", async () => {
+    const cm = makeChatManager();
+    let rebuildCount = 0;
+    (cm as any).rebuild = async () => {
+      rebuildCount++;
+    };
+    (cm as any).adapters.set("slack:conn-1", {
+      platform: "slack",
+      connectionId: "conn-1",
+      config: {},
+    });
+
+    cm.scheduleAdapterRecycle(0);
+    await new Promise((r) => setTimeout(r, 40));
+    cm.stopAdapterRecycle();
+
+    assert.strictEqual(rebuildCount, 0);
+  });
+
+  it("calling scheduleAdapterRecycle twice replaces the timer (no double-fire)", async () => {
+    const cm = makeChatManager();
+    let rebuildCount = 0;
+    (cm as any).rebuild = async () => {
+      rebuildCount++;
+    };
+    (cm as any).adapters.set("slack:conn-1", {
+      platform: "slack",
+      connectionId: "conn-1",
+      config: {},
+    });
+
+    cm.scheduleAdapterRecycle(15);
+    cm.scheduleAdapterRecycle(15);
+    await new Promise((r) => setTimeout(r, 50));
+    cm.stopAdapterRecycle();
+
+    // With a single active timer at 15ms, expect ~3 fires in 50ms — not 6.
+    assert.ok(rebuildCount <= 4, `expected ≤4 rebuilds (single timer), got ${rebuildCount}`);
+  });
+
+  it("stopAdapterRecycle() halts further rebuilds", async () => {
+    const cm = makeChatManager();
+    let rebuildCount = 0;
+    (cm as any).rebuild = async () => {
+      rebuildCount++;
+    };
+    (cm as any).adapters.set("slack:conn-1", {
+      platform: "slack",
+      connectionId: "conn-1",
+      config: {},
+    });
+
+    cm.scheduleAdapterRecycle(15);
+    await new Promise((r) => setTimeout(r, 50));
+    cm.stopAdapterRecycle();
+    const countAfterStop = rebuildCount;
+    await new Promise((r) => setTimeout(r, 60));
+
+    assert.strictEqual(rebuildCount, countAfterStop);
+  });
+});

--- a/bot/src/chat-manager.test.ts
+++ b/bot/src/chat-manager.test.ts
@@ -396,4 +396,78 @@ describe("ChatManager — scheduleAdapterRecycle()", () => {
 
     assert.strictEqual(rebuildCount, countAfterStop);
   });
+
+  it("swallows rebuild() errors and keeps ticking (until failure limit)", async () => {
+    const cm = makeChatManager();
+    let attempts = 0;
+    (cm as any).rebuild = async () => {
+      attempts++;
+      throw new Error("simulated rebuild failure");
+    };
+    (cm as any).adapters.set("slack:conn-1", {
+      platform: "slack",
+      connectionId: "conn-1",
+      config: {},
+    });
+
+    cm.scheduleAdapterRecycle(15);
+    await new Promise((r) => setTimeout(r, 60));
+    cm.stopAdapterRecycle();
+
+    // Should have attempted at least 2 ticks before the circuit breaker stops
+    // it (RECYCLE_FAILURE_LIMIT is 3). The .catch() must not crash the timer.
+    assert.ok(attempts >= 2, `expected at least 2 attempts, got ${attempts}`);
+  });
+
+  it("circuit breaker halts the timer after RECYCLE_FAILURE_LIMIT consecutive failures", async () => {
+    const cm = makeChatManager();
+    let attempts = 0;
+    (cm as any).rebuild = async () => {
+      attempts++;
+      throw new Error("simulated rebuild failure");
+    };
+    (cm as any).adapters.set("slack:conn-1", {
+      platform: "slack",
+      connectionId: "conn-1",
+      config: {},
+    });
+
+    cm.scheduleAdapterRecycle(10);
+    // Wait long enough that the breaker would have tripped (3 failures × 10 ms
+    // + some scheduling slack), then a stretch where further ticks could fire.
+    await new Promise((r) => setTimeout(r, 200));
+    const attemptsAfterTrip = attempts;
+    await new Promise((r) => setTimeout(r, 100));
+
+    // After the breaker trips no further attempts should occur.
+    assert.strictEqual(attempts, attemptsAfterTrip);
+    // And the trip should have happened at exactly RECYCLE_FAILURE_LIMIT (3)
+    // — not earlier and not (much) later.
+    assert.ok(attempts >= 3, `expected ≥3 attempts before trip, got ${attempts}`);
+    assert.ok(attempts <= 4, `expected ≤4 attempts (timer race), got ${attempts}`);
+  });
+
+  it("resets consecutive-failure counter after a successful rebuild", async () => {
+    const cm = makeChatManager();
+    let attempts = 0;
+    (cm as any).rebuild = async () => {
+      attempts++;
+      // Fail every other tick — the breaker should NEVER trip because a
+      // success resets the counter.
+      if (attempts % 2 === 1) throw new Error("flaky");
+    };
+    (cm as any).adapters.set("slack:conn-1", {
+      platform: "slack",
+      connectionId: "conn-1",
+      config: {},
+    });
+
+    cm.scheduleAdapterRecycle(10);
+    await new Promise((r) => setTimeout(r, 200));
+    cm.stopAdapterRecycle();
+
+    // Without reset, attempts would max out at 3-4 before the breaker fires.
+    // With reset, we expect many more attempts in 200 ms × 10 ms interval.
+    assert.ok(attempts >= 5, `expected ≥5 attempts (counter reset on success), got ${attempts}`);
+  });
 });

--- a/bot/src/chat-manager.ts
+++ b/bot/src/chat-manager.ts
@@ -56,6 +56,13 @@ export class ChatManager {
    *  state (notably the chat-adapter-mattermost ws closures and bridge.ts
    *  module-level user cache). */
   private recycleTimer: ReturnType<typeof setInterval> | null = null;
+  /** RES-286 — circuit breaker. If `rebuild()` throws on
+   *  `RECYCLE_FAILURE_LIMIT` consecutive scheduled ticks the timer halts so
+   *  we don't fill logs with the same error every 6 h. The first failure
+   *  on each run is still surfaced; the timer can be re-enabled by another
+   *  call to `scheduleAdapterRecycle(...)`. */
+  private consecutiveRecycleFailures: number = 0;
+  private static readonly RECYCLE_FAILURE_LIMIT = 3;
 
   constructor(redisUrl: string, registerHandlers: (bot: Chat) => void) {
     this.redisUrl = redisUrl;
@@ -277,13 +284,29 @@ export class ChatManager {
       console.log("ChatManager: adapter recycle disabled");
       return;
     }
+    this.consecutiveRecycleFailures = 0;
     this.recycleTimer = setInterval(() => {
       if (this.adapters.size === 0) return;
       if (this.transitioning) return;
       console.log(`ChatManager: scheduled adapter recycle (every ${Math.round(intervalMs / 1000)}s)`);
-      this.rebuild().catch((err: unknown) => {
-        console.error("ChatManager: scheduled recycle failed:", err);
-      });
+      this.rebuild()
+        .then(() => {
+          this.consecutiveRecycleFailures = 0;
+        })
+        .catch((err: unknown) => {
+          this.consecutiveRecycleFailures++;
+          console.error(
+            `ChatManager: scheduled recycle failed (${this.consecutiveRecycleFailures}/${ChatManager.RECYCLE_FAILURE_LIMIT}):`,
+            err,
+          );
+          if (this.consecutiveRecycleFailures >= ChatManager.RECYCLE_FAILURE_LIMIT) {
+            console.error(
+              `ChatManager: recycle halted after ${this.consecutiveRecycleFailures} consecutive failures; ` +
+                "investigate logs and re-enable via a process restart or another scheduleAdapterRecycle() call",
+            );
+            this.stopAdapterRecycle();
+          }
+        });
     }, intervalMs);
     this.recycleTimer.unref();
     console.log(`ChatManager: adapter recycle enabled (every ${Math.round(intervalMs / 1000)}s)`);
@@ -295,6 +318,7 @@ export class ChatManager {
       clearInterval(this.recycleTimer);
       this.recycleTimer = null;
     }
+    this.consecutiveRecycleFailures = 0;
   }
 
   getCurrentBot(): Chat | null {

--- a/bot/src/chat-manager.ts
+++ b/bot/src/chat-manager.ts
@@ -51,6 +51,11 @@ export class ChatManager {
   /** Maps workspace identifiers to connectionId for URL-based routing.
    *  e.g. Slack team_id "T0APJ2FNUKZ" → connectionId "abc-123" */
   private workspaceIdMap: Map<string, string> = new Map();
+  /** RES-286 — scheduled adapter recycle timer.
+   *  Tears down + rebuilds every adapter periodically to drop accumulated
+   *  state (notably the chat-adapter-mattermost ws closures and bridge.ts
+   *  module-level user cache). */
+  private recycleTimer: ReturnType<typeof setInterval> | null = null;
 
   constructor(redisUrl: string, registerHandlers: (bot: Chat) => void) {
     this.redisUrl = redisUrl;
@@ -241,6 +246,54 @@ export class ChatManager {
     } finally {
       this.transitioning = false;
       this.notifyRebuildCompleteListeners();
+    }
+  }
+
+  /**
+   * RES-286 — schedule periodic adapter recycle to drop accumulated state in
+   * long-lived adapter websockets (the chat-adapter-mattermost leak in
+   * particular). Each tick calls `rebuild()` which discards the old Chat
+   * instance + every adapter and reconstructs them fresh from stored configs.
+   *
+   * Re-entry is naturally guarded by `transitioning`: if the previous rebuild
+   * is still in flight when the timer fires, the new rebuild simply runs
+   * after; `rebuild()` is idempotent.
+   *
+   * Webhook deliveries during the ~1 s rebuild window are buffered by
+   * `WebhookBuffer` and replayed once the new bot is ready, so users see
+   * no degradation from a recycle.
+   *
+   * Calling this more than once replaces the existing timer.
+   *
+   * @param intervalMs how often to recycle. Pass 0 or a negative value to
+   *                   disable (useful for tests and local dev).
+   */
+  scheduleAdapterRecycle(intervalMs: number): void {
+    if (this.recycleTimer) {
+      clearInterval(this.recycleTimer);
+      this.recycleTimer = null;
+    }
+    if (intervalMs <= 0) {
+      console.log("ChatManager: adapter recycle disabled");
+      return;
+    }
+    this.recycleTimer = setInterval(() => {
+      if (this.adapters.size === 0) return;
+      if (this.transitioning) return;
+      console.log(`ChatManager: scheduled adapter recycle (every ${Math.round(intervalMs / 1000)}s)`);
+      this.rebuild().catch((err: unknown) => {
+        console.error("ChatManager: scheduled recycle failed:", err);
+      });
+    }, intervalMs);
+    this.recycleTimer.unref();
+    console.log(`ChatManager: adapter recycle enabled (every ${Math.round(intervalMs / 1000)}s)`);
+  }
+
+  /** Stop the recycle timer (used during graceful shutdown / tests). */
+  stopAdapterRecycle(): void {
+    if (this.recycleTimer) {
+      clearInterval(this.recycleTimer);
+      this.recycleTimer = null;
     }
   }
 

--- a/bot/src/index.ts
+++ b/bot/src/index.ts
@@ -189,7 +189,11 @@ async function syncConnectionsFromBackend(chatManager: ChatManager, label: strin
 }
 
 async function loadConnectionsFromBackend(chatManager: ChatManager): Promise<void> {
-  const delays = [1000, 2000, 4000, 8000, 16000];
+  // RES-286 — compressed from [1, 2, 4, 8, 16]s (31 s worst case) so that a
+  // bot restart only blocks `/bridge/...` calls for ~12 s, not ~31 s. The
+  // backend health check + Redis are typically up within ~3 s; we keep five
+  // retries for genuinely slow boots but cap the trailing waits at 4 s each.
+  const delays = [500, 1000, 2000, 4000, 4000];
 
   for (let attempt = 0; attempt < delays.length; attempt++) {
     try {
@@ -438,10 +442,18 @@ function startServer(chatManager: ChatManager): void {
   const server = createServer(async (req: IncomingMessage, res: ServerResponse) => {
     // Health check
     if (req.method === "GET" && req.url === "/health") {
-      jsonResponse(res, 200, {
-        status: "ok",
+      // RES-286 — return 503 while the chat manager is rebuilding adapters
+      // (recycle or sync) so docker healthcheck retries kick the bot only
+      // once it's actually wedged, not during legitimate 1-s recycle windows.
+      // The full `memory` block lets operators graph RSS between recycles
+      // and catch leak regressions early.
+      const transitioning = chatManager.isTransitioning();
+      jsonResponse(res, transitioning ? 503 : 200, {
+        status: transitioning ? "transitioning" : "ok",
         adapters: chatManager.listAdapters(),
-        transitioning: chatManager.isTransitioning(),
+        transitioning,
+        uptime_seconds: Math.round(process.uptime()),
+        memory: process.memoryUsage(),
       });
       return;
     }
@@ -479,6 +491,7 @@ function startServer(chatManager: ChatManager): void {
       clearInterval(backgroundSyncTimer);
       backgroundSyncTimer = null;
     }
+    chatManager.stopAdapterRecycle();
     server.close();
     const bot = chatManager.getCurrentBot();
     if (bot) {
@@ -739,6 +752,13 @@ async function main(): Promise<void> {
 
   // Start periodic background sync for self-healing
   startBackgroundSync(chatManager);
+
+  // RES-286 — schedule periodic adapter recycle to drop accumulated state in
+  // long-lived adapter websockets (notably chat-adapter-mattermost 1.1.2,
+  // which leaks ~37 MB/h via its ws message handler closures). Default is
+  // 6 h; set ADAPTER_RECYCLE_INTERVAL_MS=0 to disable for local dev.
+  const recycleMs = parseInt(process.env.ADAPTER_RECYCLE_INTERVAL_MS || "21600000", 10);
+  chatManager.scheduleAdapterRecycle(Number.isFinite(recycleMs) ? recycleMs : 21_600_000);
 
   startServer(chatManager);
   console.log("Bot service ready");

--- a/bot/src/index.ts
+++ b/bot/src/index.ts
@@ -447,6 +447,13 @@ function startServer(chatManager: ChatManager): void {
       // once it's actually wedged, not during legitimate 1-s recycle windows.
       // The full `memory` block lets operators graph RSS between recycles
       // and catch leak regressions early.
+      //
+      // SECURITY: this endpoint is unauthenticated and exposes
+      // `process.memoryUsage()` + uptime. The bot listens on `127.0.0.1:3001`
+      // (internal management surface; see docker-compose.yml `bot.ports`).
+      // If the bot port is ever exposed beyond loopback, gate this response
+      // behind the same `BRIDGE_API_KEY` Bearer auth that `/bridge/*` uses,
+      // or move memory/uptime to a separate `/debug/health` route.
       const transitioning = chatManager.isTransitioning();
       jsonResponse(res, transitioning ? 503 : 200, {
         status: transitioning ? "transitioning" : "ok",
@@ -757,8 +764,19 @@ async function main(): Promise<void> {
   // long-lived adapter websockets (notably chat-adapter-mattermost 1.1.2,
   // which leaks ~37 MB/h via its ws message handler closures). Default is
   // 6 h; set ADAPTER_RECYCLE_INTERVAL_MS=0 to disable for local dev.
-  const recycleMs = parseInt(process.env.ADAPTER_RECYCLE_INTERVAL_MS || "21600000", 10);
-  chatManager.scheduleAdapterRecycle(Number.isFinite(recycleMs) ? recycleMs : 21_600_000);
+  //
+  // A floor of 60 s applies to any positive override — a too-small interval
+  // would thrash the websocket and degrade availability. The `=== 0` escape
+  // hatch is preserved so dev/tests can opt out entirely.
+  const RECYCLE_DEFAULT_MS = 21_600_000;
+  const RECYCLE_FLOOR_MS = 60_000;
+  const recycleRaw = parseInt(process.env.ADAPTER_RECYCLE_INTERVAL_MS || `${RECYCLE_DEFAULT_MS}`, 10);
+  const recycleMs = !Number.isFinite(recycleRaw)
+    ? RECYCLE_DEFAULT_MS
+    : recycleRaw === 0
+      ? 0
+      : Math.max(recycleRaw, RECYCLE_FLOOR_MS);
+  chatManager.scheduleAdapterRecycle(recycleMs);
 
   startServer(chatManager);
   console.log("Bot service ready");

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -108,6 +108,16 @@ services:
     # bridge was the outlier (issue #34). Backend (8000) and web (3000)
     # remain on 0.0.0.0 since they're behind a reverse proxy in prod.
     ports: ["127.0.0.1:3001:3001"]
+    # RES-286 — bot self-heals after any exit (OOM, crash, SIGKILL).
+    # On a t4g.medium (4 GiB, no swap) running 6 hot services, an
+    # unrestricted bot can leak past the host's free-memory headroom in
+    # ~18 h via the long-lived chat-adapter-mattermost WebSocket and take
+    # everything down with it. `mem_limit` caps the bot in cgroup-land;
+    # `NODE_OPTIONS --max-old-space-size` keeps V8 GCing aggressively
+    # below the cgroup line so SIGTERM/graceful shutdown still fires.
+    restart: unless-stopped
+    mem_limit: 768m
+    memswap_limit: 768m
     depends_on:
       redis:
         condition: service_healthy
@@ -119,11 +129,19 @@ services:
       REDIS_URL: redis://redis:6379
       BOT_PORT: "3001"
       BRIDGE_API_KEY: ${BRIDGE_API_KEY:-}
+      NODE_OPTIONS: "--max-old-space-size=512"
+      # Structural leak fix — rebuild the chat-adapter set every 6 h so
+      # accumulated WebSocket state in chat-adapter-mattermost (1.1.2 has
+      # a slow leak in its long-lived ws + unbounded handler closures) is
+      # discarded long before it threatens the cgroup limit. Set to 0 to
+      # disable (e.g. local dev).
+      ADAPTER_RECYCLE_INTERVAL_MS: "21600000"
     healthcheck:
       test: ["CMD", "wget", "--spider", "-q", "http://localhost:3001/health"]
       interval: 10s
       timeout: 5s
       retries: 3
+      start_period: 45s
 
 volumes:
   weaviate_data:

--- a/src/beever_atlas/api/connections.py
+++ b/src/beever_atlas/api/connections.py
@@ -6,11 +6,12 @@ import logging
 from typing import Any
 
 import httpx
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel
 
 from beever_atlas.infra.auth import Principal, require_user
 from beever_atlas.infra.config import get_settings
+from beever_atlas.infra.rate_limit import limiter
 from beever_atlas.stores import get_stores
 
 logger = logging.getLogger(__name__)
@@ -418,8 +419,18 @@ async def validate_connection(connection_id: str) -> ConnectionResponse:
 
 
 @router.get("/api/connections/{connection_id}/channels", response_model=list[ChannelItem])
-async def list_connection_channels(connection_id: str) -> list[ChannelItem]:
-    """List available channels for a platform connection."""
+@limiter.limit("20/minute")
+async def list_connection_channels(
+    request: Request,  # noqa: ARG001 — required by slowapi to identify the caller
+    connection_id: str,
+) -> list[ChannelItem]:
+    """List available channels for a platform connection.
+
+    Rate-limited to 20/minute per client (RES-286 security review): the FE
+    Refresh button can be clicked rapidly, and each call proxies to the
+    upstream Mattermost/Slack/etc. API. The cap prevents a runaway client
+    from exhausting the bot token's upstream rate limit.
+    """
     stores = get_stores()
     conn = await stores.platform.get_connection(connection_id)
     if conn is None:

--- a/web/src/components/settings/ManageChannelsDialog.tsx
+++ b/web/src/components/settings/ManageChannelsDialog.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { X, Loader2, AlertCircle, Save } from "lucide-react";
+import { X, Loader2, AlertCircle, Save, RefreshCw } from "lucide-react";
 import { ChannelSelector } from "./ChannelSelector";
 import { useConnectionChannels, useUpdateChannels } from "@/hooks/useConnections";
 import type { PlatformConnection } from "@/lib/types";
@@ -10,7 +10,7 @@ interface ManageChannelsDialogProps {
 }
 
 export function ManageChannelsDialog({ connection, onClose }: ManageChannelsDialogProps) {
-  const { channels, loading, error } = useConnectionChannels(connection.id);
+  const { channels, loading, error, refetch } = useConnectionChannels(connection.id);
   const { updateChannels, loading: saving, error: saveError } = useUpdateChannels(connection.id);
   const [selected, setSelected] = useState<string[]>(connection.selected_channels);
 
@@ -42,13 +42,31 @@ export function ManageChannelsDialog({ connection, onClose }: ManageChannelsDial
               {connection.display_name || connection.platform}
             </p>
           </div>
-          <button
-            type="button"
-            onClick={onClose}
-            className="w-8 h-8 flex items-center justify-center rounded-lg hover:bg-muted transition-colors"
-          >
-            <X className="w-4 h-4 text-muted-foreground" />
-          </button>
+          <div className="flex items-center gap-1">
+            {/* RES-286 — refresh button. Calling refetch() re-fetches the bot's
+                live channel list, so a channel the user just added the bot to
+                (e.g. tech-studio on Mattermost) shows up without restarting the
+                bot or reopening the dialog. */}
+            <button
+              type="button"
+              onClick={refetch}
+              disabled={loading}
+              title="Refresh channel list"
+              aria-label="Refresh channel list"
+              className="w-8 h-8 flex items-center justify-center rounded-lg hover:bg-muted transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              <RefreshCw
+                className={`w-4 h-4 text-muted-foreground ${loading ? "animate-spin" : ""}`}
+              />
+            </button>
+            <button
+              type="button"
+              onClick={onClose}
+              className="w-8 h-8 flex items-center justify-center rounded-lg hover:bg-muted transition-colors"
+            >
+              <X className="w-4 h-4 text-muted-foreground" />
+            </button>
+          </div>
         </div>
 
         {/* Content */}


### PR DESCRIPTION
## Summary
- **Root cause:** `chat-adapter-mattermost@1.1.2` leaks ~37 MB/h via long-lived WebSocket handler closures. Bot OOMs after ~19h on a 4 GiB host, and compose had `restart: no`, so it stayed dead silently until QA noticed.
- **Structural fix:** `ChatManager.scheduleAdapterRecycle()` rebuilds adapters every 6 h, dropping accumulated state proactively. Existing `WebhookBuffer` covers the ~1 s rebuild window. Circuit breaker halts the timer after 3 consecutive failures so a sustained-degradation state doesn't fill logs.
- **Safety net:** `restart: unless-stopped`, `mem_limit: 768m`, `NODE_OPTIONS=--max-old-space-size=512` on the bot service. Even if leak ever doubles, host stays healthy.
- **Cross-platform leak protection:** beyond `mattermostUserCache`, audit found 4 more module-level Maps in `bridge.ts` (`userProfileCache`, `teamsConversationRegistry`, `telegramChatRegistry`, `bridgeCache`). All wired into the existing `onRebuild` cleanup — clear-on-rebuild for transient caches, age-out-on-rebuild for the Teams/Telegram registries that are the only source of truth for `listChannels()` on those platforms.
- **Feature gap closed:** Refresh button in Manage Channels dialog calls the existing `useConnectionChannels.refetch`. Rate-limited server-side at `20/minute` per client.

Designed via OMC critic + architect validation, then refined after OMC code-reviewer (APPROVE, 2 mediums + 1 low) + security-reviewer (LOW risk, 1 medium + 2 lows). All actionable findings addressed in commit 81a3696.

Linear ticket: [RES-286](https://linear.app/votee/issue/RES-286). Live-verified on EE deployment 2026-05-18.

## Why this is "long-term" not a band-aid
| Metric | Before | After |
|---|---|---|
| Time-to-OOM | ~19 h | Never (recycle pre-empts at 6 h) |
| Bot dead silently | Forever (no restart) | Never (auto-restart, verified ~200 ms) |
| MM WS events lost on restart | ALL 35+ h dead window | ≤ 1 s every 6 h (recycle) or ≤ 12 s on unexpected restart |
| Newly-invited MM channels | Invisible until manual op | Visible after Refresh click |
| Host OOM risk | High (no `mem_limit`) | Negligible (bot capped at 768 MiB of 4 GiB) |
| Slack/Discord/Teams/Telegram caches | Grew unbounded | Cleared / pruned on every recycle |
| Refresh button DoS | N/A (no button) | Capped at 20/minute server-side |

Math: 37 MB/h × 6 h = ~220 MB peak. At 2× expected leak rate, still 440 MB — under the 512 MiB V8 cap.

## Commits
1. **`cc3e5f7`** — initial fix: scheduled recycle, restart policy, mem_limit, NODE_OPTIONS, MM cache clear, Refresh button, /health enrichment, faster startup retry, shutdown cleanup.
2. **`81a3696`** — review-driven round 2: cross-platform cache cleanup (Slack/Discord/Teams/Telegram), recycle circuit breaker, interval floor, /health SECURITY comment, server-side rate limit on `/api/connections/{id}/channels`.

## Files
- `bot/src/chat-manager.ts` — `scheduleAdapterRecycle()` + `stopAdapterRecycle()` with consecutive-failure circuit breaker
- `bot/src/chat-manager.test.ts` — 10 new tests covering recycle + circuit breaker
- `bot/src/bridge.ts` — `clearUserProfileCache()`, `clearMattermostUserCache()`, `pruneStaleTeamsConversations()`, `pruneStaleTelegramChats()`; all wired into existing `onRebuild` listener
- `bot/src/bridge.caches.test.ts` — new tests for prune + clear functions
- `bot/src/index.ts` — recycle wiring with interval floor, `/health` enrichment + SECURITY comment, faster startup retry, shutdown cleanup
- `docker-compose.yml` — restart, mem_limit, NODE_OPTIONS, ADAPTER_RECYCLE_INTERVAL_MS, start_period
- `src/beever_atlas/api/connections.py` — `@limiter.limit("20/minute")` on `list_connection_channels`
- `web/src/components/settings/ManageChannelsDialog.tsx` — Refresh button

## Deferred follow-ups (filed separately)
- Heap-snapshot diff to pinpoint exact leak object in `chat-adapter-mattermost` and report upstream
- Deep WS-state healthcheck (needs adapter API surface change)
- REST enumeration of non-member MM channels (needs `list_team_channels` MM permission)
- OOM-event alerting via `docker events`
- Multi-tenant IDOR review of `/api/connections/{id}/channels` once multi-tenancy lands

## Test plan
- [x] Bot: 183 / 183 tests pass (10 new tests for recycle + circuit breaker + cache prune)
- [x] Web: 531 / 531 vitest tests pass
- [x] Python: 86 / 86 connection tests pass
- [x] Lint: 0 errors (pre-existing warnings only)
- [x] `docker compose config` validates
- [x] Live verification on EE deployment (commit cc3e5f7 deployed; round-2 redeploy in progress)
  - [x] Bot up + healthy
  - [x] `restart: unless-stopped` triggers in ~200 ms after exit
  - [x] `/health` returns new memory + uptime fields
  - [x] Manage Channels endpoint returns 200 with channel list
  - [x] New web bundle hash confirms Refresh button shipped
- [ ] 24 h drift test: bot RSS stays flat under recycle (monitor running)

🤖 Generated with [Claude Code](https://claude.com/claude-code)