### PR TITLE
fix(ux+observability): TTL ring buffer (RES-284), orphan platform fallback (RES-287/4a), Mermaid cancellation guard (RES-287/4b)

### DIFF
--- a/src/beever_atlas/agents/tools/_citation_decorator.py
+++ b/src/beever_atlas/agents/tools/_citation_decorator.py
@@ -185,7 +185,11 @@ def _annotate(
 
 def _derive_native_identity(kind: str, item: dict) -> str | None:
     if kind == "channel_message":
-        platform = item.get("platform") or "slack"
+        # RES-287/4a — sibling of the api/channels.py fallback. Orphan items
+        # without a platform field used to silently become "slack", producing
+        # broken Slack permalinks on Mattermost/Discord data. The permalink
+        # resolver handles "unknown" gracefully (returns None).
+        platform = item.get("platform") or "unknown"
         channel_id = item.get("channel_id") or ""
         message_ts = item.get("message_ts") or item.get("timestamp") or ""
         fact_id = item.get("fact_id") or item.get("id") or "0"

--- a/src/beever_atlas/api/channels.py
+++ b/src/beever_atlas/api/channels.py
@@ -511,7 +511,11 @@ async def list_channels() -> list[ChannelResponse]:
             *[stores.mongodb.get_channel_display_name(cid) for cid in orphaned_ids]
         )
         for cid, name in zip(orphaned_ids, name_results):
-            platform = _detect_platform_from_channel_id(cid) or "discord"
+            # RES-287/4a — orphaned channels (no connection_id) used to fall
+            # back to "discord", which caused the sidebar to show the Discord
+            # icon on Mattermost/Slack workspaces. "unknown" is the truthful
+            # answer; PlatformIcon renders a neutral MessageSquare for it.
+            platform = _detect_platform_from_channel_id(cid) or "unknown"
             all_channels.append(
                 ChannelInfo(
                     channel_id=cid,
@@ -664,7 +668,8 @@ async def get_channel(
     synced_ids = await stores.mongodb.list_synced_channel_ids()
     if channel_id in synced_ids:
         name = await stores.mongodb.get_channel_display_name(channel_id)
-        platform = _detect_platform_from_channel_id(channel_id) or "discord"
+        # RES-287/4a — see list_channels above; same orphan-platform fallback.
+        platform = _detect_platform_from_channel_id(channel_id) or "unknown"
         return await _enrich_with_language(
             ChannelResponse(
                 channel_id=channel_id,

--- a/src/beever_atlas/api/llm_debug.py
+++ b/src/beever_atlas/api/llm_debug.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Query
 from pydantic import BaseModel
 
 from beever_atlas.services.llm_call_log import snapshot as _snapshot
@@ -43,7 +43,16 @@ class RecentLLMCallsResponse(BaseModel):
 
 
 @router.get("/recent-llm-calls", response_model=RecentLLMCallsResponse)
-async def recent_llm_calls() -> RecentLLMCallsResponse:
+async def recent_llm_calls(
+    max_age_seconds: float = Query(
+        1800.0,
+        ge=0,
+        description=(
+            "RES-284 — drop entries older than this many seconds (default 30 min). "
+            "Set to a large value (e.g. 86400) to inspect older calls for debugging."
+        ),
+    ),
+) -> RecentLLMCallsResponse:
     """Return the most recent LLM dispatch calls, newest first.
 
     Use cases:
@@ -55,8 +64,10 @@ async def recent_llm_calls() -> RecentLLMCallsResponse:
         upstream returned without exposing credentials.
 
     Bounded to the last 50 calls. Process-local — uvicorn restart resets.
+    Filtered by ``max_age_seconds`` to prevent stale failures from haunting
+    the Agent Models tab indefinitely (RES-284).
     """
-    rows: list[dict[str, Any]] = _snapshot()
+    rows: list[dict[str, Any]] = _snapshot(expires_after_seconds=max_age_seconds)
     return RecentLLMCallsResponse(calls=[RecentLLMCallResponse(**r) for r in rows])
 
 

--- a/src/beever_atlas/services/llm_call_log.py
+++ b/src/beever_atlas/services/llm_call_log.py
@@ -94,7 +94,13 @@ class RecentLLMCall:
 
 
 _RING_SIZE = 50
-_recent: deque[RecentLLMCall] = deque(maxlen=_RING_SIZE)
+# RES-284 — entries are stored as (wall_clock_ts, call) tuples so `snapshot()`
+# can age out stale failures. Without the TTL, a burst of `ok=false` calls
+# during a misconfiguration sticks in the buffer until 50 newer calls evict
+# them or the process restarts — which is what painted the Agent Models tab
+# red for hours after the LiteLLM-embeddings migration sync.
+_recent: deque[tuple[float, RecentLLMCall]] = deque(maxlen=_RING_SIZE)
+_DEFAULT_TTL_SECONDS = 1800.0  # 30 minutes — paired with FE poll interval (15s)
 
 
 def _now_iso() -> str:
@@ -143,27 +149,39 @@ def record_call(
             error_class = type(exc).__name__
             error_summary = _redact(str(exc)[:200])
         _recent.append(
-            RecentLLMCall(
-                ts=_now_iso(),
-                kind=kind,
-                consumer=consumer,
-                provider=provider,
-                model=model,
-                api_base=api_base,
-                latency_ms=elapsed_ms if ok else None,
-                ok=ok,
-                response_model=response_model if isinstance(response_model, str) else None,
-                error_class=error_class,
-                error_summary=error_summary,
+            (
+                time.time(),  # RES-284 — wall-clock TTL anchor
+                RecentLLMCall(
+                    ts=_now_iso(),
+                    kind=kind,
+                    consumer=consumer,
+                    provider=provider,
+                    model=model,
+                    api_base=api_base,
+                    latency_ms=elapsed_ms if ok else None,
+                    ok=ok,
+                    response_model=response_model if isinstance(response_model, str) else None,
+                    error_class=error_class,
+                    error_summary=error_summary,
+                ),
             )
         )
     except Exception:  # noqa: BLE001 — never crash dispatch on logging
         pass
 
 
-def snapshot() -> list[dict[str, Any]]:
-    """Return the ring buffer newest-first, serialised to dicts."""
-    return [asdict(r) for r in reversed(_recent)]
+def snapshot(expires_after_seconds: float = _DEFAULT_TTL_SECONDS) -> list[dict[str, Any]]:
+    """Return the ring buffer newest-first, serialised to dicts.
+
+    RES-284: entries older than ``expires_after_seconds`` (default 30 min) are
+    filtered out. This prevents a single failure burst from haunting the
+    Agent Models tab for hours after the underlying cause is resolved.
+    Pass a negative value to disable filtering (debug/test use).
+    """
+    if expires_after_seconds < 0:
+        return [asdict(call) for _ts, call in reversed(_recent)]
+    cutoff = time.time() - expires_after_seconds
+    return [asdict(call) for ts, call in reversed(_recent) if ts >= cutoff]
 
 
 def clear() -> None:

--- a/tests/services/test_llm_call_log.py
+++ b/tests/services/test_llm_call_log.py
@@ -273,6 +273,104 @@ def test_dispatch_owns_recording_contextvar_skips_custom_logger() -> None:
     assert _DISPATCH_OWNS_RECORDING.get() is False
 
 
+# ── RES-284 — ring buffer TTL ────────────────────────────────────────────────
+
+
+def test_snapshot_default_ttl_keeps_recent_entries() -> None:
+    """Just-recorded entries are well inside the 30-min default TTL."""
+    import time
+
+    llm_call_log.record_call(
+        started_at=time.monotonic(),
+        kind="completion",
+        consumer="qa_agent",
+        provider="openai",
+        model="gpt-4o-mini",
+        api_base=None,
+        exc=RuntimeError("transient 429"),
+    )
+    snap = llm_call_log.snapshot()
+    assert len(snap) == 1
+    assert snap[0]["ok"] is False
+
+
+def test_snapshot_filters_entries_older_than_ttl(monkeypatch: pytest.MonkeyPatch) -> None:
+    """RES-284: a failure recorded >ttl seconds ago must not surface — the
+    stale-failure regression that haunted Agent Models for hours after a
+    sync run."""
+    import time as _real_time
+
+    fixed_now = 1_700_000_000.0
+    # Record at t=fixed_now
+    monkeypatch.setattr(llm_call_log.time, "time", lambda: fixed_now)
+    llm_call_log.record_call(
+        started_at=_real_time.monotonic(),
+        kind="completion",
+        consumer="qa_agent",
+        provider="openai",
+        model="gpt-4o-mini",
+        api_base=None,
+        exc=RuntimeError("upstream failure from yesterday"),
+    )
+    assert len(llm_call_log.snapshot(expires_after_seconds=1800)) == 1
+
+    # Fast-forward 31 minutes (> default 1800 s TTL)
+    monkeypatch.setattr(llm_call_log.time, "time", lambda: fixed_now + 31 * 60)
+    assert llm_call_log.snapshot(expires_after_seconds=1800) == []
+    # But a longer TTL window still returns it
+    assert len(llm_call_log.snapshot(expires_after_seconds=2 * 3600)) == 1
+
+
+def test_snapshot_ttl_boundary_just_inside_and_outside(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Entries at exactly TTL seconds old are kept; one second older are dropped."""
+    import time as _real_time
+
+    fixed_now = 1_700_000_000.0
+    monkeypatch.setattr(llm_call_log.time, "time", lambda: fixed_now)
+    llm_call_log.record_call(
+        started_at=_real_time.monotonic(),
+        kind="completion",
+        consumer=None,
+        provider="openai",
+        model="m",
+        api_base=None,
+        response=type("R", (), {"model": "m"})(),
+    )
+
+    # At exactly TTL seconds later — still inside (cutoff is >=)
+    monkeypatch.setattr(llm_call_log.time, "time", lambda: fixed_now + 1800)
+    assert len(llm_call_log.snapshot(expires_after_seconds=1800)) == 1
+
+    # One second past — dropped
+    monkeypatch.setattr(llm_call_log.time, "time", lambda: fixed_now + 1801)
+    assert llm_call_log.snapshot(expires_after_seconds=1800) == []
+
+
+def test_snapshot_negative_ttl_disables_filtering(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pass a negative ``expires_after_seconds`` to inspect arbitrarily old
+    entries (operators debugging an outage)."""
+    import time as _real_time
+
+    fixed_now = 1_700_000_000.0
+    monkeypatch.setattr(llm_call_log.time, "time", lambda: fixed_now)
+    llm_call_log.record_call(
+        started_at=_real_time.monotonic(),
+        kind="completion",
+        consumer=None,
+        provider="openai",
+        model="m",
+        api_base=None,
+        exc=RuntimeError("ancient failure"),
+    )
+
+    # 7 days later: default TTL would drop it, negative TTL keeps it.
+    monkeypatch.setattr(llm_call_log.time, "time", lambda: fixed_now + 7 * 86400)
+    assert llm_call_log.snapshot() == []
+    assert len(llm_call_log.snapshot(expires_after_seconds=-1)) == 1
+
+
 def test_snapshot_serialisation_shape() -> None:
     """Every field in the dataclass must round-trip through ``asdict``."""
     import time

--- a/tests/test_orphan_platform_fallback.py
+++ b/tests/test_orphan_platform_fallback.py
@@ -1,0 +1,80 @@
+"""RES-287/4a — orphan-channel platform fallback regression tests.
+
+When a channel has no `connection_id` (CSV-imported, pre-connection-model
+legacy, etc.) and its channel id doesn't match a known shape, the platform
+field used to hardcode-fall-back to ``"discord"`` (api/channels.py) or
+``"slack"`` (agents/tools/_citation_decorator.py). That painted the wrong
+icon in the sidebar and produced broken Slack-shaped permalinks for
+non-Slack data. The truthful answer is ``"unknown"`` — PlatformIcon falls
+back to the neutral MessageSquare icon and the permalink resolver returns
+``None`` for unknown platforms.
+"""
+
+from __future__ import annotations
+
+
+def test_detect_platform_returns_none_for_arbitrary_string() -> None:
+    """The detector's failure mode (returning None) is the trigger for the
+    fallback we changed — this asserts the contract the fallback relies on."""
+    from beever_atlas.api.channels import _detect_platform_from_channel_id
+
+    # Mattermost channel ids are 26-char base-36; not matched by Slack
+    # (starts with C/D/G) or Discord (17-20 digit snowflake) detection.
+    assert _detect_platform_from_channel_id("uksaigrf77ywbyyg8ooz1ozqxa") is None
+    # CSV-style human ids
+    assert _detect_platform_from_channel_id("example_chat") is None
+    assert _detect_platform_from_channel_id("any-random-thing") is None
+
+
+def test_detect_platform_still_recognizes_slack_and_discord() -> None:
+    """Sanity: the fallback only fires when detection misses — make sure the
+    existing detection paths still work and aren't being shadowed."""
+    from beever_atlas.api.channels import _detect_platform_from_channel_id
+
+    assert _detect_platform_from_channel_id("C12345678") == "slack"
+    assert _detect_platform_from_channel_id("D12345678") == "slack"
+    assert _detect_platform_from_channel_id("G12345678") == "slack"
+    # Discord snowflakes are all-digits, 17-20 chars
+    assert _detect_platform_from_channel_id("123456789012345678") == "discord"
+
+
+def test_citation_decorator_falls_back_to_unknown_when_platform_missing() -> None:
+    """RES-287/4a — `_derive_native_identity` for ``channel_message`` items
+    without a ``platform`` field used to produce a ``slack:...`` identity
+    string. The fallback now yields ``unknown:...`` so the permalink resolver
+    gracefully returns None instead of constructing a broken Slack URL."""
+    from beever_atlas.agents.tools._citation_decorator import _derive_native_identity
+
+    # Platform absent entirely
+    native_id = _derive_native_identity(
+        "channel_message",
+        {"channel_id": "C12345", "message_ts": "1234567890.000100", "fact_id": "f-1"},
+    )
+    assert native_id is not None
+    assert native_id.startswith("unknown:"), native_id
+
+    # Platform present and falsy (empty string) — same fallback path
+    native_id_empty = _derive_native_identity(
+        "channel_message",
+        {"platform": "", "channel_id": "C12345", "message_ts": "1.0", "fact_id": "f-2"},
+    )
+    assert native_id_empty is not None
+    assert native_id_empty.startswith("unknown:"), native_id_empty
+
+
+def test_citation_decorator_keeps_explicit_platform() -> None:
+    """The fallback must only fire when ``platform`` is missing/empty — an
+    explicit value (mattermost, discord, etc.) must round-trip unchanged."""
+    from beever_atlas.agents.tools._citation_decorator import _derive_native_identity
+
+    native = _derive_native_identity(
+        "channel_message",
+        {
+            "platform": "mattermost",
+            "channel_id": "uksaigrf77ywbyyg8ooz1ozqxa",
+            "message_ts": "2026-05-16T18:00:00",
+            "fact_id": "f-99",
+        },
+    )
+    assert native is not None
+    assert native.startswith("mattermost:"), native

--- a/web/src/components/wiki/MermaidBlock.tsx
+++ b/web/src/components/wiki/MermaidBlock.tsx
@@ -183,10 +183,30 @@ export function MermaidBlock({ chart }: MermaidBlockProps) {
   const [expanded, setExpanded] = useState(false);
   const [zoom, setZoom] = useState(1);
 
+  // RES-287/4b — mirrors the canonical pattern in
+  // `channel/MermaidBlock.tsx` (lines 129-184). The previous implementation
+  // had no cleanup on this useEffect, so React StrictMode's double-invoke
+  // fired two concurrent `mermaid.render()` coroutines against the singleton
+  // mermaid instance. The first (aborted) call corrupted mermaid's internal
+  // state and the second produced an error SVG → setError fired → fallback
+  // <details> tile rendered. With N MermaidBlocks on a wiki page, the page
+  // stacked N error tiles. The cancellation flag + clearTimeout + parse-first
+  // pattern below eliminates the race.
   useEffect(() => {
-    const render = async () => {
+    let cancelled = false;
+
+    // Debounce so we don't re-run mermaid's expensive parse+render on every
+    // rapid prop change (StrictMode double-invoke, theme flip, etc.). 250ms
+    // matches the channel/MermaidBlock implementation.
+    const debounceMs = 250;
+    const timer = setTimeout(() => {
+      if (!cancelled) void render();
+    }, debounceMs);
+
+    async function render(): Promise<void> {
       const theme = resolvedTheme === "dark" ? "dark" : "light";
       await ensureMermaidInit(theme, mermaidThemeConfig(theme));
+      if (cancelled) return;
       const sanitized = sanitizeMermaid(chart);
       // Mermaid v10+ resolves the promise even on parse errors, but returns a
       // diagnostic SVG containing the error text. Detect these cases explicitly.
@@ -197,24 +217,41 @@ export function MermaidBlock({ chart }: MermaidBlockProps) {
       const newId = () => `m${Math.random().toString(36).slice(2).replace(/[^a-zA-Z0-9]/g, "")}`;
 
       try {
+        // Parse first so bad syntax throws cleanly instead of returning a
+        // valid-shape SVG that contains "Syntax error in text". Some mermaid
+        // versions swallow the throw inside render() — parse() is the only
+        // path that reliably surfaces malformed source.
+        await mermaid.parse(sanitized, { suppressErrors: false });
+        if (cancelled) return;
         const id = newId();
         const result = await mermaid.render(id, sanitized);
+        if (cancelled) return;
         if (isErrorSvg(result.svg)) throw new Error("mermaid returned error svg");
         setSvg(result.svg);
         setError(null);
       } catch {
+        if (cancelled) return;
         try {
+          const simplified = simplifyMermaid(sanitized);
+          await mermaid.parse(simplified, { suppressErrors: false });
+          if (cancelled) return;
           const id2 = newId();
-          const result2 = await mermaid.render(id2, simplifyMermaid(sanitized));
+          const result2 = await mermaid.render(id2, simplified);
+          if (cancelled) return;
           if (isErrorSvg(result2.svg)) throw new Error("mermaid returned error svg after simplify");
           setSvg(result2.svg);
           setError(null);
         } catch (err2) {
+          if (cancelled) return;
           setError(String(err2));
         }
       }
+    }
+
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
     };
-    render();
   }, [chart, resolvedTheme]);
 
   const handleZoomIn = useCallback(() => setZoom(z => Math.min(z + 0.25, 3)), []);

--- a/web/src/components/wiki/__tests__/MermaidBlock.test.tsx
+++ b/web/src/components/wiki/__tests__/MermaidBlock.test.tsx
@@ -1,0 +1,134 @@
+/**
+ * RES-287/4b — regression tests for the cancellation-guard pattern in
+ * wiki/MermaidBlock.tsx. The previous implementation had no `useEffect`
+ * cleanup, so React StrictMode's double-invoke fired two concurrent
+ * `mermaid.render()` calls against the singleton mermaid instance, the
+ * second of which produced an error SVG and slipped into the fallback
+ * `<details>` tile — stacking once per block on the page.
+ *
+ * Pattern mirrors `web/src/components/channel/__tests__/MermaidBlock.test.tsx`.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { StrictMode } from "react";
+import { MermaidBlock } from "../MermaidBlock";
+
+vi.mock("mermaid", () => ({
+  default: {
+    initialize: vi.fn(),
+    parse: vi.fn().mockResolvedValue(true),
+    render: vi.fn(),
+  },
+}));
+
+// useTheme is loaded from a hook that reads CSS-class state; stub to a stable value.
+vi.mock("@/hooks/useTheme", () => ({
+  useTheme: () => ({ resolvedTheme: "light", setTheme: vi.fn() }),
+}));
+
+describe("wiki/MermaidBlock (RES-287/4b)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders SVG for valid mermaid code", async () => {
+    const { default: mermaid } = await import("mermaid");
+    vi.mocked(mermaid.render).mockResolvedValue({
+      svg: "<svg><text>diagram</text></svg>",
+      bindFunctions: undefined,
+      diagramType: "flowchart",
+    });
+
+    render(<MermaidBlock chart="graph TD; A-->B" />);
+
+    await waitFor(() => {
+      expect(document.querySelector("svg")).not.toBeNull();
+    });
+  });
+
+  it("renders exactly one fallback <details> when the diagram fails", async () => {
+    const { default: mermaid } = await import("mermaid");
+    // Both parse attempts (initial + simplified retry) must fail so the
+    // component exhausts retries and shows the fallback.
+    vi.mocked(mermaid.parse)
+      .mockRejectedValueOnce(new Error("Syntax error in text"))
+      .mockRejectedValueOnce(new Error("Syntax error in text"));
+
+    render(<MermaidBlock chart="not valid mermaid" />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Diagram could not be rendered/i)).toBeInTheDocument();
+    });
+
+    // CRITICAL: exactly one fallback tile, not stacked.
+    expect(screen.queryAllByText(/Diagram could not be rendered/i)).toHaveLength(1);
+  });
+
+  it("two MermaidBlocks each produce at most one fallback (no stacking)", async () => {
+    const { default: mermaid } = await import("mermaid");
+    vi.mocked(mermaid.parse).mockRejectedValue(new Error("bad"));
+
+    render(
+      <>
+        <MermaidBlock chart="bad1" />
+        <MermaidBlock chart="bad2" />
+      </>,
+    );
+
+    await waitFor(() => {
+      expect(screen.queryAllByText(/Diagram could not be rendered/i).length).toBeGreaterThanOrEqual(1);
+    });
+
+    // Two blocks → exactly two fallback summaries, never four (which would
+    // be the symptom of the StrictMode race producing duplicate setError
+    // writes from the aborted first render of each block).
+    const fallbacks = screen.queryAllByText(/Diagram could not be rendered/i);
+    expect(fallbacks).toHaveLength(2);
+  });
+
+  it("StrictMode double-mount does not produce stacked error tiles", async () => {
+    const { default: mermaid } = await import("mermaid");
+    vi.mocked(mermaid.parse).mockRejectedValue(new Error("bad"));
+
+    render(
+      <StrictMode>
+        <MermaidBlock chart="invalid in strict mode" />
+      </StrictMode>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/Diagram could not be rendered/i)).toBeInTheDocument();
+    });
+
+    // The cancellation guard is what makes this pass. Without it, both
+    // mount cycles would race, set error twice, and produce stacked tiles.
+    expect(screen.queryAllByText(/Diagram could not be rendered/i)).toHaveLength(1);
+  });
+
+  it("falls back when render returns a syntax-error SVG (mermaid v11 swallow)", async () => {
+    const { default: mermaid } = await import("mermaid");
+    // parse() passes the syntax check, but render() returns the diagnostic
+    // SVG mermaid v11 emits instead of throwing. The component must detect
+    // the SVG content and treat it as an error.
+    // `true` matches mermaid's runtime contract; the type cast keeps Vitest
+    // happy with mermaid v11's typed ParseResult union.
+    vi.mocked(mermaid.parse).mockResolvedValue(true as unknown as never);
+    vi.mocked(mermaid.render)
+      .mockResolvedValueOnce({
+        svg: '<svg><text>Syntax error in text</text><text>mermaid version 11.15.0</text></svg>',
+        bindFunctions: undefined,
+        diagramType: "flowchart",
+      })
+      .mockResolvedValueOnce({
+        svg: '<svg><text>Syntax error in text</text></svg>',
+        bindFunctions: undefined,
+        diagramType: "flowchart",
+      });
+
+    render(<MermaidBlock chart="graph TD; A---" />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Diagram could not be rendered/i)).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Three small, independent QA-reported bugs bundled into one PR. Each was investigated by a separate OMC agent and the consolidated plan was stress-tested by an OMC critic before any code was written (the critic caught a missed sibling fix-site and an underspecified cancellation pattern — both addressed).

| Ticket | Bug | Fix |
|---|---|---|
| [RES-284](https://linear.app/votee/issue/RES-284) | Stale red indicators on Agent Models tab after sync | TTL on the `/api/settings/debug/recent-llm-calls` ring buffer + `?max_age_seconds` query param |
| [RES-287/4a](https://linear.app/votee/issue/RES-287) | "Ungrouped (Discord)" mislabel on Mattermost workspace | `or "discord"`/`or "slack"` → `or "unknown"` at 3 fallback sites |
| [RES-287/4b](https://linear.app/votee/issue/RES-287) | Stacked Mermaid "Syntax error in text" tiles | Cancellation guard pattern matching `channel/MermaidBlock.tsx` (debounce + `mermaid.parse()` + guard every `setState`) |

## Why a grab-bag
- All three are isolated to the file(s) listed, no cross-cutting concerns.
- Total production diff: ~50 LOC; total test diff: ~200 LOC.
- Two of the three (4a, 4b) directly close visible bugs; RES-284 hardens against a recurrence pattern that's currently invisible only because of yesterday's uvicorn restart.

## Reviewer rounds
1. **3 OMC investigators** (per ticket): produced detailed root-cause + fix designs.
2. **1 OMC critic**: returned **REVISE** with 4 actionable changes:
   - Add the missed `_citation_decorator.py:188` sibling site (rolled in).
   - MermaidBlock fix must match `channel/MermaidBlock.tsx:129-184` verbatim (rolled in: debounce, parse first, guard all setState).
   - Drop client-side TTL filter; server filter is sufficient (followed).
   - Add a test for `_citation_decorator` change (rolled in).

## Files
- `src/beever_atlas/services/llm_call_log.py` — tuple-wrap deque + `snapshot(expires_after_seconds=1800)`
- `src/beever_atlas/api/llm_debug.py` — `?max_age_seconds` Query param
- `src/beever_atlas/api/channels.py` — `or "discord"` → `or "unknown"` at lines 514 + 667
- `src/beever_atlas/agents/tools/_citation_decorator.py` — `or "slack"` → `or "unknown"` at line 188
- `web/src/components/wiki/MermaidBlock.tsx` — cancellation guard, parse-first, debounce
- `tests/services/test_llm_call_log.py` — 4 new TTL tests
- `tests/test_orphan_platform_fallback.py` — 4 new orphan-platform tests
- `web/src/components/wiki/__tests__/MermaidBlock.test.tsx` — 5 new MermaidBlock tests (incl. StrictMode regression)

## Test plan
- [x] Python: 58 / 58 pass in affected areas (services, channels, citation, orphan platform)
- [x] Web: 536 / 536 vitest tests across 60 files
- [x] TypeScript: clean
- [ ] Live verification after merge + redeploy (Agent Models tab, sidebar label, wiki page mermaid blocks)
- [ ] 24h drift: bot RSS pattern still flat (monitor still running from RES-286)

🤖 Generated with [Claude Code](https://claude.com/claude-code)