### PR TITLE
fix(web): channel-sync state isolation + top-nav gate during sync (RES-285)

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -13,7 +13,6 @@ import { Sidebar } from "@/components/layout/Sidebar";
 import { Header } from "@/components/layout/Header";
 import { Dashboard } from "@/pages/Dashboard";
 import { Channels } from "@/pages/Channels";
-import { ChannelWorkspace } from "@/pages/ChannelWorkspace";
 import { AskPage } from "@/pages/AskPage";
 import { SharedAskPage } from "@/pages/SharedAskPage";
 import {
@@ -38,6 +37,8 @@ import { ChannelSettingsTab } from "@/components/channel/ChannelSettingsTab";
 import { SyncHistoryTab } from "@/components/channel/SyncHistoryTab";
 import { useTheme } from "@/hooks/useTheme";
 import { ChannelDefaultRedirect } from "@/pages/ChannelWorkspace";
+import { ChannelWorkspaceRoute } from "@/routes/ChannelWorkspaceRoute";
+import { SyncStatusProvider } from "@/contexts/SyncStatusContext";
 
 function AppShell() {
   const [sidebarOpen, setSidebarOpen] = useState(false);
@@ -62,6 +63,7 @@ function AppShell() {
 
   return (
     <AskSessionsProvider>
+    <SyncStatusProvider>
     <div className="grid grid-cols-[auto_1fr] h-screen h-dvh bg-background">
       <Sidebar open={sidebarOpen} onClose={() => setSidebarOpen(false)} />
       {/* Mobile overlay */}
@@ -85,7 +87,10 @@ function AppShell() {
             <Routes location={location}>
               <Route path="/" element={<Dashboard />} />
               <Route path="/channels" element={<Channels />} />
-              <Route path="/channels/:id" element={<ChannelWorkspace />}>
+              {/* RES-285 — `ChannelWorkspaceRoute` mounts <ChannelWorkspace
+                  key={id} /> so the entire subtree (and every useState in
+                  it) resets atomically on channel switch. */}
+              <Route path="/channels/:id" element={<ChannelWorkspaceRoute />}>
                 <Route index element={<ChannelDefaultRedirect />} />
                 <Route path="wiki" element={<WikiTab />} />
                 <Route path="wiki/:slug" element={<WikiTab />} />
@@ -136,6 +141,7 @@ function AppShell() {
         </main>
       </div>
     </div>
+    </SyncStatusProvider>
     </AskSessionsProvider>
   );
 }

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -19,6 +19,7 @@ import { SidebarConversationList } from "./SidebarConversationList";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { useTheme } from "@/hooks/useTheme";
 import { useAskSessions } from "@/contexts/AskSessionsContext";
+import { useSyncStatus } from "@/contexts/SyncStatusContext";
 import { api, adminHeaders } from "@/lib/api";
 import { useState, useEffect, useCallback, useRef } from "react";
 
@@ -51,6 +52,11 @@ export function Sidebar({ open, onClose }: SidebarProps) {
   const resizingRef = useRef(false);
   const { resolvedTheme, toggleTheme } = useTheme();
   const { isActive: isAskActive } = useAskSessions();
+  // RES-285 — read the global "is a channel currently syncing?" signal so
+  // we can gate the top-nav NavLinks below. Channel-list switching is NOT
+  // gated; the Home logo + Home NavLink are NOT gated (universal escape
+  // hatch — user must always be able to reach the dashboard).
+  const { isSyncRunning, channelId: syncingChannelId } = useSyncStatus();
 
   useEffect(() => {
     window.localStorage.setItem(WIDTH_KEY, String(width));
@@ -138,22 +144,42 @@ export function Sidebar({ open, onClose }: SidebarProps) {
         </button>
       </div>
 
-      {/* Nav items */}
+      {/* Nav items
+       *  RES-285 — when `isSyncRunning` is true, gate every top-nav link
+       *  EXCEPT Home (`to === "/"`). Home is a universal escape hatch,
+       *  intentionally left clickable so a stuck sync never traps the
+       *  user. The gate is a triple-defense:
+       *    1. `aria-disabled` — assistive tech announces the state
+       *    2. `tabIndex={-1}` — keyboard tab skips the link
+       *    3. `onClick preventDefault` — click and Enter do nothing
+       *  A Tooltip names the syncing channel so users understand why.
+       */}
       <nav className="py-2 shrink-0">
         {navItems.map(({ to, icon: Icon, label }) => {
+          const gated = isSyncRunning && to !== "/";
           const navLink = (
             <NavLink
               key={to}
               to={to}
               end={to === "/"}
-              onClick={() => { if (open) onClose(); }}
+              aria-disabled={gated ? true : undefined}
+              tabIndex={gated ? -1 : undefined}
+              onClick={(e) => {
+                if (gated) {
+                  e.preventDefault();
+                  return;
+                }
+                if (open) onClose();
+              }}
               className={({ isActive }) =>
                 cn(
                   "flex items-center gap-2.5 px-3 py-1.5 text-[14px] transition-all duration-150 rounded-lg relative mx-1",
                   isActive
                     ? "bg-primary/10 text-primary font-medium"
                     : "text-muted-foreground hover:text-foreground hover:bg-muted",
-                  collapsed && "justify-center px-0 mx-0"
+                  collapsed && "justify-center px-0 mx-0",
+                  gated &&
+                    "opacity-50 cursor-not-allowed hover:bg-transparent hover:text-muted-foreground",
                 )
               }
             >
@@ -166,7 +192,24 @@ export function Sidebar({ open, onClose }: SidebarProps) {
             return (
               <Tooltip key={to}>
                 <TooltipTrigger render={navLink} />
-                <TooltipContent side="right">{label}</TooltipContent>
+                <TooltipContent side="right">
+                  {gated
+                    ? `Sync in progress${syncingChannelId ? ` on #${syncingChannelId}` : ""} — wait for completion`
+                    : label}
+                </TooltipContent>
+              </Tooltip>
+            );
+          }
+          // Even when expanded, surface a tooltip on gated items so users
+          // understand the disabled state rather than wondering why their
+          // click did nothing.
+          if (gated) {
+            return (
+              <Tooltip key={to}>
+                <TooltipTrigger render={navLink} />
+                <TooltipContent side="right">
+                  {`Sync in progress${syncingChannelId ? ` on #${syncingChannelId}` : ""} — wait for completion`}
+                </TooltipContent>
               </Tooltip>
             );
           }

--- a/web/src/contexts/SyncStatusContext.tsx
+++ b/web/src/contexts/SyncStatusContext.tsx
@@ -1,0 +1,77 @@
+/**
+ * SyncStatusContext (RES-285)
+ *
+ * Mirrors the derived "is any channel syncing right now?" signal out of
+ * `ChannelWorkspace` into a shared scope so `Sidebar` can gate its
+ * top-nav NavLinks without subscribing to the polling hook directly.
+ *
+ * Design notes (from the ralplan consensus loop):
+ *
+ *  - **Two `useState` cells, not one object.** Splitting the boolean and
+ *    the string keeps React's `Object.is` bail-out in play: identical
+ *    publishes (e.g. `setIsSyncRunning(true)` while already `true`)
+ *    short-circuit and consumers don't re-render. Wrapping the same
+ *    values in a single object literal would create a fresh identity on
+ *    every publish and break AC6.
+ *  - **`setIsSyncRunning` / `setChannelId` are the raw React setters** —
+ *    referentially stable for the life of the provider, safe to put in
+ *    useEffect dependency arrays.
+ *  - **Gate scope: ONLY `state === "syncing"`.** Error / idle / completed
+ *    DO NOT gate the nav. Rationale: error is terminal and the fix path
+ *    usually goes through Settings — gating Settings would trap the
+ *    user with no recovery. The publisher in `ChannelWorkspace` is
+ *    responsible for narrowing `syncState.state` to that boolean.
+ *  - **Home is intentionally excluded from the gate** (universal escape
+ *    hatch). The Sidebar consumer is the policy site.
+ */
+
+import {
+  type Dispatch,
+  type ReactNode,
+  type SetStateAction,
+  createContext,
+  useContext,
+  useMemo,
+  useState,
+} from "react";
+
+export interface SyncStatusContextValue {
+  /** True iff some channel's `useSync` reports `state === "syncing"`. */
+  isSyncRunning: boolean;
+  /** The channelId currently syncing, or null when idle. Surfaced so the
+   *  nav-gate tooltip can name it ("Sync in progress on #marketing…"). */
+  channelId: string | null;
+  setIsSyncRunning: Dispatch<SetStateAction<boolean>>;
+  setChannelId: Dispatch<SetStateAction<string | null>>;
+}
+
+const SyncStatusContext = createContext<SyncStatusContextValue | null>(null);
+
+interface SyncStatusProviderProps {
+  children: ReactNode;
+}
+
+export function SyncStatusProvider({ children }: SyncStatusProviderProps) {
+  const [isSyncRunning, setIsSyncRunning] = useState(false);
+  const [channelId, setChannelId] = useState<string | null>(null);
+
+  // useMemo deps are PRIMITIVES (boolean + string|null), so this memo
+  // only invalidates when a real value change happens — preserving the
+  // `Object.is` bail-out path through to subscribers.
+  const value = useMemo<SyncStatusContextValue>(
+    () => ({ isSyncRunning, channelId, setIsSyncRunning, setChannelId }),
+    [isSyncRunning, channelId],
+  );
+
+  return (
+    <SyncStatusContext.Provider value={value}>{children}</SyncStatusContext.Provider>
+  );
+}
+
+export function useSyncStatus(): SyncStatusContextValue {
+  const ctx = useContext(SyncStatusContext);
+  if (!ctx) {
+    throw new Error("useSyncStatus must be used inside <SyncStatusProvider>");
+  }
+  return ctx;
+}

--- a/web/src/contexts/__tests__/SyncStatusContext.test.tsx
+++ b/web/src/contexts/__tests__/SyncStatusContext.test.tsx
@@ -1,0 +1,146 @@
+/**
+ * RES-285 — SyncStatusContext behaviour tests.
+ *
+ * Specifically guards AC6: "Subscriber re-renders only when `isSyncRunning`
+ * value changes." The whole point of splitting state into two primitive
+ * `useState` cells (vs. one wrapped object) is to preserve React's
+ * `Object.is` bail-out path. If a future refactor wraps these back into a
+ * single object setter, this test will fail noisily.
+ */
+
+import { describe, it, expect } from "vitest";
+import { act, render } from "@testing-library/react";
+import { useRef } from "react";
+import { SyncStatusProvider, useSyncStatus } from "../SyncStatusContext";
+
+describe("SyncStatusContext (RES-285)", () => {
+  it("default value is { isSyncRunning: false, channelId: null }", () => {
+    let captured: { isSyncRunning: boolean; channelId: string | null } | null = null;
+    function Probe() {
+      const { isSyncRunning, channelId } = useSyncStatus();
+      captured = { isSyncRunning, channelId };
+      return null;
+    }
+    render(
+      <SyncStatusProvider>
+        <Probe />
+      </SyncStatusProvider>,
+    );
+    expect(captured).toEqual({ isSyncRunning: false, channelId: null });
+  });
+
+  it("throws when used outside the provider", () => {
+    function Probe() {
+      useSyncStatus();
+      return null;
+    }
+    // React 19 prints to console.error in addition to throwing. Capture
+    // and assert only that we got the expected error type.
+    const originalError = console.error;
+    console.error = () => {};
+    try {
+      expect(() => render(<Probe />)).toThrow(/useSyncStatus must be used inside/);
+    } finally {
+      console.error = originalError;
+    }
+  });
+
+  it("publishing an already-equal boolean does NOT re-render subscribers (AC6)", () => {
+    let renderCount = 0;
+    let setterRef: ((v: boolean) => void) | null = null;
+
+    function Subscriber() {
+      const { isSyncRunning, setIsSyncRunning } = useSyncStatus();
+      const seen = useRef({ renders: 0 });
+      seen.current.renders += 1;
+      renderCount = seen.current.renders;
+      setterRef = setIsSyncRunning;
+      return <div data-testid="state">{String(isSyncRunning)}</div>;
+    }
+
+    render(
+      <SyncStatusProvider>
+        <Subscriber />
+      </SyncStatusProvider>,
+    );
+
+    expect(renderCount).toBe(1);
+
+    // Publish the same value (already false) — React's `Object.is` bail-out
+    // must short-circuit this. If a refactor uses a single object setter,
+    // this assertion will fail because `{...}` !== `{...}`.
+    act(() => {
+      setterRef!(false);
+    });
+    expect(renderCount).toBe(1);
+
+    // Now publish a real change — exactly one re-render.
+    act(() => {
+      setterRef!(true);
+    });
+    expect(renderCount).toBe(2);
+
+    // Same value again — still 2.
+    act(() => {
+      setterRef!(true);
+    });
+    expect(renderCount).toBe(2);
+  });
+
+  it("setIsSyncRunning and setChannelId are referentially stable across renders", () => {
+    const seen = new Set<unknown>();
+    let setterFromContext: ((v: boolean) => void) | null = null;
+
+    function Probe() {
+      const { setIsSyncRunning, setChannelId } = useSyncStatus();
+      seen.add(setIsSyncRunning);
+      seen.add(setChannelId);
+      setterFromContext = setIsSyncRunning;
+      return null;
+    }
+
+    const { rerender } = render(
+      <SyncStatusProvider>
+        <Probe />
+      </SyncStatusProvider>,
+    );
+
+    // Force a re-render — setters must still be the same instances.
+    rerender(
+      <SyncStatusProvider>
+        <Probe />
+      </SyncStatusProvider>,
+    );
+
+    // Both setters captured across renders should de-dupe to exactly 2
+    // entries (one isSync setter, one channelId setter).
+    expect(seen.size).toBe(2);
+    expect(typeof setterFromContext).toBe("function");
+  });
+
+  it("publishing channelId carries through to subscribers", () => {
+    let captured: string | null = "<unset>";
+    let setChannelIdRef: ((v: string | null) => void) | null = null;
+
+    function Subscriber() {
+      const { channelId, setChannelId } = useSyncStatus();
+      captured = channelId;
+      setChannelIdRef = setChannelId;
+      return null;
+    }
+
+    render(
+      <SyncStatusProvider>
+        <Subscriber />
+      </SyncStatusProvider>,
+    );
+
+    expect(captured).toBeNull();
+
+    act(() => setChannelIdRef!("#marketing"));
+    expect(captured).toBe("#marketing");
+
+    act(() => setChannelIdRef!(null));
+    expect(captured).toBeNull();
+  });
+});

--- a/web/src/pages/ChannelWorkspace.tsx
+++ b/web/src/pages/ChannelWorkspace.tsx
@@ -21,6 +21,7 @@ import { SyncProgress } from "@/components/channel/SyncProgress";
 import { NextSyncBadge } from "@/components/channel/NextSyncBadge";
 import { useSync } from "@/hooks/useSync";
 import { LanguageBadge } from "@/components/channel/LanguageBadge";
+import { useSyncStatus } from "@/contexts/SyncStatusContext";
 
 interface ChannelInfo {
   channel_id: string;
@@ -205,6 +206,30 @@ export function ChannelWorkspace() {
 
   const isMember = channel?.is_member === true;
   const { syncState, triggerSync, isSyncing, error: syncError } = useSync(id ?? "", channel?.connection_id ?? null);
+
+  // RES-285 — publish the strict "is sync actually running right now?"
+  // signal up to SyncStatusContext so Sidebar can gate its top-nav.
+  //
+  // We narrow `syncState.state` to a primitive boolean BEFORE handing it
+  // to the setter — the context uses two separate `useState` cells
+  // (boolean + string|null) precisely so React's `Object.is` bail-out
+  // applies and consumers don't re-render on identical publishes.
+  //
+  // Gate fires ONLY on `state === "syncing"`. NOT on `error` (terminal —
+  // user needs Settings to fix), NOT on `idle`/`completed`.
+  const { setIsSyncRunning, setChannelId: setSyncingChannelId } = useSyncStatus();
+  const isSyncRunningHere = syncState.state === "syncing";
+  useEffect(() => {
+    setIsSyncRunning(isSyncRunningHere);
+    setSyncingChannelId(isSyncRunningHere ? (id ?? null) : null);
+    // Clear the gate when the channel unmounts (route change, navigate
+    // away). Without this, navigating from a syncing channel to /
+    // would leave the gate stuck on.
+    return () => {
+      setIsSyncRunning(false);
+      setSyncingChannelId(null);
+    };
+  }, [isSyncRunningHere, id, setIsSyncRunning, setSyncingChannelId]);
   // PR-B: when the failure banner copy is built from sync state errors,
   // prefer the deduped form (single line per unique message + count)
   // so a Gemini 503 storm shows "AI provider temporarily unavailable

--- a/web/src/routes/ChannelWorkspaceRoute.tsx
+++ b/web/src/routes/ChannelWorkspaceRoute.tsx
@@ -1,0 +1,34 @@
+/**
+ * ChannelWorkspaceRoute (RES-285)
+ *
+ * Thin wrapper that reads the `:id` route param via `useParams` and
+ * passes it to `<ChannelWorkspace key={id} />`. The React `key` prop
+ * forces a full subtree remount on every channelId change, which is
+ * what makes the channel-switch state-leak class of bugs structurally
+ * impossible:
+ *
+ *   - `useSync`'s `syncState` and `lastFingerprintRef`
+ *   - `channel` / `loadingChannel` / `refreshing`
+ *   - `cooldownRemaining`'s setInterval
+ *
+ * …all five state cells in `ChannelWorkspace` reset atomically on the
+ * commit phase of the route param change, without each owner needing
+ * its own ad-hoc reset effect.
+ *
+ * Why a wrapper rather than `<ChannelWorkspace key={id} />` inline in
+ * `App.tsx:88`? React Router's `<Route element>` JSX has no access to
+ * the path params at the declaration site — `:id` is only resolved
+ * inside a descendant via `useParams`. The wrapper is the smallest
+ * idiomatic adapter.
+ */
+
+import { useParams } from "react-router-dom";
+import { ChannelWorkspace } from "@/pages/ChannelWorkspace";
+
+export function ChannelWorkspaceRoute() {
+  const { id } = useParams<{ id: string }>();
+  // React Router shouldn't render this route without `:id`, but stay
+  // defensive — returning null lets the parent route fall through.
+  if (!id) return null;
+  return <ChannelWorkspace key={id} />;
+}

--- a/web/src/routes/__tests__/ChannelWorkspaceRoute.test.tsx
+++ b/web/src/routes/__tests__/ChannelWorkspaceRoute.test.tsx
@@ -1,0 +1,115 @@
+/**
+ * RES-285 — ChannelWorkspaceRoute behaviour tests.
+ *
+ * Guards AC1 ("switching A → B mid-sync shows B's idle state, no stale UI
+ * from A") and AC7 ("cooldown countdown does not carry over") at the
+ * structural level: navigating between `/channels/a` and `/channels/b`
+ * must unmount the entire ChannelWorkspace subtree and mount a fresh one.
+ *
+ * We mock `@/pages/ChannelWorkspace` to a probe component that exposes its
+ * mount count via a global counter — if the wrapper's `key={id}` works,
+ * the probe's `useEffect` mount handler fires once per `:id` change.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, act } from "@testing-library/react";
+import {
+  MemoryRouter,
+  Route,
+  Routes,
+  useNavigate,
+  useParams,
+} from "react-router-dom";
+import { useEffect } from "react";
+
+// Track mount/unmount events from the probe so we can verify the key prop
+// actually forces a remount on `:id` change.
+const events: string[] = [];
+
+vi.mock("@/pages/ChannelWorkspace", () => {
+  // Probe component imported lazily inside the mock factory so vitest's
+  // module-mock order works correctly. Note the probe is itself a real
+  // React component using the live `useParams` from react-router-dom.
+  const ChannelWorkspaceMock = () => {
+    const { id } = useParams<{ id: string }>();
+    useEffect(() => {
+      events.push(`mount:${id}`);
+      return () => {
+        events.push(`unmount:${id}`);
+      };
+    }, [id]);
+    return <div data-testid="probe">channel:{id}</div>;
+  };
+  return { ChannelWorkspace: ChannelWorkspaceMock };
+});
+
+// Import AFTER the mock so the wrapper resolves to the mocked component.
+import { ChannelWorkspaceRoute } from "../ChannelWorkspaceRoute";
+
+describe("ChannelWorkspaceRoute (RES-285)", () => {
+  beforeEach(() => {
+    events.length = 0;
+  });
+
+  it("renders ChannelWorkspace for the current :id", () => {
+    render(
+      <MemoryRouter initialEntries={["/channels/abc"]}>
+        <Routes>
+          <Route path="/channels/:id" element={<ChannelWorkspaceRoute />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByTestId("probe").textContent).toBe("channel:abc");
+    expect(events).toContain("mount:abc");
+  });
+
+  it("unmounts the old workspace and mounts a fresh one when :id changes", () => {
+    // Render once at /channels/a, then trigger an in-router navigation
+    // to /channels/b. The `key={id}` on <ChannelWorkspace> must force a
+    // full unmount + remount.
+    function NavTrigger({ to }: { to: string }) {
+      const navigate = useNavigate();
+      return (
+        <button data-testid="nav" type="button" onClick={() => navigate(to)}>
+          go
+        </button>
+      );
+    }
+
+    render(
+      <MemoryRouter initialEntries={["/channels/a"]}>
+        <Routes>
+          <Route path="/channels/:id" element={<ChannelWorkspaceRoute />} />
+        </Routes>
+        <NavTrigger to="/channels/b" />
+      </MemoryRouter>,
+    );
+
+    expect(events.filter((e) => e === "mount:a")).toHaveLength(1);
+
+    // Click triggers in-router navigation to /channels/b.
+    act(() => {
+      screen.getByTestId("nav").click();
+    });
+
+    // Old channel unmounted; new channel mounted fresh.
+    expect(events).toContain("unmount:a");
+    expect(events).toContain("mount:b");
+    // Probe now reflects b.
+    expect(screen.getByTestId("probe").textContent).toBe("channel:b");
+  });
+
+  it("renders nothing when :id is missing", () => {
+    // Edge: deep-link to /channels (no id). The wrapper should render null
+    // and not crash, leaving the parent route to fall through.
+    const { container } = render(
+      <MemoryRouter initialEntries={["/channels/"]}>
+        <Routes>
+          <Route path="/channels/*" element={<ChannelWorkspaceRoute />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+    expect(container.querySelector("[data-testid='probe']")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
Closes [RES-285](https://linear.app/votee/issue/RES-285). Two QA-reported UX bugs during channel sync.

- **Bug A — cross-channel state leak:** sync on `#marketing`, switch to `#tech-beever-atlas`, the old progress bar stays visible (and can permanently freeze the new channel via the `lastFingerprintRef` dedup guard).
- **Bug B — top-nav not gated during sync:** users can navigate away from a syncing workspace via the top tabs, even though leaving mid-sync drops MM websocket events.

## Designed via ralplan consensus loop
- Planner v1 → Architect → Critic **ITERATE** (called out a principle violation: Option A was a symptom fix that left 4 sibling state leaks)
- Planner v2 → Architect (5 substantive amendments) → Critic **APPROVE**
- The substantive shift: flipped Bug A from a local \`useEffect\` reset (fixes 1 leak) to a route-level remount key (fixes 5 leaks structurally).

## Architecture

### Bug A — \`ChannelWorkspaceRoute\` wrapper with \`key={id}\`
The root cause is that \`ChannelWorkspace\`'s state was keyed to the component instance, not the channel. Adding \`<ChannelWorkspace key={id} />\` forces React to unmount + remount the entire subtree on every \`:id\` change. Every \`useState\` cell resets atomically — \`syncState\`, \`channel\`, \`cooldownRemaining\`, \`refreshing\`, \`loadingChannel\`. Future state cells added to ChannelWorkspace inherit this property for free.

### Bug B — \`SyncStatusContext\` with split-state cells
Mirrors the existing \`AskSessionsContext.tsx\` pattern. **Split into TWO \`useState\` cells** (\`isSyncRunning: boolean\` + \`channelId: string|null\`) — primitives bail out on \`Object.is\` so subscribers don't re-render on equal-value publishes. A single-object \`useState\` would have defeated this (new object literal every publish ≠ \`Object.is\` equal); the AC6 guard test catches that regression noisily.

**Gate scope: ONLY \`state === \"syncing\"\`.** Error, idle, completed do not gate. Rationale: error is terminal and the recovery path goes through Settings. Gating Settings on error would trap users with no fix path.

**Home is excluded from the gate** — universal escape hatch invariant. User must always be able to reach the dashboard.

**Triple-defense gate** on the 4 gated NavLinks: \`aria-disabled\` (a11y), \`tabIndex={-1}\` (keyboard skip), \`onClick preventDefault\` (click + Enter no-op). Tooltip names the syncing channel so users understand the disabled state.

## Files
| File | Change |
|---|---|
| \`web/src/routes/ChannelWorkspaceRoute.tsx\` | NEW — route wrapper |
| \`web/src/contexts/SyncStatusContext.tsx\` | NEW — sync-status publisher/subscriber |
| \`web/src/App.tsx\` | wrap layout in SyncStatusProvider + swap route element |
| \`web/src/pages/ChannelWorkspace.tsx\` | publisher \`useEffect\` |
| \`web/src/components/layout/Sidebar.tsx\` | subscriber + gate on 4 NavLinks |
| 2 new test files | 8 new tests |

## Test plan
- [x] **Web**: 544 / 544 tests pass (was 536; added 5 SyncStatusContext + 3 ChannelWorkspaceRoute)
- [x] **TypeScript**: clean
- [x] **Lint**: 0 errors (2 pre-existing warnings on untouched code)
- [ ] Live verification after merge + auto-deploy:
  - Start sync on \`#marketing\`, switch to \`#tech-beever-atlas\` → no stale progress bar on the new channel
  - Mid-sync top-nav (Channels, Ask, Activity, Settings) shows disabled state with tooltip
  - Mid-sync Home stays enabled (escape hatch)
  - Mid-sync channel-list in sidebar stays clickable
  - Cooldown countdown from channel A does not carry over to channel B
- [ ] 24h post-merge: bot RSS monitor still flat (from RES-286)

## Deferred (consciously not in this PR)
- Sync-cancel CTA inside ChannelWorkspace (the more user-friendly answer to the home-trap question; needs backend cancel endpoint)
- Migrate other channel-scoped hooks (e.g. chat draft state) to the route-remount pattern — audit

🤖 Generated with [Claude Code](https://claude.com/claude-code)