### PR TITLE
feat(ingestion): INGEST_BOT_MESSAGES flag to keep webhook/bot-authored content

### DIFF
--- a/src/beever_atlas/agents/ingestion/preprocessor.py
+++ b/src/beever_atlas/agents/ingestion/preprocessor.py
@@ -113,13 +113,19 @@ def _is_bot_message(msg: dict[str, Any]) -> bool:
     return False
 
 
-def _is_skippable(msg: dict[str, Any]) -> bool:
+def _is_skippable(msg: dict[str, Any], keep_bot_messages: bool = False) -> bool:
     """Return True if the message should be excluded from preprocessing.
 
     Skipped if:
     - No ``text`` content (or text is purely whitespace).
-    - Sent by a bot — UNLESS it's a thread reply with substantive content (>20 chars).
+    - Sent by a bot — UNLESS it's a thread reply with substantive content (>20
+      chars), or ``keep_bot_messages`` is set (then bot authorship alone never
+      skips; empty-text and system-subtype messages are still dropped).
     - Is a Slack join/leave or other system subtype.
+
+    ``keep_bot_messages`` mirrors ``Settings.ingest_bot_messages`` — it exists for
+    deployments where "people" post through webhooks (e.g. Discord webhook
+    personas, which Discord always stamps ``author.bot=true``).
     """
     text: str = (msg.get("text") or msg.get("content") or "").strip()
     has_attachments = bool(msg.get("attachments") or msg.get("files"))
@@ -128,7 +134,7 @@ def _is_skippable(msg: dict[str, Any]) -> bool:
 
     raw_meta = msg.get("raw_metadata") if isinstance(msg.get("raw_metadata"), dict) else {}
 
-    if _is_bot_message(msg):
+    if not keep_bot_messages and _is_bot_message(msg):
         # Keep bot thread replies with substantive content (CI results, deploy notices, etc.)
         thread_id = msg.get("thread_ts") or msg.get("thread_id")
         msg_id = msg.get("ts") or msg.get("message_id")
@@ -345,8 +351,12 @@ class PreprocessorAgent(BaseAgent):
         skipped = 0
         msg_seq = 0
 
+        # Webhook-persona deployments (e.g. Discord) set this so bot-authored
+        # messages aren't dropped as integration noise. Read once per batch.
+        keep_bot_messages = get_settings().ingest_bot_messages
+
         for msg in messages:
-            if _is_skippable(msg):
+            if _is_skippable(msg, keep_bot_messages=keep_bot_messages):
                 skipped += 1
                 continue
 

--- a/src/beever_atlas/infra/config.py
+++ b/src/beever_atlas/infra/config.py
@@ -159,6 +159,18 @@ class Settings(BaseSettings):
     entity_threshold: float = Field(default=0.6)
     max_facts_per_message: int = Field(default=2)
     sync_batch_timeout_seconds: int = Field(default=600)
+    # When true, the PreprocessorAgent KEEPS messages flagged as bot-authored
+    # (top-level ``is_bot`` or ``raw_metadata.is_bot``) instead of dropping them
+    # as integration noise. Needed when "people" are posted via webhooks — e.g.
+    # Discord webhook personas (each message carries a custom username + avatar
+    # but Discord stamps ``author.bot=true``), or community/bridged webhooks.
+    # Empty-text and system-subtype messages are still skipped. Default False
+    # preserves CI/deploy-bot noise filtering for normal deployments.
+    ingest_bot_messages: bool = Field(
+        default=False,
+        alias="INGEST_BOT_MESSAGES",
+        description="Keep bot/webhook-authored messages during preprocessing (e.g. Discord webhook personas) instead of dropping them as noise.",
+    )
 
     # ── Embedding (provider-pluggable via LiteLLM) ────────────────────────
     # Defaults preserve the legacy Jina-v4 @ 2048d behaviour bit-for-bit so

--- a/tests/test_preprocessor.py
+++ b/tests/test_preprocessor.py
@@ -22,6 +22,39 @@ def test_is_skippable_rejects_system_message_from_raw_metadata() -> None:
     assert _is_skippable(msg) is True
 
 
+def _discord_webhook_persona_msg() -> dict:
+    """A Discord webhook 'persona' message: human content, but Discord stamps
+    ``author.bot=true`` so the bridge stores ``raw_metadata.is_bot=true`` and the
+    message is posted flat (no thread reference)."""
+    return {
+        "content": "We should book the ryokan early — the good ones sell out months ahead.",
+        "author_name": "Ken Lau",
+        "is_bot": False,
+        "raw_metadata": {"is_bot": True},
+    }
+
+
+def test_is_skippable_drops_webhook_bot_message_by_default() -> None:
+    # Default behaviour: a flat bot-authored message is integration noise -> drop.
+    assert _is_skippable(_discord_webhook_persona_msg()) is True
+
+
+def test_is_skippable_keeps_webhook_bot_message_when_flag_set() -> None:
+    # With ingest_bot_messages on, bot authorship alone must not skip it.
+    assert _is_skippable(_discord_webhook_persona_msg(), keep_bot_messages=True) is False
+
+
+def test_is_skippable_flag_still_drops_empty_and_system_messages() -> None:
+    # The flag only relaxes the bot check — empty-text and system subtypes still skip.
+    empty = {"content": "   ", "raw_metadata": {"is_bot": True}}
+    system = {
+        "content": "@alice joined",
+        "raw_metadata": {"is_bot": True, "subtype": "channel_join"},
+    }
+    assert _is_skippable(empty, keep_bot_messages=True) is True
+    assert _is_skippable(system, keep_bot_messages=True) is True
+
+
 def test_build_thread_context_supports_normalized_thread_fields() -> None:
     parent_ts = datetime(2026, 3, 20, 12, 0, tzinfo=UTC).isoformat()
     parent = {


### PR DESCRIPTION
## Problem
The `PreprocessorAgent` drops bot-authored messages (`is_bot` / `raw_metadata.is_bot`) as integration noise, keeping only substantive thread replies. That silently discards **people posted via webhooks** — most notably **Discord webhook personas**: each message carries a custom username + avatar, but Discord stamps `author.bot=true`, so the bridge stores `raw_metadata.is_bot=true` and every flat (non-threaded) message is filtered → **0 facts → no memories → no wiki**.

This is exactly what bit the demo Discord channels (gaming, japan-trip): extraction returned `{"facts":[]}` for every batch because the preprocessor retained 0 messages.

## Change
- New `Settings.ingest_bot_messages` (env **`INGEST_BOT_MESSAGES`**, default **False**).
- `_is_skippable(msg, keep_bot_messages=...)`: when set, bot authorship alone no longer skips a message. Empty-text and system-subtype messages are **still** dropped.
- Threaded through `PreprocessorAgent` (read once per batch from settings).

Default **False** preserves CI/deploy-bot noise filtering for normal deployments. Set `INGEST_BOT_MESSAGES=true` in `.env` for webhook-persona deployments (e.g. the Discord demo).

## Tests
- `test_is_skippable_drops_webhook_bot_message_by_default`
- `test_is_skippable_keeps_webhook_bot_message_when_flag_set`
- `test_is_skippable_flag_still_drops_empty_and_system_messages`

Local: `pytest tests/test_preprocessor.py` ✅ (6 passed) · `ruff check`/`format` ✅ · `pyright` 0 errors.