### PR TITLE
fix(sync): /sync/status ignores synthetic worker_extraction jobs

### DIFF
--- a/src/beever_atlas/stores/mongodb_store.py
+++ b/src/beever_atlas/stores/mongodb_store.py
@@ -702,9 +702,17 @@ class MongoDBStore:
         ``batch_results`` array then pollutes the frontend's chip strip
         with stale DONE batches before any new work has been done.
 
-        Falls back to the most-recent row (any status) when no running
-        sync exists so legacy callers reading historical state — e.g.
-        cooldown checks in ``capabilities.sync`` — keep working.
+        Falls back to the most-recent ``kind="sync"`` row (any status) when
+        no running sync exists so legacy callers reading historical state —
+        e.g. cooldown checks in ``capabilities.sync`` — keep working.
+
+        The synthetic ``worker_extraction`` rows (``worker:<channel>:<ts>``)
+        are deliberately excluded from BOTH queries: the ExtractionWorker
+        writes per-batch progress to them but never finalizes them to
+        ``completed`` (they're internal telemetry — "a row nobody reads").
+        Including them here meant a stuck ``running`` worker row was returned
+        as the active job, so ``/sync/status`` reported a perpetual sync and
+        the sidebar "Syncing now…" dot never cleared.
         """
         running = await self._sync_jobs.find_one(
             {"channel_id": channel_id, "kind": "sync", "status": "running"},
@@ -714,7 +722,7 @@ class MongoDBStore:
             running.pop("_id", None)
             return SyncJob(**running)
         latest = await self._sync_jobs.find_one(
-            {"channel_id": channel_id},
+            {"channel_id": channel_id, "kind": "sync"},
             sort=[("started_at", -1)],
         )
         if latest is None:

--- a/tests/services/test_stale_batch_results_leak.py
+++ b/tests/services/test_stale_batch_results_leak.py
@@ -205,6 +205,57 @@ async def test_get_sync_status_returns_none_when_no_rows() -> None:
     assert await store.get_sync_status("C_EMPTY") is None
 
 
+async def test_get_sync_status_fallback_ignores_worker_extraction() -> None:
+    """The fallback must skip synthetic ``worker_extraction`` rows.
+
+    The ExtractionWorker never finalizes its ``worker:<channel>:<ts>`` row to
+    ``completed``; a stuck ``running`` one is newer than the real sync job. If
+    the fallback returned it, ``/sync/status`` would report a perpetual sync
+    and the sidebar "Syncing now…" dot would never clear.
+    """
+    channel = "C_WORKER"
+    now = datetime.now(tz=UTC)
+    real_sync = _make_sync_job_doc(
+        job_id="sync-done",
+        channel_id=channel,
+        status="completed",
+        started_at=now - timedelta(minutes=5),
+        kind="sync",
+    )
+    stuck_worker = _make_sync_job_doc(
+        job_id="worker:C_WORKER:123",
+        channel_id=channel,
+        status="running",  # never finalized
+        started_at=now,  # newer than the real sync
+        kind="worker_extraction",
+    )
+    store, _ = _store_with_jobs([real_sync, stuck_worker])
+
+    result = await store.get_sync_status(channel)
+
+    assert result is not None
+    assert result.id == "sync-done"  # the real sync, not the stuck worker row
+    assert result.status == "completed"
+
+
+async def test_get_sync_status_none_when_only_worker_extraction() -> None:
+    """A lone stuck ``worker_extraction`` row must read as idle (None), not
+    as an active sync."""
+    channel = "C_ONLY_WORKER"
+    store, _ = _store_with_jobs(
+        [
+            _make_sync_job_doc(
+                job_id="worker:C_ONLY_WORKER:999",
+                channel_id=channel,
+                status="running",
+                started_at=datetime.now(tz=UTC),
+                kind="worker_extraction",
+            )
+        ]
+    )
+    assert await store.get_sync_status(channel) is None
+
+
 # ── Layer B tests ───────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Problem
After extraction, the sidebar **"Syncing now…" dot never clears** for a channel (seen on every Discord channel post-sync).

`get_sync_status` prefers a running `kind="sync"` row, but its **fallback returned the most-recent row of *any* kind**. The ExtractionWorker writes per-batch progress to a synthetic `worker:<channel>:<ts>` row (`kind=worker_extraction`) that it **never finalizes to `completed`** — by design, "a row nobody reads". When that stuck `running` row was newest, the fallback returned it as the active job → `/sync/status` reported a perpetual sync → the dot stuck on.

## Fix
Scope the fallback to `kind="sync"`, matching **every other** user-facing sync query in the store (lines 440/599/648/662/710). Synthetic worker rows are now ignored; the indicator follows the real sync job's lifecycle.

## Tests
- `test_get_sync_status_fallback_ignores_worker_extraction` — newer stuck worker row is skipped; the completed sync row is returned
- `test_get_sync_status_none_when_only_worker_extraction` — a lone stuck worker row reads as idle
- Existing `get_sync_status` / `create_sync_job` tests still pass (8 total)

Local: `pytest` ✅ · `ruff check`/`format` ✅ · `pyright` 0 errors.