### PR TITLE
fix(deploy): self-heal + memory-cap the API container; restart policies for all services

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -318,10 +318,22 @@ CROSS_BATCH_THREAD_CONTEXT_ENABLED=true
 THREAD_CONTEXT_MAX_LENGTH=200
 
 # --- 3.8 Ingestion concurrency & rate limits --------------
+# Low-memory hosts (<8 GiB, e.g. a t4g.medium running the full compose
+# stack): lower INGEST_BATCH_CONCURRENCY and IMAGE_EXTRACTOR_CONCURRENCY
+# to 2. Extraction memory scales with concurrent LLM batches × concurrent
+# image OCR; at 4×4 the API process can exceed its container memory cap
+# (ATLAS_API_MEM_LIMIT below) during multi-channel syncs.
 INGEST_BATCH_CONCURRENCY=4
 CONTRADICTION_CONCURRENCY=4
 IMAGE_EXTRACTOR_CONCURRENCY=4
 GEMINI_RPM=300
+# Container memory cap for the API service (docker-compose.yml). The cap
+# keeps a runaway extraction from destabilising the host — worst case the
+# API container restarts instead of the host OOM-ing. Raise on hosts with
+# plenty of RAM if extraction keeps hitting the limit (watch for exit 137
+# in `docker ps`); memswap should stay ≥ mem so spikes can spill to swap.
+ATLAS_API_MEM_LIMIT=2048m
+ATLAS_API_MEMSWAP_LIMIT=3072m
 # When true, persister batches Neo4j name_vector writes via one UNWIND
 # Cypher per batch instead of N serial round-trips. Saves ~300ms/batch.
 # Falls back to per-entity loop on Cypher error.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,21 @@
 services:
   beever-atlas:
     build: .
+    # The ExtractionWorker runs in-process with the API (uvicorn). During
+    # multi-channel syncs its memory footprint scales with concurrent LLM
+    # batches + image OCR + embeddings, and on a small host (e.g. 4 GiB
+    # demo box) it can exhaust system RAM: first the kernel OOM-kills
+    # uvicorn (and with no restart policy the site stays down), and if the
+    # backlog resumes on a host without swap, total memory exhaustion can
+    # freeze the host OS outright. Same protection pattern as the bot's
+    # RES-286 block below: `mem_limit` caps the API in cgroup-land so the
+    # host and datastores are never at risk; `restart` self-heals after
+    # any exit. Limits are overridable per deployment via .env — see
+    # "3.8 Ingestion concurrency & rate limits" in .env.example for
+    # low-memory tuning.
+    restart: unless-stopped
+    mem_limit: ${ATLAS_API_MEM_LIMIT:-2048m}
+    memswap_limit: ${ATLAS_API_MEMSWAP_LIMIT:-3072m}
     ports: ["8000:8000"]
     depends_on:
       weaviate:
@@ -41,11 +56,17 @@ services:
     # 8080 (CIS Docker Benchmark — non-root). Host port 3000 unchanged so
     # existing dev URLs (http://localhost:3000/) keep working.
     ports: ["3000:8080"]
+    restart: unless-stopped
     depends_on:
       - beever-atlas
 
+  # Datastores + web get `restart: unless-stopped` so the whole stack
+  # comes back by itself after a host reboot or daemon restart — without
+  # it, only containers that happen to have a policy (previously just the
+  # bot) survive a reboot and everything else needs manual `docker start`.
   weaviate:
     image: cr.weaviate.io/semitechnologies/weaviate:1.28.0@sha256:58b576d36eace6a33f1a0866b9fd13fd58abfb9ce1eaaa419758c70b6a427e36
+    restart: unless-stopped
     ports: ["127.0.0.1:8080:8080", "127.0.0.1:50051:50051"]
     volumes: [weaviate_data:/var/lib/weaviate]
     environment:
@@ -64,6 +85,7 @@ services:
 
   neo4j:
     image: neo4j:5.26-community@sha256:f66304b9511c60d33555a2c451f88e03d82d1ebc893f32d84c98a6b326096435
+    restart: unless-stopped
     ports: ["127.0.0.1:7474:7474", "127.0.0.1:7687:7687"]
     environment:
       NEO4J_AUTH: neo4j/${NEO4J_PASSWORD:?NEO4J_PASSWORD must be set}
@@ -83,6 +105,7 @@ services:
   #   docker compose -f docker-compose.yml -f docker-compose.auth.yml up
   mongodb:
     image: mongo:7.0@sha256:43fddee7e532a920f3dfdee9e8f4834398c155c26bcb92d790cc1cd3c630fc40
+    restart: unless-stopped
     ports: ["127.0.0.1:27017:27017"]
     volumes: [mongo_data:/data/db]
     healthcheck:
@@ -93,6 +116,7 @@ services:
 
   redis:
     image: redis:7-alpine@sha256:7aec734b2bb298a1d769fd8729f13b8514a41bf90fcdd1f38ec52267fbaa8ee6
+    restart: unless-stopped
     ports: ["127.0.0.1:6380:6379"]
     # AOF persistence + volume mount so cached state (Teams adapter's
     # `chat-sdk:cache:teams:channelContext:*` entries, in particular) survives


### PR DESCRIPTION
## Why

A production deployment of the full compose stack on a 4 GiB host went down twice in 12 hours with the same root cause: the **ExtractionWorker runs in-process with the API**, and a multi-channel sync queued ~4,000 messages for LLM extraction. Memory use (concurrent LLM batches × image OCR × embeddings) exceeded available RAM:

1. **Outage 1** — the kernel OOM-killed uvicorn (exit 137). The API service had **no restart policy**, so the container stayed dead and the site served 502s for ~3 hours.
2. **Outage 2** — after a manual container restart, the extraction backlog auto-resumed on the same unprotected host. Memory exhausted completely and **the host OS froze** (cloud provider marked the instance impaired); recovery required an instance reboot.

The bot service already has exactly this protection (RES-286) — the API service was never given the same.

## What changed

**`docker-compose.yml`**
- `beever-atlas` (API): `restart: unless-stopped` + `mem_limit` / `memswap_limit` (default 2 GiB / 3 GiB, overridable via `ATLAS_API_MEM_LIMIT` / `ATLAS_API_MEMSWAP_LIMIT`). Worst case is now a ~35-second container self-restart instead of a host-level outage.
- `web`, `weaviate`, `neo4j`, `mongodb`, `redis`: `restart: unless-stopped` so the whole stack survives host reboots without manual `docker start` (previously only the bot came back).

**`.env.example`**
- Documents the new memory-cap overrides.
- Documents low-memory tuning (`INGEST_BATCH_CONCURRENCY` / `IMAGE_EXTRACTOR_CONCURRENCY` 4→2) for hosts under 8 GiB. Defaults unchanged.

## Verification

- `docker compose config` validates; env-var defaults resolve correctly (API = 2 GiB cap, bot unchanged at 768 MiB).
- The same values are running on the affected deployment now (applied manually during incident recovery): API at ~525 MiB / 2 GiB cap under extraction load, backlog drained with zero further incidents, host stable.

## Notes for reviewers

- `mem_limit`/`memswap_limit` follow the existing bot pattern in this same file (compose spec supports them with the docker engine; verified on Linux/arm64).
- Behaviour for well-resourced hosts is unchanged: same concurrency defaults, and the 2 GiB cap is well above the observed steady-state API footprint (~525 MiB) — it only bites when extraction would otherwise destabilize the host.
- Follow-up (out of scope here): moving the ExtractionWorker to its own container so extraction can never affect API availability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)