### PR TITLE
fix(deps): bump pyjwt to 2.13.0 to clear PYSEC-2026-175/177/178/179

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -3164,11 +3164,11 @@ wheels = [
 
 [[package]]
 name = "pyjwt"
-version = "2.12.1"
+version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Why

The required **pip-audit + npm audit (HIGH/CRITICAL gate)** check started failing on every PR (first observed on #219) after four new pyjwt advisories were published:

| Advisory | Affected | Fixed in |
|---|---|---|
| PYSEC-2026-175 | pyjwt 2.12.1 | 2.13.0 |
| PYSEC-2026-177 | pyjwt 2.12.1 | 2.13.0 |
| PYSEC-2026-178 | pyjwt 2.12.1 | 2.13.0 |
| PYSEC-2026-179 | pyjwt 2.12.1 | 2.13.0 |

These were published after the last green scheduled audit run on main (Jun 1), so main itself would fail the gate if re-run today — this is not specific to any open PR.

## What changed

Lockfile-only bump: `uv lock --upgrade-package pyjwt` → pyjwt 2.12.1 → 2.13.0 (3-line diff in `uv.lock`).

pyjwt is a transitive dependency via `mcp[crypto]`; nothing in the project pins it, and no other package versions change.

## Verification

- `uv lock --upgrade-package pyjwt` resolved cleanly (209 packages, single update).
- The audit job on this PR is the authoritative check — it runs the exact failing gate against the updated lock.

## After merge

Re-run the failed audit check on #219 (the audit job checks out the PR merge ref, so it picks up this fix from main without a rebase).

🤖 Generated with [Claude Code](https://claude.com/claude-code)