### PR TITLE
feat(adk): ADK 2.x follow-ups — Workflow graph pipeline + native tool-error callback

### DIFF
--- a/src/beever_atlas/agents/ingestion/pipeline.py
+++ b/src/beever_atlas/agents/ingestion/pipeline.py
@@ -1,10 +1,10 @@
-"""Wire all stages into the ingestion SequentialAgent."""
+"""Wire all stages into the ingestion Workflow graph."""
 
 from __future__ import annotations
 
 import logging
 
-from google.adk.agents import SequentialAgent, ParallelAgent
+from google.adk.workflow import JoinNode, Workflow
 
 from beever_atlas.agents.ingestion.preprocessor import PreprocessorAgent
 from beever_atlas.agents.ingestion.fact_extractor import create_fact_extractor
@@ -19,12 +19,24 @@ from beever_atlas.infra.config import get_settings
 logger = logging.getLogger(__name__)
 
 
-def create_ingestion_pipeline() -> SequentialAgent:
-    """Create the 6-stage ingestion pipeline.
+def create_ingestion_pipeline() -> Workflow:
+    """Create the ingestion pipeline as an ADK Workflow graph.
 
     The classifier stage has been removed — the fact quality gate callback
     now bridges extracted_facts to classified_facts directly.
     Embedder and cross-batch validator run in parallel (independent data flows).
+
+    The graph is::
+
+        preprocessor -> [fact, entity] -> join_extract
+            -> [embedder, validator] -> join_enrich -> persister
+
+    The ``JoinNode``s are correctness-critical: a node with N incoming edges
+    runs once PER predecessor unless a ``JoinNode`` collapses the fan-in to a
+    single downstream trigger. Without ``join_enrich`` the persister would run
+    twice (once per enrich-stage predecessor) and double-write to Weaviate/the
+    graph. ``join_extract`` likewise gates the enrich stage on both extractors.
+    The preprocessor fans out but does not fan in, so it needs no join.
 
     P0-3 (plan ``pipeline-cost-latency-reduction-v2.md``): the cross-batch
     validator is now a deterministic ``BaseAgent`` (name normalization +
@@ -45,18 +57,28 @@ def create_ingestion_pipeline() -> SequentialAgent:
         )
     validator = DeterministicCrossBatchValidator(name="cross_batch_validator_agent")
 
-    return SequentialAgent(
+    preprocessor = PreprocessorAgent(name="preprocessor")
+    fact = create_fact_extractor()
+    entity = create_entity_extractor()
+    embedder = EmbedderAgent(name="embedder")
+    persister = PersisterAgent(name="persister")
+    # JoinNodes collapse each parallel stage to a single downstream trigger so
+    # the fan-in target (enrich stage, then persister) runs exactly once.
+    join_extract = JoinNode(name="join_extract")
+    join_enrich = JoinNode(name="join_enrich")
+
+    return Workflow(
         name="ingestion_pipeline",
-        sub_agents=[
-            PreprocessorAgent(name="preprocessor"),
-            ParallelAgent(
-                name="extraction_parallel",
-                sub_agents=[create_fact_extractor(), create_entity_extractor()],
-            ),
-            ParallelAgent(
-                name="enrich_parallel",
-                sub_agents=[EmbedderAgent(name="embedder"), validator],
-            ),
-            PersisterAgent(name="persister"),
+        edges=[
+            ("START", preprocessor),
+            (preprocessor, fact),
+            (preprocessor, entity),
+            (fact, join_extract),
+            (entity, join_extract),
+            (join_extract, embedder),
+            (join_extract, validator),
+            (embedder, join_enrich),
+            (validator, join_enrich),
+            (join_enrich, persister),
         ],
     )

--- a/src/beever_atlas/agents/query/qa_agent.py
+++ b/src/beever_atlas/agents/query/qa_agent.py
@@ -12,6 +12,7 @@ from beever_atlas.agents.query.prompts import (
     QA_QUICK_SUFFIX,
     QA_SUMMARIZE_SUFFIX,
 )
+from beever_atlas.agents.resilient_tool_resolver import make_tool_error_callback
 from beever_atlas.agents.tools import QA_TOOLS
 from beever_atlas.agents.tools.orchestration_tools import ORCHESTRATION_TOOLS
 from beever_atlas.infra.config import ConfigurationError
@@ -71,6 +72,29 @@ def _tool_name(tool) -> str:
         or getattr(tool, "name", None)
         or getattr(getattr(tool, "func", None), "__name__", "")
     )
+
+
+def _canonical_tool_names(tools_list: list) -> list[str]:
+    """Collect the names ADK registers in ``tools_dict`` for the given
+    tools (it keys on ``tool.name``).
+
+    ``BaseToolset`` instances (e.g. ``SkillToolset``) resolve their tools
+    asynchronously at runtime, so they cannot be expanded here — they are
+    skipped. The resulting list still covers every directly-registered
+    function tool, which is what the LLM hallucinates against in practice;
+    a missing toolset name only weakens the ``did_you_mean`` suggestion,
+    never the safety of the soft-error itself.
+    """
+    from google.adk.tools.base_toolset import BaseToolset
+
+    names: list[str] = []
+    for t in tools_list:
+        if isinstance(t, BaseToolset):
+            continue
+        name = _tool_name(t)
+        if name:
+            names.append(name)
+    return names
 
 
 def _maybe_wrap_with_skills(tools_list: list) -> list:
@@ -263,6 +287,7 @@ def create_qa_agent(
             model=model,
             instruction=prompt,
             tools=agent_tools,
+            on_tool_error_callback=make_tool_error_callback(_canonical_tool_names(agent_tools)),
         )
     elif mode == "summarize":
         # Summarize: 4 tools, thinking, structured output
@@ -282,6 +307,7 @@ def create_qa_agent(
             instruction=prompt,
             tools=agent_tools,
             planner=planner,
+            on_tool_error_callback=make_tool_error_callback(_canonical_tool_names(agent_tools)),
         )
     else:
         # Deep (default): all tools, thinking, full pipeline.
@@ -304,6 +330,7 @@ def create_qa_agent(
             instruction=prompt,
             tools=agent_tools,
             planner=planner,
+            on_tool_error_callback=make_tool_error_callback(_canonical_tool_names(agent_tools)),
         )
 
     logger.info(

--- a/src/beever_atlas/agents/resilient_tool_resolver.py
+++ b/src/beever_atlas/agents/resilient_tool_resolver.py
@@ -16,26 +16,33 @@ the whole turn instead of giving the model a chance to retry.
 
 Fix
 ---
-Install a stub tool that ADK can dispatch through its normal flow. The
-stub's ``run_async`` returns a structured error containing the
-canonical tool list. ADK feeds that back to the LLM as a tool-result
-message; the LLM sees "your tool name was wrong, here are the real
-names" and tries again on the same turn.
+ADK 2.1.0 routes the unknown-tool ``ValueError`` through an agent-level
+``on_tool_error_callback``: it wraps ``_get_tool`` in ``try/except
+ValueError``, builds a placeholder ``BaseTool`` whose ``.name`` is the
+hallucinated name, and runs the registered error callbacks. If a
+callback returns a dict, ADK injects it as the ``function_response`` fed
+back to the LLM; if every callback returns ``None``, the original
+``ValueError`` is re-raised (the fail-fast contract is preserved).
 
-The default ADK behaviour stays opt-out — pass ``enabled=False`` (e.g.
-to investigate a genuine tool-registration bug) and the original
-fail-fast contract returns.
+:func:`make_tool_error_callback` builds such a callback. The returned
+dict carries the canonical tool list plus a ``did_you_mean`` suggestion;
+the LLM sees "your tool name was wrong, here are the real names" and
+retries on the same turn.
 
-Idempotent — re-installing in tests / hot reload is safe.
+This replaces the previous process-global monkey-patch of ADK's private
+``_get_tool``. The callback is per-agent, so every tool-dispatching
+``LlmAgent`` must attach it explicitly (see
+``beever_atlas.agents.query.qa_agent``).
 """
 
 from __future__ import annotations
 
 import difflib
 import logging
-from typing import Any
+from typing import Any, Callable
 
 from google.adk.tools.base_tool import BaseTool
+from google.adk.tools.tool_context import ToolContext
 
 logger = logging.getLogger(__name__)
 
@@ -98,103 +105,92 @@ def _closest_tool_match(requested: str, available: list[str]) -> str | None:
     return None
 
 
-class _UnknownToolStub(BaseTool):
-    """Echoes back a tool-error response when the LLM names a tool that
-    doesn't exist. Visible to the LLM as a normal tool-result, so it can
-    try again with one of the listed valid names on the same turn."""
+def build_unknown_tool_payload(requested_name: str, available_names: list[str]) -> dict[str, Any]:
+    """Build the structured tool-result the LLM gets back when it names a
+    tool that doesn't exist.
 
-    def __init__(self, requested_name: str, available_names: list[str]) -> None:
-        super().__init__(
-            name=requested_name,
-            description=(
-                f"Stub for the hallucinated tool name {requested_name!r}. "
-                "Returns a structured error so the LLM can retry with a valid "
-                "tool name."
-            ),
-        )
-        self._requested = requested_name
-        self._available = available_names
-
-    async def run_async(self, *, args: dict[str, Any], tool_context: Any) -> Any:  # noqa: ARG002
-        suggestion = _closest_tool_match(self._requested, self._available)
-        logger.warning(
-            "resilient_tool_resolver: model called unknown tool %r — "
-            "returning soft error (did_you_mean=%r). Available: %s",
-            self._requested,
-            suggestion,
-            ", ".join(self._available),
-        )
-        # Smaller open-source models (Gemma 2B/4B, Llama 3.2 3B, …) often
-        # drop or add a name suffix when the agent registers 15+ tools.
-        # Including an explicit ``did_you_mean`` field lets weak models
-        # recover in one extra turn instead of giving up.
-        payload: dict[str, Any] = {
-            "error": "tool_not_found",
-            "requested_tool": self._requested,
-            "available_tools": self._available,
-        }
-        if suggestion is not None:
-            payload["did_you_mean"] = suggestion
-            payload["hint"] = (
-                f"The tool {self._requested!r} does not exist. The closest "
-                f"available match is {suggestion!r} — retry the call with "
-                "EXACTLY that name."
-            )
-        else:
-            payload["hint"] = (
-                f"The tool {self._requested!r} does not exist. Pick exactly "
-                "one name from available_tools and retry. Tool names are "
-                "case-sensitive."
-            )
-        return payload
-
-
-def install_resilient_tool_resolver() -> None:
-    """Monkey-patch ADK's ``_get_tool`` to return a stub on unknown names.
-
-    Called once at server boot. Safe to call again — the patch tags the
-    function with a marker attribute so re-installation is a no-op.
-
-    Defensive: ``_get_tool`` is a private ADK symbol that could be
-    renamed or moved by a future ADK release. When it's missing, log a
-    clear warning and return — the operator will see the warning at
-    boot and can pin a known-good ADK version. The agent stream still
-    runs unpatched; behaviour reverts to ADK's hard ``ValueError`` on
-    unknown tool names (the original ADK contract).
+    The payload is JSON-serialisable and ADK injects it verbatim as the
+    ``function_response``. Smaller open-source models (Gemma 2B/4B, Llama
+    3.2 3B, …) often drop or add a name suffix when the agent registers
+    15+ tools, so an explicit ``did_you_mean`` field lets weak models
+    recover in one extra turn instead of giving up.
     """
-    from google.adk.flows.llm_flows import functions as adk_functions
-
-    if not hasattr(adk_functions, "_get_tool"):
-        logger.warning(
-            "resilient_tool_resolver: ADK's flows.llm_flows.functions._get_tool "
-            "is missing — likely an ADK version upgrade renamed it. Falling back "
-            "to the unpatched contract (hard ValueError on hallucinated tool "
-            "names). Pin the working ADK range in pyproject.toml or update this "
-            "patch."
-        )
-        return
-
-    if getattr(adk_functions._get_tool, "_beever_resilient", False):
-        return
-
-    def _resilient_get_tool(function_call: Any, tools_dict: dict[str, BaseTool]) -> BaseTool:
-        name = getattr(function_call, "name", None)
-        if name in tools_dict:
-            return tools_dict[name]
-        # Don't raise — return a stub that emits a tool-result back to the
-        # model with the canonical tool list, letting it recover on the
-        # same turn instead of killing the stream.
-        return _UnknownToolStub(
-            requested_name=str(name) if name is not None else "<unknown>",
-            available_names=sorted(tools_dict.keys()),
-        )
-
-    _resilient_get_tool._beever_resilient = True  # type: ignore[attr-defined]
-    adk_functions._get_tool = _resilient_get_tool
-    logger.info(
-        "resilient_tool_resolver: installed — unknown tool names now return "
-        "a soft error instead of crashing the agent stream"
+    suggestion = _closest_tool_match(requested_name, available_names)
+    logger.warning(
+        "resilient_tool_resolver: model called unknown tool %r — "
+        "returning soft error (did_you_mean=%r). Available: %s",
+        requested_name,
+        suggestion,
+        ", ".join(available_names),
     )
+    payload: dict[str, Any] = {
+        "error": "tool_not_found",
+        "requested_tool": requested_name,
+        "available_tools": available_names,
+    }
+    if suggestion is not None:
+        payload["did_you_mean"] = suggestion
+        payload["hint"] = (
+            f"The tool {requested_name!r} does not exist. The closest "
+            f"available match is {suggestion!r} — retry the call with "
+            "EXACTLY that name."
+        )
+    else:
+        payload["hint"] = (
+            f"The tool {requested_name!r} does not exist. Pick exactly "
+            "one name from available_tools and retry. Tool names are "
+            "case-sensitive."
+        )
+    return payload
 
 
-__all__ = ["install_resilient_tool_resolver", "_UnknownToolStub"]
+def make_tool_error_callback(
+    available_tool_names: list[str] | Callable[[], list[str]],
+) -> Callable[[BaseTool, dict, ToolContext, Exception], dict | None]:
+    """Build an agent-level ``on_tool_error_callback`` that turns ADK's
+    unknown-tool ``ValueError`` into a structured tool-result the LLM can
+    recover from on the same turn.
+
+    Args:
+        available_tool_names: the canonical tool names the agent exposes,
+            either as a static list bound at construction or a callable
+            returning the list lazily (e.g. when a SkillToolset resolves
+            its tools at runtime). Names must match what ADK registers in
+            ``tools_dict`` (which keys on ``tool.name``) for the
+            ``did_you_mean`` suggestions to land.
+
+    Returns:
+        A callback with ADK's positional agent-level signature
+        ``(tool, args, tool_context, error)``. It handles ONLY the
+        unknown-tool case (``ValueError`` whose message contains "not
+        found") and returns ``None`` for every other error so ADK
+        re-raises it — the fail-fast contract is preserved for real tool
+        failures.
+    """
+
+    # NOTE: the 2nd parameter MUST be named ``args`` — ADK invokes the
+    # agent-level callback with ``args=`` as a keyword (the plugin-level
+    # callback uses ``tool_args`` instead). See functions.py:507-513.
+    def on_tool_error(
+        tool: BaseTool,
+        args: dict,  # noqa: ARG001 — required by ADK's keyword invocation
+        tool_context: ToolContext,  # noqa: ARG001
+        error: Exception,
+    ) -> dict | None:
+        # Only soften the hallucinated-tool case. Other errors (real tool
+        # failures) propagate untouched so genuine bugs stay loud.
+        if not (isinstance(error, ValueError) and "not found" in str(error)):
+            return None
+        # The placeholder BaseTool carries the hallucinated name as .name.
+        requested_name = tool.name
+        names = available_tool_names() if callable(available_tool_names) else available_tool_names
+        return build_unknown_tool_payload(requested_name, sorted(names))
+
+    return on_tool_error
+
+
+__all__ = [
+    "_closest_tool_match",
+    "build_unknown_tool_payload",
+    "make_tool_error_callback",
+]

--- a/src/beever_atlas/agents/runner.py
+++ b/src/beever_atlas/agents/runner.py
@@ -5,10 +5,12 @@ session-per-request pattern for use in API route handlers.
 """
 
 import uuid
+from typing import Any
 
 from google.adk.agents import BaseAgent
 from google.adk.runners import Runner
 from google.adk.sessions import InMemorySessionService, Session
+from google.adk.workflow import BaseNode
 
 # Module-level session service shared across the app
 _session_service = InMemorySessionService()
@@ -16,15 +18,41 @@ _session_service = InMemorySessionService()
 APP_NAME = "beever_atlas"
 
 
-def create_runner(agent: BaseAgent) -> Runner:
-    """Create an ADK Runner for the given root agent.
+def create_runner(agent: Any) -> Runner:
+    """Create an ADK Runner for the given root agent or workflow node.
 
     Args:
-        agent: The root ADK Agent (e.g., query_router_agent).
+        agent: The root ADK Agent (e.g., query_router_agent) for the
+            agent-tree path, or a ``Workflow``/``BaseNode`` for the
+            graph-based ingestion pipeline.
 
     Returns:
         A Runner instance configured with InMemorySessionService.
+
+    Note:
+        In ADK 2.x ``BaseAgent`` itself subclasses ``BaseNode``, so the
+        agent check must come first — otherwise every ``LlmAgent`` would be
+        routed through ``Runner(node=...)`` and silently change the QA
+        execution path. Only non-agent graph objects (``Workflow``,
+        ``JoinNode``) take the ``node=`` path.
+
+        ``Runner(node=...)`` defaults ``app_name`` to ``node.name``, which
+        would diverge from the ``APP_NAME`` used by ``create_session`` and
+        cause SessionNotFoundError. We pass ``app_name=APP_NAME`` explicitly
+        so both paths share one app namespace.
     """
+    if isinstance(agent, BaseAgent):
+        return Runner(
+            agent=agent,
+            app_name=APP_NAME,
+            session_service=_session_service,
+        )
+    if isinstance(agent, BaseNode):
+        return Runner(
+            node=agent,
+            app_name=APP_NAME,
+            session_service=_session_service,
+        )
     return Runner(
         agent=agent,
         app_name=APP_NAME,

--- a/src/beever_atlas/server/app.py
+++ b/src/beever_atlas/server/app.py
@@ -240,21 +240,6 @@ async def lifespan(app: FastAPI):
             "lifespan: register_litellm_observer failed (non-fatal)", exc_info=True
         )
 
-    # Soften ADK's hard-fail behaviour on hallucinated tool names so non-
-    # Gemini models reached via LiteLLM (GLM, Llama, …) can recover on the
-    # same turn instead of killing the stream. See module docstring.
-    try:
-        from beever_atlas.agents.resilient_tool_resolver import (
-            install_resilient_tool_resolver,
-        )
-
-        install_resilient_tool_resolver()
-    except Exception:  # noqa: BLE001
-        logging.getLogger(__name__).warning(
-            "lifespan: install_resilient_tool_resolver failed (non-fatal)",
-            exc_info=True,
-        )
-
     # PR-E: hydrate the DB-stored encrypted API key into the runtime so the
     # embedding shim can use it without round-tripping to MongoDB on every
     # call. Runs BEFORE the dim-guard probe so the probe uses the same key

--- a/src/beever_atlas/services/batch_pipeline.py
+++ b/src/beever_atlas/services/batch_pipeline.py
@@ -1,6 +1,6 @@
 """Batch pipeline orchestrator using Gemini Batch API for extraction stages.
 
-Replaces the ADK SequentialAgent pipeline for batch mode. Runs stages manually:
+Replaces the ADK Workflow ingestion pipeline for batch mode. Runs stages manually:
   1. Preprocess   — PreprocessorAgent in-process via ADK runner
   2. Batch Extract — fact + entity extraction via parallel Gemini Batch API jobs
   3. Quality Gates — filter facts/entities by configured thresholds
@@ -19,7 +19,7 @@ import logging
 import time
 from typing import Any
 
-from google.adk.agents import ParallelAgent, SequentialAgent
+from google.adk.workflow import Workflow
 
 from beever_atlas.agents.ingestion.cross_batch_validator import (
     create_cross_batch_validator,
@@ -191,8 +191,8 @@ async def _run_adk_agent(
 class BatchPipelineRunner:
     """Orchestrates ingestion using Gemini Batch API for extraction stages.
 
-    Runs the six ingestion stages manually, replacing the ADK SequentialAgent
-    for batch mode. Extraction (stages 2 & 3) is submitted as parallel Gemini
+    Runs the six ingestion stages manually, replacing the ADK Workflow ingestion
+    pipeline for batch mode. Extraction (stages 2 & 3) is submitted as parallel Gemini
     Batch API jobs. All other stages run in-process via ADK runners.
     """
 
@@ -272,9 +272,9 @@ class BatchPipelineRunner:
 
         t0 = time.monotonic()
         preprocess_state = await _run_adk_agent(
-            SequentialAgent(
+            Workflow(
                 name="batch_preprocessor",
-                sub_agents=[PreprocessorAgent(name="preprocessor")],
+                edges=[("START", PreprocessorAgent(name="preprocessor"))],
             ),
             state={
                 "messages": messages,
@@ -661,12 +661,19 @@ class BatchPipelineRunner:
         await _update_progress(stage4_label)
 
         t_enrich = time.monotonic()
+        # INVARIANT: this joinless fan-out is safe ONLY because both nodes are
+        # terminal AND state_delta-only (neither yields Event(output=...)).
+        # ADK's Workflow._finalize raises "multiple terminal nodes produced
+        # output" if more than one terminal node sets ctx.output. If either
+        # agent ever gains an output_schema / output Event, or a downstream
+        # node is added (which would run once per predecessor), insert a
+        # JoinNode — see create_ingestion_pipeline() for the pattern.
         enrich_state = await _run_adk_agent(
-            ParallelAgent(
+            Workflow(
                 name="batch_enrich",
-                sub_agents=[
-                    EmbedderAgent(name="embedder"),
-                    create_cross_batch_validator(),
+                edges=[
+                    ("START", EmbedderAgent(name="embedder")),
+                    ("START", create_cross_batch_validator()),
                 ],
             ),
             state={
@@ -748,9 +755,9 @@ class BatchPipelineRunner:
 
         t_persist = time.monotonic()
         persist_state = await _run_adk_agent(
-            SequentialAgent(
+            Workflow(
                 name="batch_persister",
-                sub_agents=[PersisterAgent(name="persister")],
+                edges=[("START", PersisterAgent(name="persister"))],
             ),
             state={
                 "embedded_facts": embedded_facts,

--- a/src/beever_atlas/services/batch_processor.py
+++ b/src/beever_atlas/services/batch_processor.py
@@ -1,7 +1,7 @@
 """Batch processor — chunks messages and drives them through the ingestion pipeline.
 
 Splits a list of NormalizedMessage objects into fixed-size batches, runs each
-batch through the ADK ``ingestion_pipeline`` SequentialAgent, and accumulates
+batch through the ADK ``ingestion_pipeline`` Workflow, and accumulates
 per-batch results into a final ``BatchResult``.
 """
 
@@ -819,11 +819,11 @@ class BatchProcessor:
                                 # preprocessor/persister are local-only, no quota needed.
                                 #
                                 # memory-then-wiki-pipeline-realignment G6 audit:
-                                # ADK's ``ParallelAgent`` (``extraction_parallel`` wrapping
-                                # fact_extractor + entity_extractor, ``enrich_parallel``
-                                # wrapping embedder + validator) does NOT emit a single
-                                # event under its own name — each sub-agent emits its own
-                                # event with ``author = sub_agent.name``. The dispatch
+                                # The ADK Workflow's parallel fan-out (fact_extractor +
+                                # entity_extractor after the preprocessor; embedder +
+                                # validator after join_extract) does NOT emit a single
+                                # event under a container name — each sub-agent node emits
+                                # its own event with ``author = sub_agent.name``. The dispatch
                                 # below therefore acquires ONE token per concurrent Gemini
                                 # call. No double-counting fix needed; the previous design
                                 # hypothesis about under-counting was incorrect.

--- a/tests/agents/ingestion/test_pipeline_workflow.py
+++ b/tests/agents/ingestion/test_pipeline_workflow.py
@@ -1,0 +1,203 @@
+"""Regression tests for the ADK Workflow ingestion pipeline.
+
+``create_ingestion_pipeline`` now returns a ``google.adk.workflow.Workflow``
+instead of a deprecated ``SequentialAgent``. The graph fans out to two
+extractors, then to embedder + validator, with ``JoinNode``s gating each
+fan-in so the downstream stage (ultimately the persister) runs EXACTLY ONCE.
+
+A plain fan-in target runs once per predecessor trigger, so without the
+``join_enrich`` node the persister would run twice and double-write to
+Weaviate/the graph. These tests lock in:
+
+  1. the persister-equivalent stage runs exactly once (the JoinNode guard),
+  2. state written by the preprocessor is visible to downstream stages,
+  3. the pipeline completes without error.
+
+The LLM-dependent extractors are monkeypatched to lightweight fake
+``BaseAgent``s that only write marker keys to ``session.state``, so no LLM
+provider call is required.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from typing import Any
+
+import pytest
+
+from google.adk.agents import BaseAgent
+from google.adk.agents.invocation_context import InvocationContext
+from google.adk.events import Event, EventActions
+from google.adk.workflow import Workflow
+
+
+# ── helpers ─────────────────────────────────────────────────────────────────
+
+
+class _MarkerAgent(BaseAgent):
+    """A fake BaseAgent that writes a single marker key via state_delta."""
+
+    out_key: str
+    out_val: Any
+
+    async def _run_async_impl(self, ctx: InvocationContext) -> AsyncGenerator[Event, None]:
+        yield Event(
+            author=self.name,
+            invocation_id=ctx.invocation_id,
+            actions=EventActions(state_delta={self.out_key: self.out_val}),
+        )
+
+
+class _CountingPersister(BaseAgent):
+    """A fake persister that counts its own invocations and records whether
+    the preprocessor's marker was visible in shared ``session.state``.
+    """
+
+    calls: list[int]
+
+    async def _run_async_impl(self, ctx: InvocationContext) -> AsyncGenerator[Event, None]:
+        self.calls.append(1)
+        saw_preprocessed = ctx.session.state.get("marker_preprocessed")
+        yield Event(
+            author=self.name,
+            invocation_id=ctx.invocation_id,
+            actions=EventActions(
+                state_delta={
+                    "persist_result": {
+                        "saw_preprocessed": saw_preprocessed,
+                        "run_count": len(self.calls),
+                    }
+                }
+            ),
+        )
+
+
+def _patch_pipeline_stages(monkeypatch, persister: _CountingPersister) -> None:
+    """Replace every pipeline stage factory with a lightweight fake so the
+    real graph topology (edges + JoinNodes) is exercised end-to-end without
+    touching the LLM provider or the stores.
+    """
+    import beever_atlas.agents.ingestion.pipeline as pipeline_mod
+
+    monkeypatch.setattr(
+        pipeline_mod,
+        "PreprocessorAgent",
+        lambda name: _MarkerAgent(name=name, out_key="marker_preprocessed", out_val="PP"),
+    )
+    monkeypatch.setattr(
+        pipeline_mod,
+        "create_fact_extractor",
+        lambda: _MarkerAgent(name="fact_extractor", out_key="marker_facts", out_val="F"),
+    )
+    monkeypatch.setattr(
+        pipeline_mod,
+        "create_entity_extractor",
+        lambda: _MarkerAgent(name="entity_extractor", out_key="marker_entities", out_val="E"),
+    )
+    monkeypatch.setattr(
+        pipeline_mod,
+        "EmbedderAgent",
+        lambda name: _MarkerAgent(name=name, out_key="marker_embedded", out_val="EM"),
+    )
+    monkeypatch.setattr(
+        pipeline_mod,
+        "DeterministicCrossBatchValidator",
+        lambda name: _MarkerAgent(name=name, out_key="marker_validated", out_val="V"),
+    )
+    monkeypatch.setattr(pipeline_mod, "PersisterAgent", lambda name: persister)
+
+
+async def _run_pipeline(workflow: Workflow) -> dict[str, Any]:
+    """Drive the workflow to completion via a fresh Runner + InMemory session
+    and return the final session state. ``app_name`` must match the Runner's
+    resolved app name (Runner(node=...) defaults it to ``node.name``), so we
+    pass it explicitly to both.
+    """
+    from google.adk.runners import Runner
+    from google.adk.sessions import InMemorySessionService
+    from google.genai import types
+
+    app_name = "beever_atlas"
+    svc = InMemorySessionService()
+    runner = Runner(node=workflow, app_name=app_name, session_service=svc)
+    session = await svc.create_session(
+        app_name=app_name, user_id="system", session_id="s-test", state={}
+    )
+
+    async for _event in runner.run_async(
+        user_id="system",
+        session_id=session.id,
+        new_message=types.Content(role="user", parts=[types.Part(text="process")]),
+    ):
+        pass  # Drive to completion
+
+    final = await svc.get_session(app_name=app_name, user_id="system", session_id=session.id)
+    return dict(final.state) if final else {}
+
+
+# ── tests ────────────────────────────────────────────────────────────────────
+
+
+def test_create_ingestion_pipeline_returns_workflow(monkeypatch):
+    """The composition layer now returns a Workflow graph, not a
+    SequentialAgent."""
+    persister = _CountingPersister(name="persister", calls=[])
+    _patch_pipeline_stages(monkeypatch, persister)
+
+    from beever_atlas.agents.ingestion.pipeline import create_ingestion_pipeline
+
+    workflow = create_ingestion_pipeline()
+    assert isinstance(workflow, Workflow)
+    assert workflow.name == "ingestion_pipeline"
+
+
+@pytest.mark.asyncio
+async def test_persister_runs_exactly_once(monkeypatch):
+    """JoinNode regression guard: the persister must run EXACTLY ONCE despite
+    two incoming enrich-stage predecessors. Without ``join_enrich`` it would
+    run twice and double-write to Weaviate/the graph.
+    """
+    persister = _CountingPersister(name="persister", calls=[])
+    _patch_pipeline_stages(monkeypatch, persister)
+
+    from beever_atlas.agents.ingestion.pipeline import create_ingestion_pipeline
+
+    state = await _run_pipeline(create_ingestion_pipeline())
+
+    assert len(persister.calls) == 1, (
+        f"persister must run exactly once (JoinNode guard); ran {len(persister.calls)} times"
+    )
+    assert state["persist_result"]["run_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_preprocessor_state_visible_downstream(monkeypatch):
+    """State written by the preprocessor stage propagates through the graph
+    and is visible to the downstream persister stage."""
+    persister = _CountingPersister(name="persister", calls=[])
+    _patch_pipeline_stages(monkeypatch, persister)
+
+    from beever_atlas.agents.ingestion.pipeline import create_ingestion_pipeline
+
+    state = await _run_pipeline(create_ingestion_pipeline())
+
+    assert state["persist_result"]["saw_preprocessed"] == "PP"
+
+
+@pytest.mark.asyncio
+async def test_all_stages_complete_without_error(monkeypatch):
+    """Every stage writes its marker, confirming the full graph executed to
+    completion."""
+    persister = _CountingPersister(name="persister", calls=[])
+    _patch_pipeline_stages(monkeypatch, persister)
+
+    from beever_atlas.agents.ingestion.pipeline import create_ingestion_pipeline
+
+    state = await _run_pipeline(create_ingestion_pipeline())
+
+    assert state["marker_preprocessed"] == "PP"
+    assert state["marker_facts"] == "F"
+    assert state["marker_entities"] == "E"
+    assert state["marker_embedded"] == "EM"
+    assert state["marker_validated"] == "V"
+    assert state["persist_result"]["run_count"] == 1

--- a/tests/agents/test_resilient_tool_resolver.py
+++ b/tests/agents/test_resilient_tool_resolver.py
@@ -3,145 +3,204 @@
 Validates that hallucinated tool names are intercepted and turned into a
 structured tool-result the LLM can recover from — instead of letting
 ADK's default ``ValueError`` crash the agent stream.
+
+ADK 2.1.0 routes the unknown-tool ``ValueError`` through an agent-level
+``on_tool_error_callback``. These tests cover the callback in isolation
+plus an integration-style test that drives ADK's real flow function
+``_execute_single_function_call_async`` with a ``FunctionCall`` for a
+nonexistent tool.
 """
 
 from __future__ import annotations
 
-from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
+from google.adk.agents import LlmAgent
+from google.adk.agents.invocation_context import InvocationContext
 from google.adk.flows.llm_flows import functions as adk_functions
+from google.adk.sessions import InMemorySessionService
+from google.adk.tools.base_tool import BaseTool
+from google.genai import types
 
 from beever_atlas.agents.resilient_tool_resolver import (
-    _UnknownToolStub,
-    install_resilient_tool_resolver,
+    _closest_tool_match,
+    build_unknown_tool_payload,
+    make_tool_error_callback,
 )
 
 
-@pytest.fixture(autouse=True)
-def _restore_original_get_tool():
-    """Each test starts with the un-patched ``_get_tool``; restore after."""
-    original = adk_functions._get_tool
-    yield
-    adk_functions._get_tool = original
+def _placeholder_tool(name: str) -> BaseTool:
+    """Mirror ADK's placeholder: ``BaseTool(name=..., description='Tool not found')``."""
+    return BaseTool(name=name, description="Tool not found")
 
 
-def _fake_call(name: str) -> Any:
-    fc = MagicMock()
-    fc.name = name
-    return fc
+# ---------------------------------------------------------------------------
+# build_unknown_tool_payload — the shared payload builder
+# ---------------------------------------------------------------------------
 
 
-def _fake_tool(name: str) -> Any:
-    """A minimal stand-in for a BaseTool — same identity check as ADK uses."""
-    t = MagicMock()
-    t.name = name
-    return t
+def test_payload_no_close_match_falls_back_to_generic_hint():
+    """No close match → JSON-serialisable error dict with the case-sensitive hint."""
+    payload = build_unknown_tool_payload("people-profile", ["find_experts", "search_facts"])
+
+    assert payload["error"] == "tool_not_found"
+    assert payload["requested_tool"] == "people-profile"
+    assert payload["available_tools"] == ["find_experts", "search_facts"]
+    assert "case-sensitive" in payload["hint"].lower()
+    assert "did_you_mean" not in payload
 
 
-def test_install_replaces_get_tool_idempotently():
-    """Second install is a no-op — the marker attribute prevents double-wrap."""
-    install_resilient_tool_resolver()
-    first = adk_functions._get_tool
-    assert getattr(first, "_beever_resilient", False) is True
-
-    install_resilient_tool_resolver()
-    second = adk_functions._get_tool
-    assert second is first, "second install should be idempotent"
-
-
-def test_known_tool_returned_unchanged():
-    """When the LLM names a real tool, the resilient resolver returns it directly."""
-    install_resilient_tool_resolver()
-    tools = {"search_facts": _fake_tool("search_facts")}
-
-    result = adk_functions._get_tool(_fake_call("search_facts"), tools)
-
-    assert result is tools["search_facts"]
-
-
-def test_unknown_tool_returns_stub_with_available_names():
-    """Hallucinated tool name → ``_UnknownToolStub`` with sorted available names."""
-    install_resilient_tool_resolver()
-    tools = {
-        "search_facts": _fake_tool("search_facts"),
-        "find_experts": _fake_tool("find_experts"),
-    }
-
-    result = adk_functions._get_tool(_fake_call("people-profile"), tools)
-
-    assert isinstance(result, _UnknownToolStub)
-    assert result.name == "people-profile"
-    # Sorted so error output is deterministic / matchable in higher-level tests
-    assert result._available == ["find_experts", "search_facts"]
-
-
-@pytest.mark.asyncio
-async def test_stub_run_async_returns_structured_error():
-    """Stub returns a JSON-serialisable error dict the LLM can react to."""
-    stub = _UnknownToolStub("people-profile", ["find_experts", "search_facts"])
-
-    result = await stub.run_async(args={}, tool_context=MagicMock())
-
-    assert result["error"] == "tool_not_found"
-    assert result["requested_tool"] == "people-profile"
-    assert result["available_tools"] == ["find_experts", "search_facts"]
-    # No close match → falls back to the generic case-sensitive hint
-    assert "case-sensitive" in result["hint"].lower()
-    assert "did_you_mean" not in result
-
-
-@pytest.mark.asyncio
-async def test_stub_suggests_closest_when_suffix_dropped():
+def test_payload_suggests_closest_when_suffix_dropped():
     """User-reported case: gemma4:e2b called 'list_channels' instead of
-    the real 'list_channels_tool'. The stub should auto-suggest the suffix
-    so a weak model can recover in one retry."""
-    stub = _UnknownToolStub(
+    the real 'list_channels_tool'. The payload should auto-suggest the
+    suffix so a weak model can recover in one retry."""
+    payload = build_unknown_tool_payload(
         "list_channels",
         ["list_channels_tool", "list_skills", "search_qa_history"],
     )
 
-    result = await stub.run_async(args={}, tool_context=MagicMock())
-
-    assert result["did_you_mean"] == "list_channels_tool"
-    assert "list_channels_tool" in result["hint"]
+    assert payload["did_you_mean"] == "list_channels_tool"
+    assert "list_channels_tool" in payload["hint"]
 
 
-@pytest.mark.asyncio
-async def test_stub_suggests_closest_when_typo():
-    """Generic typo fallback via difflib — covers swap/missing-char drift
-    (``sercch_facts`` → ``search_facts``)."""
-    stub = _UnknownToolStub(
-        "sercch_facts",
-        ["search_facts", "search_qa_history", "load_skill"],
+# ---------------------------------------------------------------------------
+# _closest_tool_match — the suggestion logic
+# ---------------------------------------------------------------------------
+
+
+def test_closest_match_suffix_drop():
+    assert (
+        _closest_tool_match("list_channels", ["list_channels_tool", "search_qa_history"])
+        == "list_channels_tool"
     )
 
-    result = await stub.run_async(args={}, tool_context=MagicMock())
 
-    assert result["did_you_mean"] == "search_facts"
+def test_closest_match_typo_via_difflib():
+    """Generic typo fallback via difflib — swap/missing-char drift."""
+    assert (
+        _closest_tool_match("sercch_facts", ["search_facts", "search_qa_history", "load_skill"])
+        == "search_facts"
+    )
 
 
-@pytest.mark.asyncio
-async def test_stub_suggests_closest_when_dash_used():
+def test_closest_match_dash_vs_underscore():
     """Dash-vs-underscore drift — common with GLM-style models."""
-    stub = _UnknownToolStub(
-        "find-experts",
-        ["find_experts", "search_qa_history"],
+    assert (
+        _closest_tool_match("find-experts", ["find_experts", "search_qa_history"]) == "find_experts"
     )
 
-    result = await stub.run_async(args={}, tool_context=MagicMock())
 
+def test_closest_match_returns_none_when_unrelated():
+    assert _closest_tool_match("totally_made_up", ["find_experts", "search_facts"]) is None
+
+
+# ---------------------------------------------------------------------------
+# make_tool_error_callback — the agent-level callback
+# ---------------------------------------------------------------------------
+
+
+def test_callback_returns_payload_for_unknown_tool():
+    """A 'not found' ValueError on the placeholder tool yields the did_you_mean payload."""
+    callback = make_tool_error_callback(["find_experts", "search_facts"])
+    error = ValueError("Tool 'find-experts' not found.")
+
+    result = callback(
+        _placeholder_tool("find-experts"),
+        {},
+        MagicMock(),
+        error,
+    )
+
+    assert result["error"] == "tool_not_found"
+    assert result["requested_tool"] == "find-experts"
     assert result["did_you_mean"] == "find_experts"
 
 
-def test_unknown_tool_with_no_name_attribute_does_not_crash():
-    """Malformed FunctionCall (no ``name`` attr) shouldn't blow up the resolver."""
-    install_resilient_tool_resolver()
-    nameless = MagicMock(spec=[])  # no ``name`` attribute
-    tools = {"x": _fake_tool("x")}
+def test_callback_passes_through_non_not_found_errors():
+    """A real tool failure (not the unknown-tool ValueError) returns None so
+    ADK re-raises it — the fail-fast contract is preserved."""
+    callback = make_tool_error_callback(["search_facts"])
 
-    result = adk_functions._get_tool(nameless, tools)
+    assert (
+        callback(_placeholder_tool("search_facts"), {}, MagicMock(), RuntimeError("boom")) is None
+    )
+    # A ValueError without 'not found' is a genuine tool error, not a name miss.
+    assert (
+        callback(_placeholder_tool("search_facts"), {}, MagicMock(), ValueError("bad arg")) is None
+    )
 
-    assert isinstance(result, _UnknownToolStub)
-    assert result.name == "<unknown>"
+
+def test_callback_accepts_callable_name_source():
+    """``available_tool_names`` may be a callable resolved lazily at call time."""
+    names: list[str] = []
+    callback = make_tool_error_callback(lambda: names)
+    names.extend(["search_facts", "find_experts"])
+
+    result = callback(
+        _placeholder_tool("searc_facts"),
+        {},
+        MagicMock(),
+        ValueError("Tool 'searc_facts' not found."),
+    )
+
+    assert result["available_tools"] == ["find_experts", "search_facts"]
+    assert result["did_you_mean"] == "search_facts"
+
+
+# ---------------------------------------------------------------------------
+# Integration — drive ADK's real flow function end-to-end
+# ---------------------------------------------------------------------------
+
+
+async def _make_invocation_context(agent: LlmAgent) -> InvocationContext:
+    svc = InMemorySessionService()
+    session = await svc.create_session(app_name="test_app", user_id="u")
+    return InvocationContext(
+        session_service=svc,
+        invocation_id="iv-test",
+        agent=agent,
+        session=session,
+    )
+
+
+@pytest.mark.asyncio
+async def test_adk_flow_injects_payload_for_unknown_tool():
+    """End-to-end: ADK's ``_execute_single_function_call_async`` runs the
+    agent-level callback for a hallucinated tool name and injects the
+    did_you_mean payload as the function_response (no ValueError escapes)."""
+    agent = LlmAgent(
+        name="qa_probe_agent",
+        model="gemini-2.0-flash",
+        instruction="x",
+        on_tool_error_callback=make_tool_error_callback(
+            ["search_facts", "find_experts", "list_channels_tool"]
+        ),
+    )
+    ic = await _make_invocation_context(agent)
+    fc = types.FunctionCall(name="people-profile", args={})
+
+    event = await adk_functions._execute_single_function_call_async(ic, fc, {}, agent)
+
+    assert event is not None
+    function_response = event.content.parts[0].function_response
+    assert function_response.name == "people-profile"
+    assert function_response.response["error"] == "tool_not_found"
+    assert function_response.response["requested_tool"] == "people-profile"
+    assert function_response.response["available_tools"] == [
+        "find_experts",
+        "list_channels_tool",
+        "search_facts",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_adk_flow_without_callback_still_raises():
+    """Backward-compatible: a tool-bearing agent WITHOUT the callback keeps
+    ADK's hard-fail contract (the original ValueError propagates)."""
+    agent = LlmAgent(name="bare_agent", model="gemini-2.0-flash", instruction="x")
+    ic = await _make_invocation_context(agent)
+    fc = types.FunctionCall(name="people-profile", args={})
+
+    with pytest.raises(ValueError, match="not found"):
+        await adk_functions._execute_single_function_call_async(ic, fc, {}, agent)


### PR DESCRIPTION
## Summary

Implements the two viable follow-ups from #221 (stacked on top of it), and documents the two that were **evaluated and deliberately skipped** with probe-backed evidence.

> **Stack structure** (retargeted to `main` so full CI runs — `ci.yml`/`audit.yml`/`codeql.yml` only trigger on PRs targeting main)
> This PR currently includes #221's dep-bump commit in its diff. Recommended merge sequence:
> 1. Merge **#221** first (the clean dep bump, independently CI-green)
> 2. Rebase this branch onto the new `main` → diff shrinks to just the 2 follow-up commits
> 3. Merge **#222** when its CI re-passes
>
> Alternatively, #222 can be merged alone (it contains everything) and #221 closed as superseded.

## Commit 1 — `feat(agents)`: native `on_tool_error_callback` replaces the `_get_tool` monkey-patch

ADK 2.x adds a first-class `on_tool_error_callback` on `LlmAgent` that fires for exactly the unknown-tool `ValueError` the process-global monkey-patch intercepted (probe-verified against `flows/llm_flows/functions.py:533-548`).

- `resilient_tool_resolver.py`: monkey-patch machinery removed → `make_tool_error_callback()` factory + public `build_unknown_tool_payload()`; `_closest_tool_match` (did-you-mean) reused unchanged
- `qa_agent.py`: callback attached to all 3 tool-bearing LlmAgents, tool names bound at construction
- `server/app.py`: boot-time patch install removed
- Tests: rewritten as callback tests, including integration tests that drive **ADK's real function-call dispatch** with a hallucinated tool name, plus a test pinning the `'not found'` message contract so an ADK wording change fails loudly

## Commit 2 — `feat(ingestion)`: Workflow graph replaces deprecated `SequentialAgent`/`ParallelAgent`

The 4 custom `BaseAgent` stages keep `_run_async_impl` **unchanged** (ADK auto-bridges them into graph nodes); only the composition layer changes.

- `pipeline.py`: `create_ingestion_pipeline()` returns a `Workflow` with explicit edges; **JoinNodes gate both fan-ins** — without `join_enrich` the persister runs once *per predecessor* and double-writes to Weaviate/graph (probe-verified)
- `runner.py`: `BaseAgent → Runner(agent=)`, `Workflow/BaseNode → Runner(node=, app_name=)` — **the order matters**: in ADK 2.x `BaseAgent` subclasses `BaseNode`, so checking `BaseNode` first would silently reroute every QA LlmAgent
- `batch_pipeline.py`: 3 throwaway wrappers → Workflows, with a documented invariant on the joinless `batch_enrich` fan-out
- New regression test runs the **real** Workflow end-to-end and asserts the persister executes exactly once (mutation-verified: removing `join_enrich` makes it fail)

## Evaluated and skipped (with evidence)

| Follow-up | Verdict | Evidence |
|---|---|---|
| `_run_async_impl` → `_run_impl` swap | **Don't do** | Probe: a pure `_run_impl` agent raises `NotImplementedError` under the Runner path. ADK's `base_agent.py:288-305` already bridges legacy agents into graphs. |
| `RetryConfig` replacing `adk_recovery.py` / batch retry | **Don't do** | `RetryConfig` fires only on **raised exceptions**. `adk_recovery.py` handles **succeeded-but-truncated** JSON on the success path (free re-parse vs. paid LLM retry); `process_batch_with_retry` is domain-aware (reduce facts → split batch) which generic backoff can't replicate. |

## Verification

| Gate | Result |
|---|---|
| pytest (full suite) | ✅ 3,627 passed, 53 skipped, 1 xfailed (+1 known wall-clock flake, passes 3/3 in isolation — see #213 class) |
| pyright | ✅ 0 errors |
| ruff format + check | ✅ clean |
| New regression tests | ✅ persister-runs-once (mutation-verified), callback integration via real ADK dispatch |
| Multi-agent adversarial review | ✅ 4 dimensions (graph correctness, callback correctness, behavioral regression, test adequacy) — **zero confirmed defects**; all probe-verified |

Key probe-verified review evidence:
- Ingestion graph is **exactly equivalent** to the old composition (barriers preserved, every node runs once)
- `checkpoint_skip` / `quality_gates` / `adk_recovery` callbacks still fire as graph nodes (ADK routes node execution through `run_async`, which runs the callback chain)
- No event-author collisions in `batch_processor`'s consumer loop
- QA path routing unchanged (probe: LlmAgent → `Runner(agent=)`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
