### PR TITLE
feat(mcp): standalone stdio entrypoint for MCP registry introspection (Glama)

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,8 @@ See [docs/mcp-server.md](docs/mcp-server.md) for:
 - **Client configuration** — ready-to-use `.mcp.json` templates for Claude Code and Cursor
 - **Rate limits** — principal-keyed limits to prevent one agent from throttling others
 
+It also ships a **standalone stdio mode** (`python -m beever_atlas.api.mcp_server` / `beever-atlas-mcp`) that exposes the same tool catalog with no HTTP server or backing stores — handy for MCP registries (Glama.ai) and local introspection. See [docs/mcp-server.md](docs/mcp-server.md#standalone-introspection-mode-stdio).
+
 Quick example (Claude Code):
 ```json
 {

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -8,6 +8,24 @@ Beever Atlas exposes a Model Context Protocol (MCP) server at `/mcp` so external
 
 **Supported clients:** Claude Code (`.mcp.json` config), Cursor, or any MCP-compatible IDE assistant.
 
+## Standalone Introspection Mode (stdio)
+
+Running `python -m beever_atlas.api.mcp_server` (or the installed `beever-atlas-mcp` console script) serves the **same curated MCP surface over stdio** — no HTTP server, no `/mcp` mount, and no backing stores (MongoDB, Weaviate, Neo4j, Redis). The server starts instantly and answers protocol handshakes from a clean environment.
+
+**Who it's for:** MCP registries (Glama.ai), local launchers (`mcp-proxy`, Claude Desktop), and anyone who wants to inspect the tool catalog without deploying the full stack.
+
+**Key contract:** catalog introspection — `tools/list`, `prompts/list`, `resources/list`, and their `*/get` counterparts — needs **zero external dependencies** and works against a bare container. Tool *invocations* that read or write knowledge still require the backing stores; in this mode they return the same structured errors documented in the [Error Catalog](#error-catalog) rather than crashing.
+
+**Auth:** stdio is a local single-principal transport, so the HTTP `Authorization: Bearer` middleware does not apply (and there is no store data to protect). Production deployments should keep using the authenticated `/mcp` mount described below.
+
+```bash
+# From a built image (e.g. a registry sandbox)
+docker run -i --rm beever-atlas python -m beever_atlas.api.mcp_server
+
+# From a local checkout
+uv run beever-atlas-mcp
+```
+
 ## Enable the MCP Server
 
 ### 1. Set Environment Variables

--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": ["alan5543"],
+  "command": "python",
+  "args": ["-m", "beever_atlas.api.mcp_server"]
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,11 @@ test = [
     "tiktoken>=0.7",
 ]
 
+[project.scripts]
+# Standalone stdio MCP server (no HTTP, no backing stores) — used by MCP
+# registries (Glama) and local launchers; see api/mcp_server/__main__.py.
+beever-atlas-mcp = "beever_atlas.api.mcp_server.__main__:main"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/src/beever_atlas/api/mcp_server/__main__.py
+++ b/src/beever_atlas/api/mcp_server/__main__.py
@@ -1,0 +1,45 @@
+"""Standalone stdio entrypoint for the Beever Atlas MCP server.
+
+``python -m beever_atlas.api.mcp_server`` serves the curated MCP surface over
+stdio (JSON-RPC on stdin/stdout) with no HTTP server and no backing stores.
+
+Why this exists:
+
+- MCP registries (Glama.ai) and local launchers (Claude Desktop, ``mcp-proxy``)
+  introspect a server by spawning its process and driving the MCP handshake
+  (``initialize`` -> ``tools/list``). The production deployment serves MCP over
+  streamable-HTTP at ``/mcp`` behind Bearer auth (``server/app.py``), which an
+  anonymous registry sandbox can never reach — and the full server requires
+  MongoDB/Weaviate/Neo4j/Redis at startup besides.
+- ``build_mcp()`` registers tools lazily: no store is touched until a tool is
+  *invoked*. The catalog (tools, prompts, resources) is therefore fully
+  introspectable with zero external dependencies, which is exactly what
+  registry checks need.
+
+Tool calls that require backing stores return structured errors in this mode;
+point clients at a full deployment's ``/mcp`` mount for real data.
+
+Auth note: stdio is a local, single-principal transport — the process inherits
+the invoker's privileges and exposes no network surface, so the ASGI
+``MCPAuthMiddleware`` (HTTP-only by construction) is intentionally not
+involved. With no stores connected there is also no data to protect.
+"""
+
+from __future__ import annotations
+
+from beever_atlas.api.mcp_server import build_mcp
+
+
+def main() -> None:
+    """Run the MCP server on stdio.
+
+    ``show_banner=False`` keeps the process output strictly JSON-RPC; the
+    FastMCP banner targets stderr but registry sandboxes are conservative
+    about any non-protocol output.
+    """
+    mcp = build_mcp()
+    mcp.run(transport="stdio", show_banner=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/api/test_mcp_standalone.py
+++ b/tests/api/test_mcp_standalone.py
@@ -1,0 +1,66 @@
+"""Tests for the standalone stdio MCP entrypoint (Glama / registry introspection).
+
+Covers:
+- ``build_mcp()`` + in-memory client can complete the MCP handshake and answer
+  ``tools/list`` / ``prompts/list`` with NO backing stores and NO env config.
+  This is the contract MCP registries (Glama.ai) verify in their sandbox.
+- The ``__main__`` module exposes a ``main()`` callable wired to stdio
+  transport (checked by signature, not by running a blocking stdio loop).
+
+These tests intentionally use no mocks for stores: the whole point of the
+standalone mode is that tool *registration* must never touch MongoDB,
+Weaviate, Neo4j, or Redis.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastmcp import Client
+
+from beever_atlas.api.mcp_server import build_mcp
+
+
+# ---------------------------------------------------------------------------
+# Introspection with zero external dependencies
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_tools_list_requires_no_stores():
+    """tools/list must succeed with no DBs running and no env vars set."""
+    mcp = build_mcp()
+    async with Client(mcp) as client:
+        tools = await client.list_tools()
+
+    names = {tool.name for tool in tools}
+    # Spot-check tools from each registration group rather than pinning the
+    # full catalog (which grows over time).
+    assert "whoami" in names  # discovery
+    assert "ask_channel" in names  # retrieval
+    assert "find_experts" in names  # graph
+    assert "start_new_session" in names  # session
+    assert "trigger_sync" in names  # orchestration
+    assert len(names) >= 20
+
+
+@pytest.mark.asyncio
+async def test_prompts_list_requires_no_stores():
+    """prompts/list must succeed with no DBs running."""
+    mcp = build_mcp()
+    async with Client(mcp) as client:
+        prompts = await client.list_prompts()
+
+    names = {prompt.name for prompt in prompts}
+    assert names == {"summarize_channel", "investigate_decision", "onboard_new_channel"}
+
+
+# ---------------------------------------------------------------------------
+# Entrypoint wiring
+# ---------------------------------------------------------------------------
+
+
+def test_main_module_exposes_entrypoint():
+    """``python -m beever_atlas.api.mcp_server`` resolves to a main() callable."""
+    from beever_atlas.api.mcp_server import __main__ as entrypoint
+
+    assert callable(entrypoint.main)


### PR DESCRIPTION
## Why

[awesome-mcp-servers PR #7155](https://github.com/punkpeye/awesome-mcp-servers/pull/7155) (88K-star MCP directory) is gated on Beever Atlas being listed on [Glama.ai](https://glama.ai/mcp/servers) — the MCP registry that Cursor/Anthropic ecosystems reference. Glama verifies servers by **building the repo's Dockerfile and driving an MCP handshake (`initialize` → `tools/list`) in a sandbox with no databases, no env vars, and no network**.

Today the image can't pass:
- The production CMD boots the full FastAPI app, which requires MongoDB + Weaviate + Neo4j + Redis at startup → exits within ~30s in a bare sandbox
- The production `/mcp` mount is (correctly) Bearer-auth, deny-by-default → anonymous introspection gets 401

## What

A **standalone stdio MCP entrypoint** that serves the existing curated MCP surface (28 tools, 3 prompts) with no HTTP server and no backing stores:

| File | Change |
|---|---|
| `src/beever_atlas/api/mcp_server/__main__.py` | **New** — `python -m beever_atlas.api.mcp_server` → `build_mcp().run(transport="stdio")` |
| `glama.json` | **New** — registry claim (maintainers) + stdio launch command for Glama's sandbox |
| `tests/api/test_mcp_standalone.py` | **New** — CI contract: catalog introspection must never require stores |
| `pyproject.toml` | `beever-atlas-mcp` console script |
| `docs/mcp-server.md`, `README.md` | Standalone-mode documentation |

**Production is untouched**: Dockerfile CMD, the authenticated `/mcp` streamable-HTTP mount, and all store behavior are unchanged. Tool *invocations* in standalone mode return the documented structured errors; only the catalog is served store-free.

## Verification (all executed, not assumed)

- ✅ `docker build` clean; venv picks up the new entrypoint + console script
- ✅ **Real stdio handshake inside the container with zero env/DBs**: `initialize` → `tools/list` → **28 tools**, `prompts/list` → 3 prompts
- ✅ Raw JSON-RPC pipe test: stdout contains *only* JSON-RPC frames (no banner/log pollution; config warnings go to stderr)
- ✅ 3 new tests + 156 existing MCP tests green; ruff lint/format clean; `uv lock --check` passes
- ✅ Glama requirements audit: glama.json schema valid (fetched live schema), Apache-2.0 license, README, stdio command resolvable on image PATH

## After merge (Glama submission steps)

1. Submit `Beever-AI/beever-atlas` at https://glama.ai/mcp/servers and claim it (GitHub auth; maintainer is in `glama.json`)
2. In Glama's admin panel: point at the repo `Dockerfile`, launch command `python -m beever_atlas.api.mcp_server` → Deploy → Make Release
3. Add the score badge to awesome-mcp-servers PR #7155:
   `[![Beever-AI/beever-atlas MCP server](https://glama.ai/mcp/servers/Beever-AI/beever-atlas/badges/score.svg)](https://glama.ai/mcp/servers/Beever-AI/beever-atlas)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)