### PR TITLE
docs(mcp): polish all 28 tool descriptions to A-tier registry quality

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Six short clips — connect a workspace, sync history, watch memory build, brows
     <td width="33%" align="center" valign="top">
       <strong>MCP Server</strong><br><br>
       <img src="assets/clips/mcp.gif" alt="MCP server querying from Claude Code demo" width="100%"><br>
-      Plug Claude Code / Cursor into your knowledge base — 16 tools, per-agent auth.
+      Plug Claude Code / Cursor into your knowledge base — 28 tools, per-agent auth.
     </td>
   </tr>
 </table>
@@ -316,7 +316,7 @@ curl -X POST http://localhost:8000/api/channels/C12345/sync \
 Beever Atlas exposes a curated MCP (Model Context Protocol) server at `/mcp` for AI agents like Claude Code and Cursor. This allows external code assistants to query your team's knowledge base without using the dashboard.
 
 See [docs/mcp-server.md](docs/mcp-server.md) for:
-- **Tool catalog** — 16 tools for discovery, retrieval, graph traversal, and long-running operations
+- **Tool catalog** — 28 tools for discovery, retrieval, wiki reading, graph traversal, and long-running operations
 - **Auth setup** — generating and managing `BEEVER_MCP_API_KEYS`
 - **Client configuration** — ready-to-use `.mcp.json` templates for Claude Code and Cursor
 - **Rate limits** — principal-keyed limits to prevent one agent from throttling others

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -94,199 +94,297 @@ This principal id is used for:
 
 ## Tool Catalog
 
-Beever Atlas exposes 16 tools (15 in active use + 1 deprecation shim) grouped by domain. Each tool enforces channel-access policy and returns structured errors.
+Beever Atlas exposes **28 tools** (27 in active use + 1 deprecation shim) grouped by domain: Discovery (3), Retrieval (17), Graph (3), Session (1), and Orchestration (3). Each tool enforces principal-scoped channel/connection access policy and returns structured error payloads (see the [Error Catalog](#error-catalog)).
+
+**Recommended entry sequence:** `whoami` → `list_connections` → `list_channels(connection_id)` → then any retrieval/graph tool with the `channel_id` you obtained. `list_channels` is the ground truth for which channels exist — do not infer availability from `list_connections.selected_channel_count`.
+
+> **Wiki tool families.** There are two wiki-page surfaces. `get_wiki_page(page_type)` is the **legacy** static-page reader (seven fixed page types). `read_wiki_page` / `list_wiki_pages` / `read_wiki_module` / `read_wiki_section` / `get_wiki_graph` are the **redesigned slug-keyed** surface (per-page identity, structured module payloads, cross-link graph). Prefer the slug-keyed tools for new integrations; call `list_wiki_pages` first to discover slugs.
 
 ### Discovery (3 tools)
 
-Tools for exploring your accessible team topology.
+Tools for exploring your accessible team topology. All are instant (single store/metadata read).
 
-#### `whoami`
-Returns the authenticated principal id, the list of connections you can access, and the MCP server version. Use this to verify your credentials and understand your scope.
+#### `whoami()`
+Return the authenticated principal id, the connection ids you can access, and the deployed server version. Call this first to verify auth and obtain connection ids. Instant; response is stable within a session, so do not poll it.
 
-**Returns:** `{principal_id: str, connections: [str, ...], server_version: str}`
+**Returns:** `{principal_id, connections: [connection_id, ...], server_version}` — e.g. `{"principal_id": "mcp:9f2a1c…", "connections": ["conn_abc123"], "server_version": "0.1.0"}`. The `connections` list is ids only — call `list_connections` for full metadata.
 
-#### `list_connections`
-List all platform connections (Slack workspaces, Discord servers, Microsoft Teams organizations) accessible to your principal. Returns metadata including platform, display name, sync status, and when it was last synced.
+#### `list_connections()`
+List all platform connections (Slack workspaces, Discord servers, Teams orgs, file imports) owned by your principal, with full metadata. Results are filtered by ownership. Instant.
 
 **Returns:** `{connections: [{connection_id, platform, display_name, status, last_synced_at, selected_channel_count, source}, ...]}`
 
-#### `list_channels(connection_id: str)`
-List all channels currently selected for sync under a connection you own. Each channel includes sync status, last-sync timestamp, and estimated message count.
+**Field caveat:** `selected_channel_count` is the size of the user's **sync pick-list**, NOT the number of channels on the platform. `0` does not mean the connection is empty. Always call `list_channels` for the real channel list.
+
+#### `list_channels(connection_id)`
+List the channels the bot can actually read on a connection — the **ground truth** for what channels exist. Returns picked channels when the user has a non-empty sync pick-list, otherwise every channel the bot is a member of (file-import connections return every uploaded file). Instant.
 
 **Parameters:**
-- `connection_id` — the connection to list channels from (required, e.g., `"slack-workspace-123"`)
+- `connection_id` (required) — the connection id from `list_connections`, e.g. `"conn_abc123"`.
 
-**Returns:** `{channels: [{channel_id, name, platform, last_sync_ts, sync_status, message_count_estimate}, ...]}`
+**Returns:** `{channels: [{channel_id, name, platform, last_sync_ts, sync_status, message_count_estimate}, ...]}`. `sync_status="never_synced"` is normal and does not mean the channel is inaccessible — call `trigger_sync(channel_id)` to index it.
 
-**Error:** `{"error": "connection_access_denied", "connection_id": "..."}` if you don't own the connection.
+**Error:** `{"error": "connection_access_denied", "connection_id": "..."}` if you do not own the connection (existence is not leaked).
 
-### Retrieval (5 tools)
+### Retrieval (17 tools)
 
-Tools for searching and reading team knowledge.
+Tools for searching and reading team knowledge. Unless noted, all are read-only and instant-to-fast.
 
-#### `ask_channel(channel_id: str, question: str, mode: str = "quick", session_id: str | None = None)`
-Ask a natural-language question about a channel's knowledge. The server runs the ADK QA agent in the requested mode, streams thinking and tool-call events as progress notifications, and returns a structured answer with citations and follow-up suggestions.
-
-**Parameters:**
-- `channel_id` — target channel (required, e.g., `"C1234567890"`)
-- `question` — your question in natural language (required, e.g., `"How does JWT auth work here?"`)
-- `mode` — reasoning depth: `"quick"` (~5s, retrieval-only), `"summarize"` (~10s, synthesis), `"deep"` (~30s, tool calls enabled). Default: `"quick"`.
-- `session_id` — optional; if omitted, the server maintains one per-principal session for follow-ups.
-
-**Returns:** `{answer: str, citations: [{source, author, timestamp, permalink}, ...], follow_ups: [str, ...], metadata: {...}}`
-
-**Errors:**
-- `{"error": "channel_access_denied", "channel_id": "..."}` if you cannot access the channel.
-- `{"error": "answer_timeout"}` if reasoning exceeds 90 seconds.
-
-**Streaming:** While the tool runs, progress notifications are emitted containing thinking chunks, response deltas, and tool-call descriptions. The final result includes structured citations and follow-up questions.
-
-#### `search_channel_facts(channel_id: str, query: str, time_scope: str | None = None, limit: int = 10)`
-BM25 + semantic hybrid search over atomic facts in a channel's knowledge base. Returns individual facts with full citation metadata (source message, author, timestamp, permalink).
+#### `ask_channel(channel_id, question, mode="deep", session_id=None)`
+Flagship retrieval tool: answer a natural-language question about a channel by running the full ADK QA pipeline (BM25 + vector hybrid search + graph context + optional multi-hop reasoning) and returning a structured, cited answer. Streams thinking and tool-call events as progress notifications while it runs. Use when you need a synthesized answer; prefer `search_channel_facts`/`find_facts` for raw fact lookup, and `search_memory` when you don't yet know which channel holds the answer.
 
 **Parameters:**
-- `channel_id` — target channel (required)
-- `query` — search query (required, e.g., `"JWT token expiry"`)
-- `time_scope` — optional filter: `"last_7_days"`, `"last_30_days"`, `"all"`. Default: `"all"`.
-- `limit` — max results to return (default: 10, max: 100)
+- `channel_id` (required) — target channel from `list_channels`, e.g. `"C1234567890"`.
+- `question` (required) — natural-language question, **1–4000 characters** (over-length returns `invalid_parameter`), e.g. `"How does JWT auth work here?"`.
+- `mode` — `"quick"` (BM25-only, no reasoning, ~3s), `"deep"` (full ADK pipeline + graph, ~20–60s; **default**), or `"summarize"` (structured summary over wiki pages, ~10–30s). Invalid values return `invalid_parameter`.
+- `session_id` — conversation-continuity id from `start_new_session`; omit to use a per-principal session. Example: `"mcp:9f2a1c…:1a2b3c4d"`.
 
-**Returns:** `{facts: [{fact, channel_id, author, timestamp, permalink, confidence}, ...]}`
+**Returns:** `{answer, citations, follow_ups, metadata}`. **Latency:** long-running (up to 90s); progress notifications are emitted during the run.
 
-**Error:** `{"error": "channel_access_denied", "channel_id": "..."}` if you cannot access the channel.
+**Errors:** `{"error": "channel_access_denied", "channel_id": "..."}`, `{"error": "answer_timeout"}` if the 90s hard cap is exceeded, `{"error": "adk_error"}` on internal failure, `{"error": "invalid_parameter", "parameter": ...}`.
 
-#### `get_wiki_page(channel_id: str, page_type: str)`
-Fetch one pre-generated wiki page. Pages are automatically regenerated nightly and on sync; you can also trigger regeneration via `refresh_wiki`.
-
-**Parameters:**
-- `channel_id` — target channel (required)
-- `page_type` — one of: `"overview"`, `"faq"`, `"decisions"`, `"people"`, `"glossary"`, `"activity"`, `"topics"` (required)
-
-**Returns:** `{page_type, content, generated_at, citations: [{source, author}, ...]}`
-
-**Error:** `{"error": "channel_access_denied", "channel_id": "..."}` if you cannot access the channel.
-
-#### `get_recent_activity(channel_id: str, days: int = 7, topic: str | None = None, limit: int = 20)`
-Fetch recent facts and summaries from a channel, optionally filtered by topic and time window.
+#### `search_channel_facts(channel_id, query, time_scope="any", limit=10)`
+BM25 + vector hybrid search over atomic facts in a single channel. Returns ranked facts with citations. Faster and more precise than `ask_channel` for lookup; for substring/deterministic matching use `find_facts`; for cross-channel search use `search_memory`.
 
 **Parameters:**
-- `channel_id` — target channel (required)
-- `days` — look back this many days (default: 7)
-- `topic` — optional; filter to this topic (e.g., `"authentication"`)
-- `limit` — max results (default: 20, max: 100)
+- `channel_id` (required) — target channel from `list_channels`.
+- `query` (required) — search query, e.g. `"JWT token expiry"`.
+- `time_scope` — `"any"` (all time; **default**) or `"recent"` (last 30 days).
+- `limit` — max facts, **1–50, default 10** (clamped server-side).
 
-**Returns:** `{facts: [{fact, timestamp, author, topic, permalink}, ...]}`
+**Returns:** `{facts: [{text, author, timestamp, permalink, channel_id, confidence, topic_tags}, ...]}`
 
-**Error:** `{"error": "channel_access_denied", "channel_id": "..."}` if you cannot access the channel.
+**Error:** `{"error": "channel_access_denied", "channel_id": "..."}`.
 
-#### `search_media_references(channel_id: str, query: str, media_type: str | None = None, limit: int = 5)`
-Search for images, PDFs, videos, and links referenced in channel discussions. Useful for finding design specs, architecture diagrams, or documentation links.
+#### `get_wiki_page(channel_id, page_type="overview")`
+**(Legacy static-page surface.)** Fetch one pre-compiled wiki page from the fixed seven-page namespace. Faster than `ask_channel` for structured summaries. For the redesigned slug-keyed wiki, use `read_wiki_page` / `list_wiki_pages` instead.
 
 **Parameters:**
-- `channel_id` — target channel (required)
-- `query` — search term (required, e.g., `"architecture diagram"`)
-- `media_type` — optional filter: `"image"`, `"pdf"`, `"video"`, `"link"`. Default: all types.
-- `limit` — max results (default: 5, max: 20)
+- `channel_id` (required) — target channel from `list_channels`.
+- `page_type` — one of `"overview"` (default), `"faq"`, `"decisions"`, `"people"`, `"glossary"`, `"activity"`, `"topics"`.
 
-**Returns:** `{media: [{url, type, title, source_message, timestamp, author}, ...]}`
+**Returns:** the page dict (`page_type`, `channel_id`, `content`, `summary`, `text`). `content` is `null` when the page has not been generated yet. **Error:** `{"error": "channel_access_denied", ...}`.
 
-**Error:** `{"error": "channel_access_denied", "channel_id": "..."}` if you cannot access the channel.
+#### `get_recent_activity(channel_id, days=7, topic=None, limit=20)`
+Return the most recent facts from a channel, newest first, optionally narrowed to a topic and time window. Use for "what happened recently in #channel?"; use `search_channel_facts` for non-time-bounded search and `ask_channel` for synthesis.
+
+**Parameters:**
+- `channel_id` (required) — target channel from `list_channels`.
+- `days` — look-back window, **1–90, default 7** (clamped server-side), e.g. `14`.
+- `topic` — optional topic filter, e.g. `"authentication"`.
+- `limit` — max items, **1–50, default 20** (clamped server-side).
+
+**Returns:** `{activity: [{text, author, timestamp, channel_id, topic_tags, fact_id}, ...]}`. **Error:** `{"error": "channel_access_denied", ...}`.
+
+#### `search_media_references(channel_id, query, media_type=None, limit=5)`
+Find messages containing images, PDFs, or links shared in a channel — useful for design specs, diagrams, or documentation URLs. Do not use for general knowledge search (use `search_channel_facts`).
+
+**Parameters:**
+- `channel_id` (required) — target channel from `list_channels`.
+- `query` (required) — search term, e.g. `"architecture diagram"`.
+- `media_type` — `"image"`, `"pdf"`, `"link"`, or `null` (all types; default).
+- `limit` — max results, **1–20, default 5** (clamped server-side).
+
+**Returns:** `{media: [{text, media_urls, link_urls, link_titles, author, timestamp, media_type, fact_id}, ...]}`. **Error:** `{"error": "channel_access_denied", ...}`.
+
+#### `search_memory(query, scope="all", limit=20)`
+**Cross-channel** recall: hybrid (BM25 + vector) search merged across every channel the principal can access, re-ranked by score. Use when you do NOT yet know which channel holds the answer. With `scope="channel:<id>"` it searches a single channel (equivalent results to `search_channel_facts`, in this tool's response shape). Per-channel access is enforced.
+
+**Parameters:**
+- `query` (required) — search query, **1–4000 characters** (over-length returns `invalid_parameter`), e.g. `"deployment runbook"`.
+- `scope` — `"all"` (every accessible channel; **default**) or `"channel:<channel_id>"`, e.g. `"channel:C1234567890"`.
+- `limit` — max merged hits, **1–50, default 20** (clamped server-side).
+
+**Returns:** `{hits: [{fact_id, text, score, channel_id, cluster_id, entity_tags}, ...], query}`. **Error:** `{"error": "channel_access_denied", "channel_id": ...}` only for an explicit unreachable `channel:<id>` scope (inaccessible channels are silently skipped under `scope="all"`).
+
+#### `lint_wiki(channel_id, target_lang=None, run_coherence_check=True)`
+Run wiki health checks for a channel and return findings (orphan pages, stale/duplicate sections, intra-page coherence issues). Use when auditing wiki quality before or after a refresh; not part of normal retrieval. **Cost note:** with `run_coherence_check=True` this makes one LLM call per page, so it is slower and more expensive than a plain read — set it `False` to skip the coherence pass.
+
+**Parameters:**
+- `channel_id` (required) — target channel from `list_channels`.
+- `target_lang` — BCP-47 language tag to lint; defaults to the channel's primary (`"en"`).
+- `run_coherence_check` — run the bounded LLM coherence pass, **default `True`**.
+
+**Returns:** `{findings: [{severity, category, page_id, section_id, message, suggested_action}, ...], pages_scanned}`. **Errors:** `{"error": "channel_access_denied", ...}`, `{"error": "lint_failed"}` on internal failure.
+
+#### `get_extraction_status(channel_id)`
+Return per-status counts for the channel's background extraction queue: how many messages are still pending vs. being extracted vs. done vs. failed. Use to check whether ingestion has finished before relying on retrieval results. (Distinct from `get_job_status`, which tracks one specific sync/refresh job by id.)
+
+**Parameters:**
+- `channel_id` (required) — target channel from `list_channels`.
+
+**Returns:** `{channel_id, counts: {pending, extracting, done, failed}, total}`. A non-zero `pending`/`extracting` count means retrieval may be incomplete; all-`done` means the channel is fully indexed. **Errors:** `{"error": "channel_access_denied", ...}`, `{"error": "extraction_status_failed"}`.
+
+#### `read_wiki_page(channel_id, slug, target_lang="en")`
+**(Redesigned slug-keyed surface.)** Return the full structured payload for one wiki page identified by slug. Distinct from the legacy `get_wiki_page(page_type)` — this exposes per-page identity and structured modules. Call `list_wiki_pages` first to discover slugs.
+
+**Parameters:**
+- `channel_id` (required) — target channel from `list_channels`.
+- `slug` (required) — stable human-readable page id, e.g. `"auth-architecture"`.
+- `target_lang` — BCP-47 tag, default `"en"`.
+
+**Returns:** the WikiPage document (`content_md`, `kind`, `kind_schema`, `cross_links`, `cross_links_broken`, `pin_state`, `last_updated`). Hidden pages are excluded unless the token carries the `read:hidden_pages` scope. **Errors:** `{"error": "wiki_page_not_found", "slug": ...}`, `{"error": "channel_access_denied", ...}`.
+
+#### `list_wiki_pages(channel_id, kind=None, scope="human", target_lang="en")`
+List wiki-page summaries for a channel (slug-keyed surface). **Recommended first call** before `read_wiki_page` to discover slugs. Bodies are omitted to keep the payload small.
+
+**Parameters:**
+- `channel_id` (required) — target channel from `list_channels`.
+- `kind` — optional filter, one of `"topic"`, `"entity"`, `"decisions"`, `"faq"`, `"action_items"`.
+- `scope` — `"human"` (excludes hidden + merged pages; **default**) or `"all"` (requires the `read:hidden_pages` token scope, otherwise silently downgraded to `"human"`).
+- `target_lang` — BCP-47 tag, default `"en"`.
+
+**Returns:** `{channel_id, target_lang, scope, pages: [{slug, title, kind, version, last_updated, pinned, hidden}, ...]}`. **Error:** `{"error": "wiki_list_failed"}` on internal failure (and `channel_access_denied` on ACL denial).
+
+#### `get_wiki_graph(channel_id)`
+Return the channel's **wiki cross-link graph** (page-to-page links) in Cytoscape format. Distinct from `search_relationships`, which traverses the **knowledge graph** of entities/people — this is the graph of wiki pages and their links.
+
+**Parameters:**
+- `channel_id` (required) — target channel from `list_channels`.
+
+**Returns:** `{channel_id, nodes: [{data: {id, label, kind, ...}}], edges: [{data: {id, source, target, kind}}]}`. Returns empty `nodes`/`edges` when the graph backend is unavailable. **Error:** `{"error": "channel_access_denied", ...}`.
+
+#### `read_wiki_module(channel_id, page_slug, anchor, target_lang="en")`
+Fetch one module's structured `data` payload from a wiki page without downloading the whole page — token-efficient when you only need one slice. Discover valid anchors by reading the page first via `read_wiki_page` (the slug-keyed surface).
+
+**Parameters:**
+- `channel_id` (required) — target channel from `list_channels`.
+- `page_slug` (required) — slug of the host page, e.g. `"auth-architecture"`.
+- `anchor` (required) — stable in-page module id, e.g. `"key-facts"`, `"decision-banner"`, `"tension-callout"`.
+- `target_lang` — BCP-47 tag, default `"en"`.
+
+**Returns:** `{channel_id, page_slug, anchor, module_id, data}`. **Errors:** `{"error": "wiki_page_not_found", ...}`, `{"error": "module_not_found", "slug": ..., "anchor": ...}`, `{"error": "channel_access_denied", ...}`.
+
+#### `find_decisions(channel_id, since=None, author=None, limit=50)`
+Find every decision recorded in a channel's wiki/fact store, sorted newest-first. Prefer this over `find_facts(fact_type="decision")` when you also need rationale and alternatives on each result. (For the SUPERSEDES-chain timeline of how one decision evolved, use `trace_decision_history` instead.) **Returns a JSON list (not a dict);** on access denial it returns an empty list `[]` rather than an error object.
+
+**Parameters:**
+- `channel_id` (required) — target channel from `list_channels`.
+- `since` — optional ISO-8601 date prefix; only decisions on/after this date, e.g. `"2026-04-01"`.
+- `author` — optional exact-match author name, e.g. `"Alice Chen"`.
+- `limit` — max decisions, **1–100, default 50** (clamped server-side).
+
+**Returns:** `[{fact_id, decision, decided_by, decided_at, rationale, alternatives_rejected, page_slug}, ...]` (`rationale` may be `null` when not yet extracted).
+
+#### `get_tensions(channel_id, status=None)`
+List unresolved tensions (competing positions) surfaced from `tension_callout` modules across the channel's wiki. **Returns a JSON list (not a dict);** on access denial it returns `[]`. **Note:** tension detection is not yet shipped on this track, so this is currently empty for most channels — the wiring is in place so the same call returns real data once detection lands, with no API change.
+
+**Parameters:**
+- `channel_id` (required) — target channel from `list_channels`.
+- `status` — optional filter, one of `"open"`, `"blocked"`, `"deferred"`.
+
+**Returns:** `[{tension_id, title, status, since, positions: [{author, stance, fact_id}, ...], page_slug}, ...]`.
+
+#### `find_facts(channel_id, query, fact_type=None, limit=20)`
+Deterministic **case-insensitive substring** search over fact text in a channel — not a ranked retriever. Use when you want raw fact rows that mention a keyword and `ask_channel` would over-synthesize; for semantic/vector ranking use `search_channel_facts`. **Returns a JSON list (not a dict);** on access denial it returns `[]`.
+
+**Parameters:**
+- `channel_id` (required) — target channel from `list_channels`.
+- `query` (required) — substring to match in `memory_text`, e.g. `"rate limit"`.
+- `fact_type` — optional filter, one of `"decision"`, `"observation"`, `"opinion"`, `"question"`, `"action_item"`.
+- `limit` — max facts, **1–100, default 20** (clamped server-side).
+
+**Returns:** `[{fact_id, memory_text, fact_type, importance, author_name, message_ts, page_slug}, ...]`.
+
+#### `read_wiki_section(channel_id, page_slug, anchor, target_lang="en")`
+Fetch ONE narrative section's structured data from a wiki page without loading the full page — token-efficient when you know the section anchor. Use `read_wiki_module` for a module's structured payload instead, and `find_facts` for cross-page fact-text search.
+
+**Parameters:**
+- `channel_id` (required) — target channel from `list_channels`.
+- `page_slug` (required) — slug of the host page, e.g. `"auth-architecture"`.
+- `anchor` (required) — kebab-case section id, e.g. `"context"`, `"alternatives"`, `"implications"`.
+- `target_lang` — BCP-47 tag, default `"en"`.
+
+**Returns:** `{anchor, heading, paragraphs, citations, visual, page_slug, page_title, channel_id}`. **Errors:** `{"error": "page_not_found", ...}`, `{"error": "section_not_found", "available_anchors": [...]}`, `{"error": "narrative_not_available", "has_modules": bool, "suggestion": ...}` (retry with `read_wiki_page`), `{"error": "channel_access_denied", ...}`.
+
+#### `read_provenance(fact_id)`
+Close the audit loop: given a `fact_id` surfaced by another tool (`find_decisions`, `find_facts`, `ask_channel`, …), return the original source message it was extracted from. Does not fail hard if the raw message is unreachable — `raw_message` is empty in that case but all citation fields are still populated.
+
+**Parameters:**
+- `fact_id` (required) — the fact id to resolve, e.g. `"fact_7d3a…"`.
+
+**Returns:** `{fact_id, memory_text, source: {platform, message_id, url, author, ts}, raw_message}`. **Error:** `{"error": "fact_not_found", "fact_id": ...}` — note that access-denied is deliberately mapped to `fact_not_found` so cross-tenant fact existence is not disclosed.
 
 ### Graph (3 tools)
 
-Tools for exploring relationships and decision history.
+Tools for exploring the entity knowledge graph and decision history. Fast graph reads.
 
-#### `find_experts(channel_id: str, topic: str, limit: int = 5)`
-Rank team members by expertise in a topic based on message frequency, citations, and knowledge graph analysis.
-
-**Parameters:**
-- `channel_id` — target channel (required)
-- `topic` — topic to find experts in (required, e.g., `"database indexing"`)
-- `limit` — max results (default: 5)
-
-**Returns:** `{experts: [{name, user_id, confidence, contributions_count}, ...]}`
-
-**Error:** `{"error": "channel_access_denied", "channel_id": "..."}` if you cannot access the channel.
-
-#### `search_relationships(channel_id: str, entities: [str], hops: int = 2)`
-Graph traversal: given a list of entities (people, projects, decisions), find their connections within N hops. Useful for understanding how decisions connect to projects or who is involved across multiple initiatives.
+#### `find_experts(channel_id, topic, limit=5)`
+Identify the most knowledgeable people about a topic in a channel, ranked by graph-edge frequency. Use to answer "who knows the most about X?"; use `search_channel_facts` to find facts rather than people.
 
 **Parameters:**
-- `channel_id` — target channel (required)
-- `entities` — entity names or ids to start from (required, e.g., `["Alice", "ProjectX"]`)
-- `hops` — traversal depth (default: 2, max: 4)
+- `channel_id` (required) — target channel from `list_channels`.
+- `topic` (required) — topic/keyword, e.g. `"database indexing"`.
+- `limit` — max experts, **1–20, default 5** (clamped server-side).
 
-**Returns:** `{paths: [{from, to, relationship, distance}, ...]}`
+**Returns:** `{experts: [{handle, expertise_score, fact_count, top_topics}, ...]}` (`expertise_score` is a relative ranking weight, higher = stronger). **Error:** `{"error": "channel_access_denied", ...}`.
 
-**Error:** `{"error": "channel_access_denied", "channel_id": "..."}` if you cannot access the channel.
-
-#### `trace_decision_history(channel_id: str, topic: str)`
-Trace the evolution of a decision over time: who proposed it, what alternatives were discussed, why was one chosen, and what happened afterward.
+#### `search_relationships(channel_id, entities, hops=2)`
+Traverse the **knowledge graph** of entities (people, projects, decisions) to find how they connect. Distinct from `get_wiki_graph` (page-link graph) — this returns entity nodes and relationship edges. Use to answer "how is X related to Y?".
 
 **Parameters:**
-- `channel_id` — target channel (required)
-- `topic` — decision topic (required, e.g., `"authentication method"`)
+- `channel_id` (required) — target channel from `list_channels`.
+- `entities` (required) — list of entity names to start from, e.g. `["Alice", "ProjectX"]`.
+- `hops` — traversal depth, **1–4, default 2** (clamped server-side).
 
-**Returns:** `{timeline: [{timestamp, author, event, content, decision, rationale}, ...], current_status}`
+**Returns:** `{nodes: [{name, type}, ...], edges: [{source, target, type, confidence, context}, ...], text, entities_searched}`. **Error:** `{"error": "channel_access_denied", ...}`.
 
-**Error:** `{"error": "channel_access_denied", "channel_id": "..."}` if you cannot access the channel.
-
-### Orchestration (3 tools)
-
-Long-running operations that return a job_id for polling.
-
-#### `trigger_sync(channel_id: str, sync_type: str | None = None)`
-Manually trigger a sync (pull ingestion) for a channel. Returns immediately with a job_id and status URI; poll via `get_job_status` or read the `atlas://job/{id}` resource to track completion.
-
-Idempotent: if a sync for this channel+principal is already queued or running, this returns the existing job_id.
+#### `trace_decision_history(channel_id, topic)`
+Reconstruct the decision timeline for a topic by following `SUPERSEDES` edges in the knowledge graph — which earlier decisions were overridden and by what. Distinct from `find_decisions` (flat wiki/fact-store decision list): use this for the historical chain, `find_decisions` for the current decision set with rationale.
 
 **Parameters:**
-- `channel_id` — channel to sync (required)
-- `sync_type` — optional; scope of sync, e.g., `"incremental"`, `"full"`. Default: determined by Atlas.
+- `channel_id` (required) — target channel from `list_channels`.
+- `topic` (required) — decision topic, e.g. `"database choice"`.
 
-**Returns:** `{job_id, status_uri: "atlas://job/{job_id}", status: "queued" | "running" | "completed" | "failed"}`
-
-**Errors:**
-- `{"error": "channel_access_denied", "channel_id": "..."}` if you cannot access the channel.
-- `{"error": "bridge_unavailable"}` if the platform bridge (Slack/Discord/Teams connector) is unreachable.
-- `{"error": "rate_limited", "retry_after_seconds": N}` if you exceed 5 syncs per minute.
-
-#### `refresh_wiki(channel_id: str, page_types: [str] | None = None)`
-Regenerate wiki pages for a channel. Returns a job_id for polling. If `page_types` is omitted, all pages are regenerated.
-
-**Parameters:**
-- `channel_id` — target channel (required)
-- `page_types` — optional list to regenerate only these pages, e.g., `["overview", "decisions"]`. Default: all.
-
-**Returns:** `{job_id, status_uri: "atlas://job/{job_id}", status: "queued" | "running" | "completed" | "failed"}`
-
-**Error:** `{"error": "channel_access_denied", "channel_id": "..."}` if you cannot access the channel.
-
-#### `get_job_status(job_id: str)`
-Poll the status of a long-running job (sync or wiki refresh). Returns the current state, progress, result (if complete), and any error.
-
-**Parameters:**
-- `job_id` — the job id returned by `trigger_sync` or `refresh_wiki` (required)
-
-**Returns:** `{job_id, kind: "sync" | "wiki_refresh", status: "queued" | "running" | "completed" | "failed", progress_percent, result: {...} | null, error: str | null}`
-
-**Error:** `{"error": "job_not_found"}` if the job does not exist OR is owned by a different principal (no disclosure of ownership).
+**Returns:** `{decisions: [{entity, superseded_by, relationship, confidence, context, position}, ...]}`. **Error:** `{"error": "channel_access_denied", ...}`.
 
 ### Session (1 tool)
 
 #### `start_new_session()`
-Archive the current conversation and start a fresh ADK session. Useful when you want to reset context between independent inquiries.
+Reset the conversation thread and obtain a fresh `session_id` to pass to `ask_channel` — use it to drop prior context when switching topics or starting an unrelated inquiry. Do not call before every question. Instant.
 
-**Returns:** `{session_id, reset_at}`
+**Returns:** `{session_id}` — e.g. `{"session_id": "mcp:9f2a1c…:1a2b3c4d"}`. The id is an opaque conversation-boundary marker accepted by `ask_channel(session_id=...)`.
+
+### Orchestration (3 tools)
+
+Long-running operations that return immediately with a `job_id` for polling. Rate-limited to 5/min per principal for the two write tools.
+
+#### `trigger_sync(channel_id, sync_type="incremental", connection_id=None)`
+Trigger an incremental or full message sync of a channel into the knowledge base. Returns a job envelope within ~5s; ingestion runs in the background — poll `get_job_status` or read `atlas://job/<job_id>`. **Idempotent:** an existing queued/running job for the same channel is returned rather than creating a duplicate. **When to use:** only when the user explicitly asks to sync, OR when retrieval is empty/stale and the channel's `last_sync_ts` is older than 24h — sync is expensive and rate-limited. Do not call as a precaution before every question.
+
+**Parameters:**
+- `channel_id` (required) — channel to sync from `list_channels`, e.g. `"C1234567890"`.
+- `sync_type` — `"incremental"` (only new messages; **default**), `"full"` (re-fetch everything; expensive), or `"auto"` (server chooses).
+- `connection_id` — optional but strongly recommended when the principal owns multiple same-platform connections, to avoid mis-routing, e.g. `"conn_abc123"`.
+
+**Returns:** `{job_id, status_uri: "atlas://job/{job_id}", status: "queued"}`. **Errors:** `{"error": "channel_access_denied", ...}`, `{"error": "cooldown_active", "retry_after_seconds": N}`, `{"error": "service_unavailable", "service": ...}` (e.g. the platform bridge is unreachable), `{"error": "internal_error", ...}`.
+
+#### `refresh_wiki(channel_id, page_types=None)`
+Regenerate pre-compiled wiki pages for a channel from its ingested facts. Returns a job envelope within ~5s; generation runs in the background. **Expensive** — only call after a fresh sync added new facts or when the user explicitly requests regeneration; wiki pages are normally rebuilt automatically by the sync pipeline.
+
+**Parameters:**
+- `channel_id` (required) — channel from `list_channels`, e.g. `"C1234567890"`.
+- `page_types` — optional subset to regenerate from `"overview"`, `"faq"`, `"decisions"`, `"people"`, `"glossary"`, `"activity"`, `"topics"`; omit to regenerate all.
+
+**Returns:** `{job_id, status_uri: "atlas://job/{job_id}", status: "queued"}`. **Errors:** `{"error": "channel_access_denied", ...}`, `{"error": "cooldown_active", "retry_after_seconds": N}`, `{"error": "service_unavailable", "service": ...}`, `{"error": "internal_error", ...}`.
+
+#### `get_job_status(job_id)`
+Poll the state of a long-running job created by `trigger_sync` or `refresh_wiki`. **Polling guidance:** wait a few seconds between polls and back off — do not hot-loop. The `atlas://job/<id>` resource read returns the identical payload for clients that prefer `resources/read`.
+
+**Parameters:**
+- `job_id` (required) — the id returned by `trigger_sync` / `refresh_wiki`, e.g. `"job_3f1c9a"`.
+
+**Returns:** `{job_id, kind, status, progress, started_at, updated_at, ended_at, result, error, target}`. `status` ∈ `queued` | `running` | `done` | `error` | `cancelled`; `progress` is `0.0–1.0` or `null` when unavailable. **Error:** `{"error": "job_not_found", "job_id": ...}` if the job does not exist OR is owned by another principal (ownership is not disclosed).
 
 ### Deprecation Shim (1 tool)
 
-#### `search_channel_knowledge` (DEPRECATED)
-This tool has been retired. It now returns a structured error so migrating callers know which replacements to use.
+#### `search_channel_knowledge(channel_id="", query="")` (DEPRECATED)
+Retired tool name retained as a shim. It performs no retrieval and always returns a structured `tool_renamed` error pointing at the replacements, so migrating callers get a clear signal instead of a silent failure.
 
-**Returns:** `{"error": "tool_renamed", "replacement": ["ask_channel", "search_channel_facts"]}`
+**Returns:** `{"error": "tool_renamed", "replacement": ["ask_channel", "search_channel_facts"], "detail": "..."}`
 
-**Migration:** Replace calls to `search_channel_knowledge(channel_id, query)` with:
-- `ask_channel(channel_id, query, mode="quick")` for natural-language questions with citations, or
+**Migration:** replace `search_channel_knowledge(channel_id, query)` with:
+- `ask_channel(channel_id, query, mode="quick")` for natural-language, cited answers, or
 - `search_channel_facts(channel_id, query)` for structured fact search.
 
 ## Resources
@@ -321,7 +419,11 @@ Every tool and resource returns a structured error on failure. The error object 
 - **`cooldown_active`** — a sync is already in progress for this channel; try again in a few moments. The error includes `retry_after_seconds`.
 - **`invalid_parameter`** — a parameter failed validation (e.g., malformed channel_id). The error includes a `parameter` field naming the offender.
 - **`answer_timeout`** — `ask_channel` exceeded its 90-second hard cap. The partially-accumulated answer is discarded.
-- **`bridge_unavailable`** — the platform bridge (Slack/Discord/Teams connector) is unreachable. Returned by sync/refresh operations.
+- **`adk_error`** — `ask_channel` hit an internal QA-pipeline failure. Details are logged server-side, never returned.
+- **`service_unavailable`** — a backing service (e.g. the platform bridge for Slack/Discord/Teams) is unreachable. Returned by `trigger_sync` / `refresh_wiki`; the error includes a `service` field.
+- **`fact_not_found`** — `read_provenance` could not resolve the `fact_id` (the fact is unknown OR the caller lacks access — the two are deliberately indistinguishable to avoid leaking cross-tenant existence).
+- **`wiki_page_not_found`** / **`module_not_found`** / **`page_not_found`** / **`section_not_found`** / **`narrative_not_available`** — returned by the slug-keyed wiki tools when the requested slug, module anchor, or narrative section does not exist.
+- **`lint_failed`** / **`extraction_status_failed`** / **`internal_error`** — generic internal-failure codes returned by the corresponding tools when an underlying operation fails.
 
 Example error response:
 ```json
@@ -365,7 +467,8 @@ For longer jobs, only the final `get_job_status` or resource read will show comp
 
 ## Known Limitations (v1)
 
-- **`ask_channel` ADK runner stub in Phase 3:** In Phase 3 of the rollout, the `ask_channel` tool invokes the full ADK QA agent. However, in Phase 1 (current), external agents cannot mutate knowledge — no tools to upsert facts, delete memories, or edit wiki pages. Write operations remain dashboard-only.
+- **Read-mostly surface:** External agents cannot mutate knowledge — there are no tools to upsert facts, delete memories, or edit wiki pages. The only state-changing tools are `trigger_sync` and `refresh_wiki`, which queue background jobs; all other tools are read-only. Direct write operations remain dashboard-only.
+- **Tension detection not yet shipped:** `get_tensions` is wired end-to-end but returns an empty list for most channels until tension detection lands; the API will not change when it does.
 - **In-memory rate-limit state:** Each Atlas process maintains rate-limit state in memory. With multiple processes behind a load balancer, rate limits are per-process. A distributed rate-limit store (Redis) is planned for Phase 2+.
 - **Key rotation requires restart:** Changing `BEEVER_MCP_API_KEYS` requires restarting the process. A hot-reload/revocation mechanism (Phase 2+) is tracked separately.
 - **MCP sessions isolated from dashboard:** Sessions created via MCP are not visible in the dashboard `/api/ask/sessions` endpoint, and vice versa. The two session models are independent.

--- a/src/beever_atlas/api/mcp_server/__init__.py
+++ b/src/beever_atlas/api/mcp_server/__init__.py
@@ -4,31 +4,30 @@ This is the sole agent-facing MCP surface, introduced by openspec change
 ``atlas-mcp-server``. The legacy unauthenticated ``/mcp`` mount has been
 retired; all clients connect through this curated, auth-gated surface.
 
-Phase 2 shipped the factory skeleton with auth wiring; Phase 3 registers the
-full tool catalog:
+The catalog exposed via ``tools/list`` (28 tools total):
 
     Discovery      (3): whoami, list_connections, list_channels
-    Retrieval      (5): ask_channel, search_channel_facts, get_wiki_page,
-                        get_recent_activity, search_media_references
+    Retrieval     (17): ask_channel, search_channel_facts, get_wiki_page,
+                        get_recent_activity, search_media_references,
+                        search_memory, lint_wiki, get_extraction_status,
+                        read_wiki_page, list_wiki_pages, get_wiki_graph,
+                        read_wiki_module, find_decisions, get_tensions,
+                        find_facts, read_wiki_section, read_provenance
     Graph          (3): find_experts, search_relationships, trace_decision_history
     Session        (1): start_new_session
+    Orchestration  (3): trigger_sync, refresh_wiki, get_job_status
     Shim           (1): search_channel_knowledge  <- deprecation shim
 
-Phase 4 adds resources and prompts.
-Phase 5b adds the long-running-job tools:
+Plus resources (atlas:// URIs), prompts, principal-keyed rate limiting, and
+per-tool audit logging.
 
-    Orchestration  (3): trigger_sync, refresh_wiki, get_job_status
-
-Phase 7 adds principal-keyed rate limiting and per-tool audit logging.
-
-Tool-group submodules (split to keep each file under ~300 lines):
+Tool-group submodules:
     _helpers.py              shared helpers (_get_principal_id, _validate_id, …)
-    _tools_discovery.py      whoami, list_connections, list_channels
-    _tools_retrieval.py      ask_channel, search_channel_facts, get_wiki_page,
-                             get_recent_activity, search_media_references
-    _tools_graph.py          find_experts, search_relationships, trace_decision_history
-    _tools_session.py        start_new_session
-    _tools_orchestration.py  trigger_sync, refresh_wiki, get_job_status
+    _tools_discovery.py      discovery tools
+    _tools_retrieval.py      retrieval + wiki tools
+    _tools_graph.py          graph tools
+    _tools_session.py        session tools
+    _tools_orchestration.py  long-running-job orchestration tools
     _resources.py            atlas:// URI resources
     _prompts.py              summarize_channel, investigate_decision, onboard_new_channel
 """
@@ -260,10 +259,13 @@ def _register_deprecation_shim(mcp: FastMCP) -> None:
     @mcp.tool(
         name="search_channel_knowledge",
         description=(
-            "DEPRECATED. 'search_channel_knowledge' has been retired. Use "
-            "'ask_channel' for natural-language questions with citations, or "
-            "'search_channel_facts' for targeted BM25+vector fact search. "
-            "This tool returns a structured tool_renamed error."
+            "DEPRECATED — do not call. This is a compatibility shim for the "
+            "retired 'search_channel_knowledge' tool. Use 'ask_channel' for "
+            "natural-language questions answered with citations, or "
+            "'search_channel_facts' for targeted keyword+vector fact search "
+            "within one channel. Calling this always returns a structured "
+            '{"error": "tool_renamed", "replacement": [...]} payload and '
+            "performs no work (no backend call, exempt from rate limiting)."
         ),
     )
     async def search_channel_knowledge_deprecated(
@@ -302,13 +304,28 @@ def build_mcp() -> FastMCP:
     mcp = FastMCP(
         name="beever-atlas",
         instructions=(
-            "Beever Atlas MCP surface. Curated tools, resources, and prompts "
-            "for external AI agents (Claude Code, Cursor, IDE assistants) to "
-            "discover, query, and operate Atlas knowledge. Every tool that "
-            "takes a channel_id or connection_id applies a principal-scoped "
-            "ACL; unauthorized calls return structured error payloads with "
-            "codes from the mcp-auth error catalog (channel_access_denied, "
-            "connection_access_denied, job_not_found, rate_limited, etc.)."
+            "Beever Atlas is a team knowledge base that turns synced chat "
+            "platforms (Slack, Discord, Teams, etc.) into a searchable wiki, "
+            "fact store, and knowledge graph. This MCP surface lets an agent "
+            "discover, query, and operate that knowledge.\n\n"
+            "Recommended entry sequence: call whoami to confirm the principal, "
+            "list_connections to see linked platforms, then list_channels to "
+            "get the channel_id values that almost every other tool requires. "
+            "Pass those ids into the retrieval, graph, and orchestration tools.\n\n"
+            "Tool groups: DISCOVERY (whoami, list_connections, list_channels) "
+            "tells you what exists. RETRIEVAL answers questions and reads the "
+            "wiki/facts (ask_channel for cited natural-language answers, "
+            "search_channel_facts / search_memory / find_facts for targeted "
+            "lookups, read_wiki_page & list_wiki_pages for the current wiki). "
+            "GRAPH (find_experts, search_relationships, trace_decision_history) "
+            "navigates entity and decision relationships. ORCHESTRATION "
+            "(trigger_sync, refresh_wiki, get_job_status) starts long-running "
+            "jobs and polls them.\n\n"
+            "Every tool that takes a channel_id or connection_id enforces a "
+            "principal-scoped ACL. Errors are returned as structured payloads "
+            '(e.g. {"error": "channel_access_denied"}), never exceptions; '
+            "common codes include channel_access_denied, connection_access_denied, "
+            "job_not_found, invalid_parameter, and rate_limited."
         ),
         version=_atlas_version(),
     )

--- a/src/beever_atlas/api/mcp_server/_prompts.py
+++ b/src/beever_atlas/api/mcp_server/_prompts.py
@@ -11,11 +11,20 @@ def register_prompts(mcp: FastMCP) -> None:
     # 4.6 summarize_channel
     @mcp.prompt(name="summarize_channel")
     def summarize_channel(channel_id: str, since_days: int = 7) -> list[dict]:
-        """Produce a user-role instruction to summarize recent channel discussion.
+        """Recap recent activity in one channel.
+
+        Use this prompt when a user asks "what happened in #channel lately?" or
+        wants a standup-style digest. It returns a single user-role message that
+        instructs the agent to summarize decisions, open questions, and key
+        participants over the look-back window, grounded with get_recent_activity
+        and the activity wiki page. It performs no retrieval itself — the caller's
+        agent runs the named tools.
 
         Parameters:
-            channel_id: The channel id to summarize (from list_channels).
-            since_days: Look-back window in days (default 7).
+            channel_id: Channel to summarize. Get a valid id from list_channels
+                (e.g. "C12345").
+            since_days: Look-back window in days. Default 7; use a larger value
+                for a broader recap.
         """
         return [
             {
@@ -32,11 +41,20 @@ def register_prompts(mcp: FastMCP) -> None:
     # 4.7 investigate_decision
     @mcp.prompt(name="investigate_decision")
     def investigate_decision(channel_id: str, topic: str) -> list[dict]:
-        """Produce a decision-trace-style instruction for investigating a topic.
+        """Trace how a decision was made in one channel.
+
+        Use this prompt when a user asks "why did we decide X?" or "what's the
+        history behind X?". It returns a single user-role message that directs
+        the agent to reconstruct the decision's SUPERSEDES chain with
+        trace_decision_history, identify who drove it with find_experts, and
+        ground each claim with search_channel_facts. The prompt itself does no
+        retrieval — the caller's agent runs the named tools.
 
         Parameters:
-            channel_id: The channel id to investigate (from list_channels).
-            topic: The decision or topic to trace (e.g. 'database choice').
+            channel_id: Channel to investigate. Get a valid id from list_channels
+                (e.g. "C12345").
+            topic: The decision or subject to trace, in natural language
+                (e.g. "database choice", "auth provider migration").
         """
         return [
             {
@@ -53,10 +71,18 @@ def register_prompts(mcp: FastMCP) -> None:
     # 4.8 onboard_new_channel
     @mcp.prompt(name="onboard_new_channel")
     def onboard_new_channel(channel_id: str) -> list[dict]:
-        """Produce an onboarding-overview instruction for a new channel.
+        """Orient someone joining a channel for the first time.
+
+        Use this prompt when a user asks "get me up to speed on #channel" or
+        "what is this channel about?". It returns a single user-role message that
+        walks the agent through the overview, people, and topics wiki pages and
+        asks it to summarize the channel's scope, key people, active topics, and
+        recent decisions. The prompt itself does no retrieval — the caller's
+        agent runs the named tools.
 
         Parameters:
-            channel_id: The channel id to onboard (from list_channels).
+            channel_id: Channel to onboard into. Get a valid id from
+                list_channels (e.g. "C12345").
         """
         return [
             {

--- a/src/beever_atlas/api/mcp_server/_resources.py
+++ b/src/beever_atlas/api/mcp_server/_resources.py
@@ -21,7 +21,14 @@ def register_resources(mcp: FastMCP) -> None:
     @mcp.resource(
         "atlas://connection/{connection_id}",
         name="connection",
-        description="Metadata for a single platform connection owned by the calling MCP principal.",
+        description=(
+            "Read metadata for one platform connection (e.g. a linked Slack or "
+            "Discord workspace) owned by the calling principal. connection_id "
+            "comes from list_connections (e.g. 'conn_abc123'). Returns the "
+            "connection's JSON record, or a structured error: "
+            "connection_not_found if the id is unknown, connection_access_denied "
+            "if it belongs to another principal. Instant read, no side effects."
+        ),
         mime_type="application/json",
     )
     async def get_connection(connection_id: str) -> dict:
@@ -56,7 +63,14 @@ def register_resources(mcp: FastMCP) -> None:
     @mcp.resource(
         "atlas://connection/{connection_id}/channels",
         name="connection-channels",
-        description="All channels selected for sync under a connection owned by the calling principal.",
+        description=(
+            "List the channels selected for sync under one connection owned by "
+            "the calling principal. connection_id comes from list_connections "
+            "(e.g. 'conn_abc123'). Returns {channels: [...], connection_id}, or "
+            "connection_access_denied if the connection belongs to another "
+            "principal. Equivalent to the list_channels tool scoped to a single "
+            "connection. Instant read, no side effects."
+        ),
         mime_type="application/json",
     )
     async def get_connection_channels(connection_id: str) -> dict:
@@ -89,8 +103,14 @@ def register_resources(mcp: FastMCP) -> None:
         "atlas://channel/{channel_id}/wiki",
         name="channel-wiki-index",
         description=(
-            "Wiki structure index for a channel: overview summary and available page types. "
-            "Returns a stub if the wiki cache has not been populated yet."
+            "Read the wiki table of contents for a channel: the list of pages "
+            "(or page types) and a short overview. Use this to discover what "
+            "wiki content exists before fetching a specific page. channel_id "
+            "comes from list_channels (e.g. 'C12345'). Returns {channel_id, "
+            "pages|page_types, overview, stub}; stub is true when the wiki has "
+            "not been generated yet (run refresh_wiki to populate it). Returns "
+            "channel_access_denied if the channel belongs to another principal. "
+            "Instant read, no side effects."
         ),
         mime_type="application/json",
     )
@@ -191,8 +211,13 @@ def register_resources(mcp: FastMCP) -> None:
         "atlas://channel/{channel_id}/wiki/page/{page_id}",
         name="channel-wiki-page",
         description=(
-            "Pre-compiled wiki page content for a channel. page_id is one of: "
-            "overview, faq, decisions, people, glossary, activity, topics."
+            "Read one pre-compiled wiki page for a channel. channel_id comes "
+            "from list_channels (e.g. 'C12345'); page_id is one of: overview, "
+            "faq, decisions, people, glossary, activity, topics. Returns "
+            "{channel_id, page_type, content, generated_at, citations}; content "
+            "is null when that page has not been generated yet (run refresh_wiki "
+            "to populate it). Returns channel_access_denied if the channel "
+            "belongs to another principal. Instant read, no side effects."
         ),
         mime_type="application/json",
     )
@@ -243,8 +268,13 @@ def register_resources(mcp: FastMCP) -> None:
         "atlas://job/{job_id}",
         name="job-status",
         description=(
-            "Status of a long-running sync or wiki-refresh job. Returns job_not_found "
-            "for jobs not owned by the calling principal (no information leak)."
+            "Read the status of a long-running sync or wiki-refresh job started "
+            "by trigger_sync or refresh_wiki. job_id is the value those tools "
+            "return (e.g. 'job_789'). Returns the job status record (state, "
+            "progress, timestamps). Returns job_not_found both for unknown ids "
+            "and for jobs owned by another principal, so it never leaks the "
+            "existence of others' jobs. This is the resource form of the "
+            "get_job_status tool. Instant read, no side effects."
         ),
         mime_type="application/json",
     )

--- a/src/beever_atlas/api/mcp_server/_tools_discovery.py
+++ b/src/beever_atlas/api/mcp_server/_tools_discovery.py
@@ -1,4 +1,4 @@
-"""Discovery tools: whoami, list_connections, list_channels (Phase 3, tasks 3.1–3.3)."""
+"""Discovery tools: whoami, list_connections, list_channels."""
 
 from __future__ import annotations
 
@@ -20,18 +20,27 @@ def register_discovery_tools(mcp: FastMCP) -> None:
 
     @mcp.tool(name="whoami")
     async def whoami(ctx: Context) -> dict:
-        """Return the authenticated principal's identity and accessible connections.
+        """Confirm who you are authenticated as and which connection ids you can reach.
 
-        Use this tool at the start of a session to discover your principal id and
-        the list of connection ids you can access. The returned ``connections`` list
-        contains only ids — call ``list_connections`` for full connection metadata.
-        The ``server_version`` field reflects the deployed Atlas version.
+        Call this FIRST in any session, before any other tool, to (1) verify your
+        auth token resolved to a principal and (2) get the connection ids needed by
+        ``list_channels``. Returns only connection IDS here; use ``list_connections``
+        when you also need each connection's platform, status, and sync metadata.
 
-        When to use: first call in a session, before any other tool, to verify
-        authentication succeeded and to obtain connection ids for ``list_channels``.
-        Do NOT call repeatedly — the response is stable within a session.
+        When to use: once at session start. Do NOT call repeatedly — the response is
+        stable for the whole session.
 
-        Returns: ``{principal_id, connections, server_version}``
+        Latency: instant (single in-memory/DB lookup; never triggers a sync or job).
+
+        Returns a dict:
+        - ``principal_id`` (str): your authenticated identity, e.g. ``"user_42"``.
+        - ``connections`` (list[str]): connection ids you may access, e.g.
+          ``["conn_abc123", "conn_def456"]``. Empty list if you own no connections.
+        - ``server_version`` (str): deployed Atlas version, e.g. ``"0.1.0"``.
+
+        Error modes: returns ``{"error": "authentication_missing"}`` when the request
+        carries no valid principal (token absent/invalid). No access-denied path —
+        the response is always scoped to the caller.
         """
         principal_id = _get_principal_id(ctx)
         if not principal_id:
@@ -55,35 +64,36 @@ def register_discovery_tools(mcp: FastMCP) -> None:
 
     @mcp.tool(name="list_connections")
     async def list_connections(ctx: Context) -> dict:
-        """Return all platform connections (Slack workspaces, Discord servers, etc.) accessible to this principal.
+        """List the platform connections (Slack workspaces, Discord servers, file
+        imports, etc.) this principal owns, with each connection's metadata.
 
-        Each connection entry contains: ``connection_id``, ``platform``,
-        ``display_name``, ``status``, ``last_synced_at``,
-        ``selected_channel_count``, and ``source``.
+        Use this when you need a connection's platform, status, or sync metadata —
+        not just its id. If you only need the connection ids, ``whoami`` is cheaper.
+        After picking a connection here, call ``list_channels(connection_id)`` to see
+        its actual channels. Results are ownership-filtered: you only see your own.
 
-        When to use: to enumerate which workspaces/servers this principal can
-        access, then drill into a specific connection with ``list_channels``.
-        Results are filtered by ownership — you only see your own connections.
+        Latency: instant (read-only; no sync triggered).
 
-        **IMPORTANT — field semantics (don't misread these):**
+        Returns ``{"connections": [<entry>, ...]}`` (empty list if none). Each entry:
+        - ``connection_id`` (str): e.g. ``"conn_abc123"`` — pass to ``list_channels``.
+        - ``platform`` (str): e.g. ``"slack"``, ``"discord"``, ``"file"``.
+        - ``display_name`` (str): human label, e.g. ``"Acme Workspace"``.
+        - ``status`` (str): connection health, e.g. ``"connected"``.
+        - ``last_synced_at`` (str|null): ISO timestamp of the most recent sync of a
+          PICKED channel; ``null`` when the pick-list is empty (see caveat below).
+        - ``selected_channel_count`` (int): size of the sync pick-list (see caveat).
+        - ``source`` (str): how the connection was created, e.g. ``"oauth"``.
 
-        - ``selected_channel_count`` is the size of the user's **sync pick-list**
-          for this connection. It is NOT the number of channels available on
-          the platform. ``selected_channel_count: 0`` means no channels are
-          explicitly opted into sync — it does NOT mean the connection has no
-          channels. A Slack workspace with 0 selected channels can still have
-          dozens of channels the bot can read.
-        - ``last_synced_at`` is scoped to the same pick-list. When the pick-list
-          is empty, this field is ``null`` even if channels on the connection
-          were synced through another path. Do not use it to infer "this
-          connection has never been used."
+        Caveats (do NOT misread): ``selected_channel_count`` is the user's opted-in
+        sync pick-list, NOT how many channels exist. A value of ``0`` does not mean
+        the connection is empty — a Slack workspace with 0 picks can still have
+        dozens of bot-readable channels. ``last_synced_at`` is scoped to the same
+        pick-list, so an empty pick-list yields ``null`` even if channels were synced
+        another way. For ground-truth channel availability, always call
+        ``list_channels(connection_id)`` — never infer it from these counts.
 
-        **To discover actual channels, always call ``list_channels(connection_id)``**
-        — that reads the live platform catalog (scoped to channels the bot can
-        read) and is the ground truth. Do NOT infer channel availability from
-        ``selected_channel_count``.
-
-        Returns: ``{connections: [<connection dict>, ...]}``
+        Error modes: returns ``{"error": "authentication_missing"}`` when no valid
+        principal is attached. Never raises access-denied (output is self-scoped).
         """
         principal_id = _get_principal_id(ctx)
         if not principal_id:
@@ -102,36 +112,48 @@ def register_discovery_tools(mcp: FastMCP) -> None:
     @mcp.tool(name="list_channels")
     async def list_channels(
         connection_id: Annotated[
-            str, "The connection id to list channels for (from list_connections)"
+            str,
+            "Id of the connection whose channels to list, obtained from "
+            "list_connections or whoami. Format: alphanumeric/_/:/- up to 128 "
+            'chars. Example: "conn_abc123".',
         ],
         ctx: Context,
     ) -> dict:
-        """Return the channels the bot can actually read on a connection.
+        """List the channels the bot can actually read on one connection — the
+        ground-truth source for what channels exist and their indexing state.
 
-        This is the **ground truth** for what channels exist on this connection —
-        always prefer it over ``list_connections.selected_channel_count``.
+        Call this after ``list_connections``/``whoami`` (you need a valid
+        ``connection_id``), once per connection you care about, BEFORE any retrieval
+        tool (``ask_channel``, ``search_channel_facts``, ``get_wiki_page``, ...) so
+        you can pass a real ``channel_id``. Prefer this over
+        ``list_connections.selected_channel_count`` — that count is a sync pick-list,
+        not the channel inventory.
 
-        Each channel entry contains: ``channel_id``, ``name``, ``platform``,
-        ``last_sync_ts``, ``sync_status``, and ``message_count_estimate``.
+        Latency: instant for cached results; may take a few seconds when it queries
+        the live platform bridge. Read-only — does not trigger a sync.
 
-        Scoping: the returned set matches the dashboard's "CONNECTED" view.
-        When the user has picked specific channels for sync
-        (``selected_channels`` non-empty on the connection), those are returned.
-        Otherwise every channel where the bot is a member (``is_member=True``)
-        is returned — because those are exactly the channels the bot can read
-        messages from. File-import connections return every file that has been
-        uploaded.
+        Returns ``{"channels": [<entry>, ...]}`` (empty list if none/bridge error).
+        Each entry:
+        - ``channel_id`` (str): pass to retrieval/sync tools, e.g. ``"C0A955E29MX"``.
+        - ``name`` (str): display name, e.g. ``"engineering"``.
+        - ``platform`` (str): e.g. ``"slack"``, ``"discord"``, ``"file"``.
+        - ``last_sync_ts`` (str|null): ISO timestamp of last index, ``null`` if never.
+        - ``sync_status`` (str): ``"synced"``, ``"never_synced"``, or ``"n/a"`` (file
+          connections). ``"never_synced"`` is normal and does NOT mean the channel is
+          inaccessible — it just is not indexed yet; call ``trigger_sync(channel_id)``
+          to ingest it before querying its content.
+        - ``message_count_estimate`` (int|null): approx synced messages, ``null`` if
+          not yet synced.
 
-        When to use: after ``list_connections``, to enumerate real channels
-        before calling any retrieval tool. Always call this per connection you
-        care about. ``sync_status="never_synced"`` on a channel is normal and
-        does NOT mean the channel is inaccessible — it just hasn't been indexed
-        yet. ``trigger_sync(channel_id)`` can be used to ingest it.
+        Scoping: matches the dashboard "CONNECTED" view. If the user picked specific
+        channels for sync, those are returned; otherwise every channel where the bot
+        is a member (and thus can read) is returned. File connections return every
+        uploaded file.
 
-        Raises a structured ``connection_access_denied`` error if the principal
-        does not own the requested connection — connection existence is not leaked.
-
-        Returns: ``{channels: [...]}`` or ``{error: "connection_access_denied", ...}``
+        Error modes: ``{"error": "connection_access_denied", "connection_id": ...}``
+        if you do not own the connection (existence is not leaked);
+        ``{"error": "invalid_parameter", "parameter": "connection_id"}`` for a
+        malformed id; ``{"error": "authentication_missing"}`` if no principal.
         """
         principal_id = _get_principal_id(ctx)
         if not principal_id:

--- a/src/beever_atlas/api/mcp_server/_tools_graph.py
+++ b/src/beever_atlas/api/mcp_server/_tools_graph.py
@@ -20,22 +20,49 @@ def register_graph_tools(mcp: FastMCP) -> None:
 
     @mcp.tool(name="find_experts")
     async def find_experts(
-        channel_id: Annotated[str, "The channel id (from list_channels)"],
-        topic: Annotated[str, "Topic or keyword to find subject-matter experts for"],
+        channel_id: Annotated[
+            str,
+            "Required. The channel id to search within, obtained from "
+            "list_channels (e.g. 'ch-eng'). Not a human channel name.",
+        ],
+        topic: Annotated[
+            str,
+            "Required. Topic or keyword to rank experts on, e.g. 'kubernetes', "
+            "'billing', 'auth'. Matched against knowledge-graph edges, so use a "
+            "concept the channel actually discusses.",
+        ],
         ctx: Context,
-        limit: Annotated[int, "Maximum number of experts to return (1–20)"] = 5,
+        limit: Annotated[
+            int,
+            "Maximum number of experts to return. Range 1–20, default 5. Values "
+            "outside the range are silently clamped (e.g. 50 -> 20, 0 -> 1).",
+        ] = 5,
     ) -> dict:
-        """Identify the most knowledgeable people about a topic in a channel.
+        """Rank the PEOPLE most knowledgeable about a topic in one channel.
 
-        Scores channel members by graph-edge frequency for the topic and returns
-        a ranked list. Each entry includes ``handle``, ``expertise_score``,
-        ``fact_count``, and ``top_topics``.
+        Call this to answer "who should I ask about X in #channel?" or to
+        route a question to the right person. This is the only tool that
+        ranks PEOPLE; use ``search_channel_facts`` / ``find_facts`` to find
+        FACTS, and ``find_experts`` only when you specifically need a human.
 
-        When to use: to answer "who knows the most about X in #channel?" or
-        to find the right person to ask for a specific domain. Use
-        ``search_channel_facts`` to find facts, not people.
+        Prerequisite: a ``channel_id`` from ``list_channels``. Do NOT call
+        with a channel display name.
 
-        Returns: ``{experts: [...]}`` or ``{error: "channel_access_denied", ...}``
+        Returns (instant, read-only, no side effects):
+        ``{"experts": [...]}`` — a list ranked by ``expertise_score``
+        descending. Each entry has ``handle`` (e.g. '@dana'),
+        ``expertise_score`` (relative float, higher = more authoritative;
+        not a fixed 0–1 scale, only meaningful for ranking within this
+        result), ``fact_count`` (number of contributing facts), and
+        ``top_topics`` (list of related topics that person engages with).
+        An empty list means no graph signal for that topic — not an error.
+
+        Error modes: ``{"error": "authentication_missing"}`` if the caller
+        is unauthenticated; ``{"error": "channel_access_denied",
+        "channel_id": ...}`` if the principal cannot read the channel;
+        ``{"error": "invalid_parameter", ...}`` for a malformed
+        ``channel_id``. Other backend failures degrade gracefully to
+        ``{"experts": []}``.
         """
         principal_id = _get_principal_id(ctx)
         if not principal_id:
@@ -67,25 +94,55 @@ def register_graph_tools(mcp: FastMCP) -> None:
 
     @mcp.tool(name="search_relationships")
     async def search_relationships(
-        channel_id: Annotated[str, "The channel id (from list_channels)"],
+        channel_id: Annotated[
+            str,
+            "Required. The channel id to search within, obtained from "
+            "list_channels (e.g. 'ch-eng'). Not a human channel name.",
+        ],
         entities: Annotated[
             list[str],
-            "List of entity names to find relationships for",
+            "Required. One or more entity NAMES to connect, e.g. "
+            "['Postgres', 'billing-service'] or ['Dana']. These are knowledge-"
+            "graph node names (people, systems, concepts), not channel ids. "
+            "Provide at least one; provide two+ to find paths between them.",
         ],
         ctx: Context,
-        hops: Annotated[int, "Number of graph hops to traverse (1–4)"] = 2,
+        hops: Annotated[
+            int,
+            "How many graph edges to traverse out from the entities. Range 1–4, "
+            "default 2. Larger values return wider but noisier subgraphs and are "
+            "slower. Out-of-range values are silently clamped (e.g. 9 -> 4).",
+        ] = 2,
     ) -> dict:
-        """Traverse the knowledge graph to find relationships between entities.
+        """Find how named ENTITIES connect in a channel's knowledge graph.
 
-        Returns a subgraph of nodes and edges connecting the requested entities.
-        Each node has ``name`` and ``type``; each edge has ``source``, ``target``,
-        ``type``, ``confidence``, and ``context``.
+        Call this to answer "how is X related to Y?" or "what touches the
+        billing service?" by returning the subgraph of nodes and edges
+        around the given entities. This explores the KNOWLEDGE graph of
+        entities/relationships — distinct from ``get_wiki_graph``, which
+        returns the wiki PAGE-LINK graph (which wiki pages reference which).
+        Use ``find_experts`` to rank people and ``trace_decision_history``
+        to follow decision supersession.
 
-        When to use: to answer "how is X related to Y?" or to explore entity
-        connections in a channel's knowledge graph. Use ``find_experts`` to
-        find people, not relationships.
+        Prerequisite: a ``channel_id`` from ``list_channels`` and at least
+        one entity name. Names should match how the channel refers to the
+        entity; unknown names simply yield an empty subgraph.
 
-        Returns: ``{nodes, edges, text, entities_searched}`` or ``{error: ...}``
+        Returns (instant for small hop counts, read-only, no side effects):
+        ``{"nodes": [...], "edges": [...], "text": str,
+        "entities_searched": [...]}``. Each node has ``name`` and ``type``
+        (e.g. 'person', 'system', 'concept'); each edge has ``source``,
+        ``target``, ``type`` (relationship label), ``confidence`` (0–1,
+        extraction confidence), and ``context`` (snippet explaining the
+        edge). ``text`` is a human-readable summary. Empty ``nodes``/
+        ``edges`` means no connections were found — not an error.
+
+        Error modes: ``{"error": "authentication_missing"}`` if
+        unauthenticated; ``{"error": "channel_access_denied",
+        "channel_id": ...}`` if the channel is not readable; ``{"error":
+        "invalid_parameter", ...}`` for a malformed ``channel_id``. Other
+        backend failures degrade to ``{"nodes": [], "edges": [],
+        "channel_id": ...}``.
         """
         principal_id = _get_principal_id(ctx)
         if not principal_id:
@@ -120,25 +177,49 @@ def register_graph_tools(mcp: FastMCP) -> None:
 
     @mcp.tool(name="trace_decision_history")
     async def trace_decision_history(
-        channel_id: Annotated[str, "The channel id (from list_channels)"],
+        channel_id: Annotated[
+            str,
+            "Required. The channel id to trace within, obtained from "
+            "list_channels (e.g. 'ch-eng'). Not a human channel name.",
+        ],
         topic: Annotated[
             str,
-            "Topic or decision to trace (e.g. 'database choice', 'API versioning')",
+            "Required. The decision area to trace, e.g. 'database choice', "
+            "'API versioning', 'auth provider'. Matched against decision "
+            "entities in the knowledge graph; use the subject of the decision, "
+            "not a yes/no question.",
         ],
         ctx: Context,
     ) -> dict:
-        """Trace the history of decisions made about a topic in a channel.
+        """Reconstruct how a decision EVOLVED over time in a channel.
 
-        Follows ``SUPERSEDES`` edges in the knowledge graph to reconstruct
-        the decision timeline. Each item includes ``entity``, ``superseded_by``,
-        ``relationship``, ``confidence``, ``context``, and ``position``.
+        Call this to answer "how did the team arrive at the current approach
+        for X?" or "what earlier choices were overridden?" It walks
+        ``SUPERSEDES`` edges in the knowledge graph to build an ordered
+        timeline of superseded → current decisions. Distinct from
+        ``find_decisions`` (which lists current decision facts with no
+        history) and ``search_channel_facts`` (current state only, no
+        chronology); use this tool specifically when you need the
+        chronological "why we changed" trail.
 
-        When to use: to answer "how did the team arrive at the current approach
-        for X?" or "what earlier decisions were overridden?" Use
-        ``search_channel_facts`` to find facts about the current state without
-        historical context.
+        Prerequisite: a ``channel_id`` from ``list_channels``. Best results
+        on mature channels where decisions have been revised; new channels
+        often have no supersession chain yet (empty result, not an error).
 
-        Returns: ``{decisions: [...]}`` or ``{error: "channel_access_denied", ...}``
+        Returns (instant, read-only, no side effects):
+        ``{"decisions": [...]}`` ordered oldest → newest. Each item has
+        ``entity`` (the decision that was made), ``superseded_by`` (the
+        decision that replaced it, or empty for the current one),
+        ``relationship`` (edge label, typically 'SUPERSEDES'),
+        ``confidence`` (0–1 extraction confidence), ``context`` (snippet
+        explaining the change), and ``position`` (0-based index in the
+        timeline). An empty list means no recorded supersession chain.
+
+        Error modes: ``{"error": "authentication_missing"}`` if
+        unauthenticated; ``{"error": "channel_access_denied",
+        "channel_id": ...}`` if the channel is not readable; ``{"error":
+        "invalid_parameter", ...}`` for a malformed ``channel_id``. Other
+        backend failures degrade to ``{"decisions": []}``.
         """
         principal_id = _get_principal_id(ctx)
         if not principal_id:

--- a/src/beever_atlas/api/mcp_server/_tools_orchestration.py
+++ b/src/beever_atlas/api/mcp_server/_tools_orchestration.py
@@ -1,5 +1,4 @@
-"""Orchestration tools: trigger_sync, refresh_wiki, get_job_status
-(Phase 5b, tasks 5.2–5.4)."""
+"""Long-running-job orchestration tools: trigger_sync, refresh_wiki, get_job_status."""
 
 from __future__ import annotations
 
@@ -22,43 +21,61 @@ def register_orchestration_tools(mcp: FastMCP) -> None:
     @mcp.tool(
         name="trigger_sync",
         description=(
-            "Trigger an incremental or full sync of a channel's messages into the "
-            "Atlas knowledge base. Returns a job envelope "
-            "{job_id, status_uri, status: 'queued'} within 5 seconds; the actual "
-            "ingestion runs in the background. Poll atlas://job/<job_id> or call "
-            "get_job_status to track progress.\n\n"
-            "IMPORTANT — only call when the user EXPLICITLY asks to refresh or sync "
-            "a channel, OR when retrieval tools return empty/stale results AND the "
-            "channel's last_sync_ts is beyond 24 hours ago. Otherwise prefer existing "
-            "indexed data — sync is expensive and rate-limited to 5/min per principal. "
-            "Do NOT call before every question or as a precautionary step.\n\n"
-            "If a queued or running sync job already exists for the same channel, "
-            "the existing job_id is returned (idempotent). A new job is only created "
-            "when no active job exists, or after a previous job has completed or failed.\n\n"
-            "sync_type: 'incremental' (default — fetches only new messages since last "
-            "sync), 'full' (re-fetches all messages; expensive), or 'auto' (server "
-            "chooses based on sync history).\n\n"
-            "connection_id: OPTIONAL but STRONGLY RECOMMENDED when the workspace has "
-            "multiple same-platform connections (e.g. two Slack workspaces). Without "
-            "it, the server falls back to matching the channel against each "
-            "connection's selected_channels pick-list; if the channel hasn't been "
-            "added to any pick-list yet, the sync may route to the wrong connection "
-            "and fail with channel_not_found. Prefer to pass the connection_id you "
-            "got from list_channels — it disambiguates the target connection "
-            "deterministically."
+            "Ingest a chat channel's messages into the Atlas knowledge base so they "
+            "become searchable by the retrieval tools (ask_channel, "
+            "search_channel_facts, search_memory). This is the WRITE/ingestion entry "
+            "point; it does NOT answer questions — use the retrieval tools for that. "
+            "It is distinct from refresh_wiki, which only re-renders wiki pages from "
+            "already-ingested facts.\n\n"
+            "WHEN TO USE: only when the user EXPLICITLY asks to sync/refresh a "
+            "channel, OR when retrieval tools return empty/stale results AND the "
+            "channel was last synced over 24h ago. WHEN NOT TO USE: do not call "
+            "before every question or as a precautionary warm-up — prefer the data "
+            "already indexed. Sync is expensive and rate-limited (cooldown) per "
+            "channel.\n\n"
+            "PREREQUISITES: get a valid channel_id (and ideally connection_id) from "
+            "list_channels first. The calling principal must have access to the "
+            "channel.\n\n"
+            "LATENCY & SIDE EFFECTS: asynchronous. Returns within ~5s with a job "
+            "envelope while ingestion runs in the background; this WRITES facts to "
+            "the knowledge base. Shape: "
+            "{job_id: 'job_abc123', status_uri: 'atlas://job/job_abc123', "
+            "status: 'queued'}. Track progress by calling get_job_status(job_id) or "
+            "reading the atlas://job/<job_id> resource.\n\n"
+            "IDEMPOTENT: if a queued or running sync already exists for the channel, "
+            "its existing job_id is returned instead of starting a duplicate. A new "
+            "job is created only when no active job exists, or after the prior one "
+            "completed or failed.\n\n"
+            "ERROR MODES (returned as {error: ...}, never raised): "
+            "'authentication_missing' (no principal); "
+            "'invalid_parameter' (malformed channel_id/connection_id); "
+            "'channel_access_denied' (principal lacks access); "
+            "'cooldown_active' (synced too recently; includes retry_after_seconds); "
+            "'service_unavailable' (backing service down; includes service); "
+            "'internal_error' (unexpected failure)."
         ),
     )
     async def trigger_sync(
-        channel_id: Annotated[str, "The channel id to sync (from list_channels)"],
+        channel_id: Annotated[
+            str,
+            "Channel to sync, e.g. 'ch_eng_backend'. Get it from list_channels. Required.",
+        ],
         ctx: Context,
         sync_type: Annotated[
-            str, "Sync mode: 'incremental' (default), 'full', or 'auto'"
+            str,
+            "Sync mode. 'incremental' (default) fetches only messages newer than the "
+            "last sync (cheap); 'full' re-fetches the entire history (expensive); "
+            "'auto' lets the server pick based on sync history. Valid values: "
+            "'incremental' | 'full' | 'auto'.",
         ] = "incremental",
         connection_id: Annotated[
             str | None,
-            "Optional: the connection the channel belongs to (from list_connections / "
-            "list_channels). Pass it when the user has multiple same-platform "
-            "connections to avoid mis-routing.",
+            "Platform connection that owns the channel, e.g. 'conn_slack_acme'. Get "
+            "it from list_channels or list_connections. Default None. Optional but "
+            "STRONGLY RECOMMENDED when multiple same-platform connections exist (e.g. "
+            "two Slack workspaces): without it the server matches the channel against "
+            "each connection's selected_channels pick-list and may mis-route the sync "
+            "if the channel was never added to a pick-list.",
         ] = None,
     ) -> dict:
         principal_id = _get_principal_id(ctx)
@@ -108,27 +125,46 @@ def register_orchestration_tools(mcp: FastMCP) -> None:
     @mcp.tool(
         name="refresh_wiki",
         description=(
-            "Regenerate pre-compiled wiki pages for a channel from its ingested facts. "
-            "Returns a job envelope {job_id, status_uri, status: 'queued'} within 5 "
-            "seconds; generation runs in the background.\n\n"
-            "Expensive — only call after a fresh sync has added new facts (i.e., after "
-            "trigger_sync completes), or when the user explicitly requests wiki "
-            "regeneration. Do NOT call routinely — wiki pages are rebuilt automatically "
-            "as part of the standard sync pipeline.\n\n"
-            "page_types: optional subset of page types to regenerate. Valid values: "
-            "overview, faq, decisions, people, glossary, activity, topics. "
-            "Omit to regenerate all pages."
+            "Re-render a channel's pre-compiled wiki pages (overview, FAQ, decisions, "
+            "etc.) from facts ALREADY ingested into the knowledge base. Use this to "
+            "rebuild stale wiki content; the refreshed pages are then read with "
+            "get_wiki_page / read_wiki_page / list_wiki_pages. It does NOT ingest new "
+            "messages — that is trigger_sync's job — and it does NOT answer questions "
+            "(use the retrieval tools for that).\n\n"
+            "WHEN TO USE: after a sync has added new facts (i.e. after trigger_sync "
+            "completes), or when the user explicitly asks to regenerate the wiki. "
+            "WHEN NOT TO USE: do not call routinely — the standard sync pipeline "
+            "already rebuilds wiki pages automatically, so calling this after a normal "
+            "sync is usually redundant.\n\n"
+            "PREREQUISITES: a valid channel_id from list_channels; the channel must "
+            "have ingested facts (run trigger_sync first if it has none); the calling "
+            "principal must have access.\n\n"
+            "LATENCY & SIDE EFFECTS: asynchronous and expensive (runs an LLM "
+            "generation pass). Returns within ~5s with a job envelope while "
+            "generation runs in the background; this WRITES/overwrites the channel's "
+            "wiki pages. Shape: "
+            "{job_id: 'job_def456', status_uri: 'atlas://job/job_def456', "
+            "status: 'queued'}. Track progress with get_job_status(job_id) or the "
+            "atlas://job/<job_id> resource.\n\n"
+            "ERROR MODES (returned as {error: ...}, never raised): "
+            "'authentication_missing'; 'invalid_parameter' (malformed channel_id); "
+            "'channel_access_denied'; "
+            "'cooldown_active' (refreshed too recently; includes retry_after_seconds); "
+            "'service_unavailable' (includes service); 'internal_error'."
         ),
     )
     async def refresh_wiki(
         channel_id: Annotated[
             str,
-            "The channel id to regenerate wiki pages for (from list_channels)",
+            "Channel whose wiki pages to regenerate, e.g. 'ch_eng_backend'. Get it "
+            "from list_channels. Required.",
         ],
         ctx: Context,
         page_types: Annotated[
             list[str] | None,
-            "Optional list of page types to regenerate: overview, faq, decisions, people, glossary, activity, topics",
+            "Subset of wiki page types to regenerate, e.g. ['overview', 'faq']. "
+            "Valid values: 'overview' | 'faq' | 'decisions' | 'people' | 'glossary' | "
+            "'activity' | 'topics'. Default None, which regenerates ALL page types.",
         ] = None,
     ) -> dict:
         principal_id = _get_principal_id(ctx)
@@ -169,21 +205,38 @@ def register_orchestration_tools(mcp: FastMCP) -> None:
     @mcp.tool(
         name="get_job_status",
         description=(
-            "Poll the state of a long-running job created by trigger_sync or "
-            "refresh_wiki. Returns a structured dict: "
-            "{job_id, kind, status, progress, started_at, updated_at, ended_at, "
-            "result, error, target}.\n\n"
-            "status values: queued, running, done, error, cancelled.\n"
-            "progress: fraction 0.0–1.0 or null when not yet available.\n\n"
-            "Returns {error: 'job_not_found', job_id: ...} for jobs that do not "
-            "exist or are not owned by the calling principal — no information about "
-            "other principals' jobs is disclosed.\n\n"
-            "Use atlas://job/<id> as a resource-read alternative when your MCP "
-            "client prefers resources/read over tool calls."
+            "Check the progress and result of a background job started by "
+            "trigger_sync or refresh_wiki. Call this AFTER one of those tools "
+            "returns a job_id, to learn whether the sync/wiki-generation has "
+            "finished. This is read-only and instant; it neither starts work nor "
+            "answers channel questions (use the retrieval tools for that).\n\n"
+            "WHEN TO USE: poll after trigger_sync/refresh_wiki to wait for "
+            "completion before reading the freshly ingested/regenerated data. "
+            "POLLING CADENCE: wait ~2–3s between polls and back off on repeats; do "
+            "NOT hot-loop. Sync/wiki jobs typically take seconds to a few minutes — "
+            "stop once status is a terminal value (done / error / cancelled).\n\n"
+            "PREREQUISITES: a job_id previously returned by trigger_sync or "
+            "refresh_wiki; the job must belong to the calling principal.\n\n"
+            "LATENCY & SIDE EFFECTS: instant, no side effects.\n\n"
+            "RETURNS a dict: {job_id, kind ('sync' | 'wiki'), status, progress, "
+            "started_at, updated_at, ended_at, result, error, target}. "
+            "status: 'queued' | 'running' | 'done' | 'error' | 'cancelled'. "
+            "progress: float 0.0–1.0, or null when not yet available. "
+            "result/error are populated only once the job reaches a terminal state.\n\n"
+            "ERROR MODES (returned as {error: ...}): 'authentication_missing'; "
+            "'invalid_parameter' (malformed job_id); 'job_not_found' — returned both "
+            "for ids that do not exist AND for jobs owned by another principal, so no "
+            "cross-principal job information is disclosed.\n\n"
+            "Reading the atlas://job/<job_id> resource is an equivalent alternative "
+            "for clients that prefer resources/read over tool calls."
         ),
     )
     async def get_job_status(
-        job_id: Annotated[str, "The job id returned by trigger_sync or refresh_wiki"],
+        job_id: Annotated[
+            str,
+            "Job to inspect, e.g. 'job_abc123'. This is the job_id returned by "
+            "trigger_sync or refresh_wiki. Required.",
+        ],
         ctx: Context,
     ) -> dict:
         principal_id = _get_principal_id(ctx)

--- a/src/beever_atlas/api/mcp_server/_tools_retrieval.py
+++ b/src/beever_atlas/api/mcp_server/_tools_retrieval.py
@@ -1,5 +1,8 @@
-"""Retrieval tools: ask_channel, search_channel_facts, get_wiki_page,
-get_recent_activity, search_media_references (Phase 3, tasks 3.4–3.5)."""
+"""Retrieval + wiki tools (17): ask_channel, search_channel_facts, get_wiki_page,
+get_recent_activity, search_media_references, search_memory, lint_wiki,
+get_extraction_status, read_wiki_page, list_wiki_pages, get_wiki_graph,
+read_wiki_module, find_decisions, get_tensions, find_facts, read_wiki_section,
+read_provenance."""
 
 from __future__ import annotations
 
@@ -20,38 +23,55 @@ def register_retrieval_tools(mcp: FastMCP) -> None:
 
     @mcp.tool(name="ask_channel", timeout=90.0)
     async def ask_channel(
-        channel_id: Annotated[str, "The channel id to query (from list_channels)"],
-        question: Annotated[str, "The natural-language question to answer"],
+        channel_id: Annotated[
+            str,
+            "Channel id to query. Get it from list_channels (e.g. 'ch-eng'). Required.",
+        ],
+        question: Annotated[
+            str,
+            "Natural-language question, 1-4000 chars (e.g. 'What database did we pick "
+            "and why?'). Longer questions return error 'invalid_parameter'. Required.",
+        ],
         ctx: Context,
         mode: Annotated[
             str,
-            "QA mode: 'quick' (fast BM25), 'deep' (full ADK pipeline), or 'summarize'",
+            "Retrieval depth. One of: 'quick' (BM25 only, no reasoning, ~3s), "
+            "'deep' (full pipeline with graph + multi-hop reasoning, ~20-60s), "
+            "'summarize' (structured summary, ~10-30s). Default 'deep'.",
         ] = "deep",
         session_id: Annotated[
             str | None,
-            "Session id for conversation continuity; defaults to a per-principal session",
+            "Optional session id for multi-turn continuity (e.g. 'sess-abc123' from "
+            "start_new_session). Omit for a per-principal default session. Default null.",
         ] = None,
     ) -> dict:
-        """Answer a natural-language question about a channel's knowledge base.
+        """Answer a natural-language QUESTION about one channel with synthesized,
+        cited reasoning. The flagship retrieval tool — call it when the user asks
+        anything that needs an ANSWER rather than raw rows.
 
-        This is the FLAGSHIP retrieval tool. It invokes the full ADK QA pipeline
-        (embeddings + BM25 hybrid search + graph context + optional multi-hop
-        reasoning) and returns a structured answer with citations.
+        When to use: any question about a channel's content where you want a
+        composed answer with citations and reasoning across multiple messages
+        ("what did we decide about X", "why did the project slip").
 
-        When to use: whenever the user asks a question about channel content,
-        wants cited facts, or needs reasoning across multiple messages.
-        Prefer ``search_channel_facts`` for exact keyword search without inference.
+        When NOT to use: exact keyword/semantic lookup of individual facts (use
+        search_channel_facts); cross-channel recall when you don't know which
+        channel holds the answer (use search_memory); a deterministic substring
+        scan (use find_facts). Those are faster and return raw rows, not prose.
 
-        mode options:
-        - ``"quick"``: fast BM25-only retrieval, no ADK reasoning, ~3s
-        - ``"deep"``: full ADK pipeline with graph context, ~20–60s (default)
-        - ``"summarize"``: structured summary with wiki pages, ~10–30s
+        Prerequisites: a channel_id from list_channels.
 
-        The tool enforces a 90-second hard cap. On timeout, returns
-        ``{error: "answer_timeout"}``. On channel access denial, returns
-        ``{error: "channel_access_denied"}``.
+        Returns (instant for 'quick', long-running up to a 90s hard cap for
+        'deep'/'summarize'): a dict
+        ``{answer: str, citations: [{fact_id, text, permalink, author, ts}],
+        follow_ups: [str], metadata: {mode, ...}}``. Read-only — no side effects,
+        triggers no jobs.
 
-        Returns: ``{answer, citations, follow_ups, metadata}``
+        Error modes (all returned as ``{error: ...}`` dicts, never exceptions):
+        'authentication_missing' (no principal); 'invalid_parameter' (empty/over-
+        4000-char question, or mode not in quick/deep/summarize);
+        'channel_access_denied' (token lacks access to channel_id);
+        'answer_timeout' (exceeded the 90s cap — retry with mode='quick');
+        'adk_error' (internal pipeline failure).
         """
         principal_id = _get_principal_id(ctx)
         if not principal_id:
@@ -130,26 +150,47 @@ def register_retrieval_tools(mcp: FastMCP) -> None:
 
     @mcp.tool(name="search_channel_facts")
     async def search_channel_facts(
-        channel_id: Annotated[str, "The channel id to search (from list_channels)"],
-        query: Annotated[str, "Search query — BM25+vector hybrid over atomic facts"],
+        channel_id: Annotated[
+            str,
+            "Channel id to search. Get it from list_channels (e.g. 'ch-eng'). Required.",
+        ],
+        query: Annotated[
+            str,
+            "Search query, keyword or natural phrase (e.g. 'postgres migration'). "
+            "Matched with BM25+vector hybrid retrieval. Required.",
+        ],
         ctx: Context,
-        time_scope: Annotated[str, "'any' (all time) or 'recent' (last 30 days)"] = "any",
-        limit: Annotated[int, "Maximum number of facts to return (1–50)"] = 10,
+        time_scope: Annotated[
+            str,
+            "Time window. 'any' = all facts (default), 'recent' = last 30 days only.",
+        ] = "any",
+        limit: Annotated[
+            int,
+            "Max facts to return, 1-50 (values outside the range are clamped). Default 10.",
+        ] = 10,
     ) -> dict:
-        """Search atomic facts stored from a channel using BM25+vector hybrid retrieval.
+        """Find SPECIFIC facts in ONE channel by hybrid (BM25 + vector) search and
+        return them as raw, ranked rows. Call it when you want the cited source
+        facts themselves, not a composed answer.
 
-        Each returned fact includes ``text``, ``author``, ``timestamp``,
-        ``permalink``, ``channel_id``, ``confidence``, and ``topic_tags``.
+        When to use: targeted lookup of facts in a known channel ("find facts
+        about the postgres migration"). Faster and more precise than ask_channel
+        for retrieval-only tasks.
 
-        When to use: for targeted keyword or semantic search when you need
-        specific facts with citations. Faster and more precise than ``ask_channel``
-        for lookup queries. Use ``ask_channel`` when you need synthesized answers
-        with reasoning across multiple facts.
+        When NOT to use: you need a synthesized answer with reasoning (use
+        ask_channel); you don't know which channel holds the facts (use
+        search_memory, which fans this same search across every accessible
+        channel); you want a deterministic substring match rather than ranked
+        relevance (use find_facts).
 
-        time_scope: ``"any"`` returns all facts; ``"recent"`` restricts to the
-        last 30 days. Default: ``"any"``.
+        Prerequisites: a channel_id from list_channels.
 
-        Returns: ``{facts: [...]}`` or ``{error: "channel_access_denied", ...}``
+        Returns (instant, read-only): ``{facts: [{text, author, timestamp,
+        permalink, channel_id, confidence, topic_tags}, ...]}``. No side effects.
+
+        Error modes (returned as dicts): 'authentication_missing' (no principal);
+        'channel_access_denied' (token lacks access to channel_id). On any other
+        internal failure it returns an empty ``{facts: []}`` rather than erroring.
         """
         principal_id = _get_principal_id(ctx)
         if not principal_id:
@@ -187,27 +228,43 @@ def register_retrieval_tools(mcp: FastMCP) -> None:
 
     @mcp.tool(name="get_wiki_page")
     async def get_wiki_page(
-        channel_id: Annotated[str, "The channel id (from list_channels)"],
+        channel_id: Annotated[
+            str,
+            "Channel id. Get it from list_channels (e.g. 'ch-eng'). Required.",
+        ],
         ctx: Context,
         page_type: Annotated[
             str,
-            "Wiki page type: overview, faq, decisions, people, glossary, activity, topics",
+            "Which fixed page to fetch. One of exactly: 'overview', 'faq', "
+            "'decisions', 'people', 'glossary', 'activity', 'topics'. "
+            "Default 'overview'.",
         ] = "overview",
     ) -> dict:
-        """Retrieve a pre-compiled wiki page for a channel.
+        """Fetch one pre-compiled wiki page from the LEGACY fixed-page set (overview,
+        faq, decisions, people, glossary, activity, topics). Call it for a fast,
+        whole-channel summary keyed by a fixed page_type.
 
-        Wiki pages are generated offline during the sync pipeline and contain
-        summarised, structured knowledge: ``overview`` (channel purpose and key
-        topics), ``faq`` (common questions), ``decisions`` (key decisions made),
-        ``people`` (active contributors), ``glossary`` (domain terms), and more.
+        Disambiguation: this is the legacy fixed-page surface. For the redesigned
+        slug-keyed wiki — arbitrary topic/entity pages, structured kind payloads,
+        and the cross-link graph — use list_wiki_pages to discover pages then
+        read_wiki_page(slug=...). Prefer those for anything beyond the seven
+        fixed pages above.
 
-        When to use: for quick structured summaries without invoking the full QA
-        pipeline. Faster than ``ask_channel`` but less precise for specific
-        queries. Use ``ask_channel`` when the wiki page doesn't have the answer.
+        When to use: you want a quick structured summary of a known aspect of a
+        channel without running the QA pipeline. When NOT to use: you need a
+        specific answer (use ask_channel) or a non-fixed wiki topic (use
+        read_wiki_page).
 
-        Returns the page dict verbatim (``page_type``, ``channel_id``,
-        ``content``, ``summary``, ``text``), or ``null`` if the page has not
-        been generated yet, or ``{error: "channel_access_denied"}`` on denial.
+        Prerequisites: a channel_id from list_channels.
+
+        Returns (instant, read-only): the page dict
+        ``{page_type, channel_id, content, summary, text}``. ``content`` is null
+        when that page has not been generated yet (run a sync / refresh_wiki
+        first). No side effects.
+
+        Error modes (returned as dicts): 'authentication_missing' (no principal);
+        'channel_access_denied' (token lacks access to channel_id). Other internal
+        failures return the page dict with ``content: null``.
         """
         principal_id = _get_principal_id(ctx)
         if not principal_id:
@@ -244,26 +301,43 @@ def register_retrieval_tools(mcp: FastMCP) -> None:
 
     @mcp.tool(name="get_recent_activity")
     async def get_recent_activity(
-        channel_id: Annotated[str, "The channel id (from list_channels)"],
+        channel_id: Annotated[
+            str,
+            "Channel id. Get it from list_channels (e.g. 'ch-eng'). Required.",
+        ],
         ctx: Context,
-        days: Annotated[int, "Look-back window in days (1–90)"] = 7,
+        days: Annotated[
+            int,
+            "Look-back window in days, 1-90 (out-of-range values are clamped). Default 7.",
+        ] = 7,
         topic: Annotated[
             str | None,
-            "Optional topic filter — narrows search to facts related to this topic",
+            "Optional topic filter (e.g. 'deployment'); keeps only facts tagged "
+            "with that topic. Omit for all topics. Default null.",
         ] = None,
-        limit: Annotated[int, "Maximum number of activity items to return (1–50)"] = 20,
+        limit: Annotated[
+            int,
+            "Max activity items, 1-50 (out-of-range values are clamped). Default 20.",
+        ] = 20,
     ) -> dict:
-        """Return the most recent activity from a channel, optionally filtered by topic.
+        """List the most RECENT facts from one channel, newest first, optionally
+        scoped to a topic. Call it for time-bounded "what happened lately"
+        questions.
 
-        Results are sorted by timestamp descending and include ``text``,
-        ``author``, ``timestamp``, ``channel_id``, ``topic_tags``, and ``fact_id``.
+        When to use: "what's been discussed in this channel this week", "what
+        happened with topic X in the last N days". When NOT to use: search not
+        bounded by recency (use search_channel_facts); a synthesized answer or
+        reasoning across the items (use ask_channel).
 
-        When to use: to answer "what has been discussed recently in #channel?"
-        or "what happened with topic X in the last N days?" Use ``ask_channel``
-        when you need reasoning or synthesis across multiple activity items.
-        Use ``search_channel_facts`` for non-time-bounded search.
+        Prerequisites: a channel_id from list_channels.
 
-        Returns: ``{activity: [...]}`` or ``{error: "channel_access_denied", ...}``
+        Returns (instant, read-only): ``{activity: [{text, author, timestamp,
+        channel_id, topic_tags, fact_id}, ...]}`` sorted by timestamp descending.
+        No side effects.
+
+        Error modes (returned as dicts): 'authentication_missing' (no principal);
+        'channel_access_denied' (token lacks access to channel_id). Other internal
+        failures return an empty ``{activity: []}``.
         """
         principal_id = _get_principal_id(ctx)
         if not principal_id:
@@ -297,29 +371,44 @@ def register_retrieval_tools(mcp: FastMCP) -> None:
 
     @mcp.tool(name="search_media_references")
     async def search_media_references(
-        channel_id: Annotated[str, "The channel id (from list_channels)"],
-        query: Annotated[str, "Search query for finding media-containing messages"],
+        channel_id: Annotated[
+            str,
+            "Channel id. Get it from list_channels (e.g. 'ch-eng'). Required.",
+        ],
+        query: Annotated[
+            str,
+            "Search query describing the media you want (e.g. 'architecture "
+            "diagram' or 'pricing pdf'). Required.",
+        ],
         ctx: Context,
         media_type: Annotated[
             str | None,
-            "Filter by media type: 'image', 'pdf', 'link', or null for all",
+            "Optional media-type filter. One of: 'image' (photos/screenshots), "
+            "'pdf' (documents), 'link' (URLs), or null for all. Default null.",
         ] = None,
-        limit: Annotated[int, "Maximum number of results to return (1–20)"] = 5,
+        limit: Annotated[
+            int,
+            "Max results, 1-20 (out-of-range values are clamped). Default 5.",
+        ] = 5,
     ) -> dict:
-        """Search for messages containing images, PDFs, or links shared in a channel.
+        """Find messages that SHARED a file, image, PDF, or link in one channel.
+        Call it when the user is hunting for an attachment or URL ("where's the
+        design doc", "find the screenshot Alice posted") rather than for the
+        knowledge in the text.
 
-        Each result includes ``text``, ``media_urls``, ``link_urls``,
-        ``link_titles``, ``author``, ``timestamp``, ``media_type``, and
-        ``fact_id``.
+        When to use: locating shared documents, images, or links. When NOT to
+        use: general fact/knowledge search (use search_channel_facts or
+        ask_channel) — this tool only returns messages that carry media.
 
-        When to use: when the user asks about documents, images, or links shared
-        in a channel, or when you need to find a specific file or URL. Do NOT use
-        for general knowledge search — use ``search_channel_facts`` for that.
+        Prerequisites: a channel_id from list_channels.
 
-        media_type: ``"image"`` (photos/screenshots), ``"pdf"`` (documents),
-        ``"link"`` (URLs), or ``null`` (all types). Default: ``null``.
+        Returns (instant, read-only): ``{media: [{text, media_urls, link_urls,
+        link_titles, author, timestamp, media_type, fact_id}, ...]}``. No side
+        effects.
 
-        Returns: ``{media: [...]}`` or ``{error: "channel_access_denied", ...}``
+        Error modes (returned as dicts): 'authentication_missing' (no principal);
+        'channel_access_denied' (token lacks access to channel_id). Other internal
+        failures return an empty ``{media: []}``.
         """
         principal_id = _get_principal_id(ctx)
         if not principal_id:
@@ -357,35 +446,50 @@ def register_retrieval_tools(mcp: FastMCP) -> None:
     # -- search_memory ------------------------------------------------------
     @mcp.tool(name="search_memory")
     async def search_memory(
-        query: Annotated[str, "Natural-language or keyword search query"],
+        query: Annotated[
+            str,
+            "Search query, keyword or natural phrase, 1-4000 chars (e.g. 'who owns "
+            "billing'). Longer queries return error 'invalid_parameter'. Required.",
+        ],
         ctx: Context,
         scope: Annotated[
             str,
-            "Either 'all' (default — search every channel the principal can access) "
-            "or 'channel:<channel_id>' (search a single channel)",
+            "Search scope. 'all' (default) = every channel the principal can "
+            "access; 'channel:<id>' = one channel only (e.g. 'channel:ch-eng').",
         ] = "all",
-        limit: Annotated[int, "Maximum hits across all channels (1–50)"] = 20,
+        limit: Annotated[
+            int,
+            "Max hits across the merged result set, 1-50 (out-of-range values are "
+            "clamped). Default 20.",
+        ] = 20,
     ) -> dict:
-        """Cross-channel agent recall via Weaviate hybrid search.
+        """Find facts ACROSS MANY channels by hybrid (BM25 + vector) search when you
+        do NOT know which channel holds the answer. Call it first for broad recall,
+        then drill into a specific channel with the tools below.
 
-        Use this when the agent does not yet know which channel holds the
-        relevant memory — it merges hybrid (BM25 + vector) results from
-        every channel the principal can access. Each hit carries
-        ``fact_id``, ``text``, ``score``, ``channel_id``, ``cluster_id``,
-        ``entity_tags``. Results are ranked by hybrid score across the
-        merged set.
+        Routing rule for the three search tools:
+        - search_memory(scope='all') — unknown channel; fans the search across
+          every channel the principal can access and merges/ranks the hits.
+        - search_channel_facts(channel_id) — known channel; same hybrid search,
+          scoped to one channel, returning the richer per-fact shape.
+        - search_memory(scope='channel:<id>') — single channel with the
+          search_memory hit shape (use search_channel_facts instead if you want
+          author/permalink/topic_tags on each row).
+        For a synthesized ANSWER rather than rows, use ask_channel.
 
-        scope:
-          - ``"all"``: enumerate the principal's accessible channels and
-            search each (auth-gated per channel). Use this when the agent
-            does not yet know which channel holds the relevant memory.
-          - ``"channel:<id>"``: single-channel search, equivalent to
-            ``search_channel_facts`` but with the standard search_memory
-            response shape.
+        Prerequisites: none for scope='all'; a channel_id (from list_channels)
+        for scope='channel:<id>'.
 
-        Returns: ``{hits: [...], query: <echo>}`` or
-        ``{error: "channel_access_denied", channel_id: ...}`` for an
-        explicit unreachable channel scope.
+        Returns (instant for one channel, longer when fanning across many;
+        read-only): ``{hits: [{fact_id, text, score, channel_id, cluster_id,
+        entity_tags}, ...], query: <echo of query>}`` ranked by hybrid score.
+        No side effects.
+
+        Error modes (returned as dicts): 'authentication_missing' (no principal);
+        'invalid_parameter' (empty/over-4000-char query, or scope not 'all'/
+        'channel:<id>'); 'channel_access_denied' (only for an explicit
+        'channel:<id>' the token cannot reach — under scope='all' unreachable
+        channels are silently skipped).
         """
         principal_id = _get_principal_id(ctx)
         if not principal_id:
@@ -487,27 +591,42 @@ def register_retrieval_tools(mcp: FastMCP) -> None:
     # -- lint_wiki ----------------------------------------------------------
     @mcp.tool(name="lint_wiki")
     async def lint_wiki(
-        channel_id: Annotated[str, "The channel id whose wiki should be linted"],
+        channel_id: Annotated[
+            str,
+            "Channel id whose wiki to lint. Get it from list_channels (e.g. 'ch-eng'). Required.",
+        ],
         ctx: Context,
         target_lang: Annotated[
             str | None,
-            "Language tag to lint (defaults to the channel's primary)",
+            "Optional BCP-47 language tag to lint (e.g. 'en'). Omit to lint the "
+            "channel's primary language. Default null (treated as 'en').",
         ] = None,
         run_coherence_check: Annotated[
             bool,
-            "Run the bounded LLM coherence pass (one call per page)",
+            "If true, also run the LLM coherence pass (one model call per page — "
+            "slower and incurs token cost). Set false for a fast structural-only "
+            "lint. Default true.",
         ] = True,
     ) -> dict:
-        """Run the wiki lint checks for a channel and return findings.
+        """Audit a channel's wiki for health problems and return a list of findings.
+        Call it to check whether wiki pages are stale, orphaned, duplicated, or
+        internally inconsistent before relying on them or recommending a refresh.
 
-        Wraps the same ``POST /api/channels/{id}/wiki/lint`` HTTP endpoint
-        used by the WikiHealthToolbar UI. Surfaces orphan pages, stale
-        sections, duplicate sections, and intra-page coherence issues.
-        Each finding carries ``severity``, ``category``, ``page_id``,
-        ``section_id``, ``message``, and ``suggested_action``.
+        When to use: validating wiki quality, or diagnosing why an answer looked
+        wrong. When NOT to use: routine reading (use read_wiki_page /
+        list_wiki_pages) — linting is heavier. Set run_coherence_check=false to
+        avoid the per-page LLM cost when you only need structural checks.
 
-        Returns: ``{findings: [...], pages_scanned: N}`` or
-        ``{error: "channel_access_denied", ...}``.
+        Prerequisites: a channel_id from list_channels.
+
+        Returns (long-running when run_coherence_check=true — one LLM call per
+        page; read-only, writes nothing): ``{findings: [{severity, category,
+        page_id, section_id, message, suggested_action}, ...], pages_scanned: N}``.
+
+        Error modes (returned as dicts): 'authentication_missing' (no principal);
+        'channel_access_denied' (token lacks access to channel_id);
+        'lint_failed' (returned as ``{findings: [], error: 'lint_failed'}`` on an
+        internal lint error).
         """
         principal_id = _get_principal_id(ctx)
         if not principal_id:
@@ -569,16 +688,36 @@ def register_retrieval_tools(mcp: FastMCP) -> None:
     # -- get_extraction_status ---------------------------------------------
     @mcp.tool(name="get_extraction_status")
     async def get_extraction_status(
-        channel_id: Annotated[str, "The channel id whose extraction queue depth to return"],
+        channel_id: Annotated[
+            str,
+            "Channel id whose extraction progress to report. Get it from "
+            "list_channels (e.g. 'ch-eng'). Required.",
+        ],
         ctx: Context,
     ) -> dict:
-        """Return per-status extraction counts for a channel.
+        """Report how far fact EXTRACTION has progressed for a channel's messages,
+        as a count per status. Call it to judge whether a channel's knowledge is
+        fully ingested before you trust retrieval results, or to track progress
+        after triggering a sync.
 
-        Backs operator + agent visibility into the background
-        ExtractionWorker queue. Wraps the same ``GET
-        /api/channels/{id}/extraction-status`` HTTP endpoint used by the
-        Sync Progress + WikiTab UIs. Returns
-        ``{channel_id, counts: {pending, extracting, done, failed}, total}``.
+        Distinguish from get_job_status: this counts MESSAGES by extraction state
+        (corpus readiness); get_job_status reports the lifecycle of one async JOB
+        by job_id. Use this for "is this channel done extracting?"; use
+        get_job_status for "did my trigger_sync/refresh_wiki job finish?".
+
+        When to use: gauge corpus completeness, or detect a backlog (high
+        ``pending``) or failures (non-zero ``failed``) before relying on
+        ask_channel/search_channel_facts.
+
+        Prerequisites: a channel_id from list_channels.
+
+        Returns (instant, read-only): ``{channel_id, counts: {pending,
+        extracting, done, failed}, total}`` where each count is the number of
+        messages in that state and ``total`` is their sum. No side effects.
+
+        Error modes (returned as dicts): 'authentication_missing' (no principal);
+        'channel_access_denied' (token lacks access to channel_id);
+        'extraction_status_failed' (internal error reading the queue).
         """
         principal_id = _get_principal_id(ctx)
         if not principal_id:
@@ -633,26 +772,47 @@ def register_retrieval_tools(mcp: FastMCP) -> None:
 
     @mcp.tool(name="read_wiki_page")
     async def read_wiki_page(
-        channel_id: Annotated[str, "The channel id (from list_channels)"],
+        channel_id: Annotated[
+            str,
+            "Channel id. Get it from list_channels (e.g. 'ch-eng'). Required.",
+        ],
         slug: Annotated[
             str,
-            "The page slug — stable, human-readable identifier from the wiki",
+            "Page slug — the stable identifier of the page (e.g. "
+            "'auth-architecture'). Discover valid slugs with list_wiki_pages. "
+            "Required.",
         ],
         ctx: Context,
-        target_lang: Annotated[str, "Target language tag (BCP-47); defaults to 'en'"] = "en",
+        target_lang: Annotated[
+            str,
+            "BCP-47 language tag for the rendered page (e.g. 'en', 'fr'). Default 'en'.",
+        ] = "en",
     ) -> dict:
-        """Return the structured payload for one wiki page (slug-keyed).
+        """Read ONE full wiki page by its slug from the redesigned slug-keyed wiki.
+        Call it after list_wiki_pages tells you which slug you want, to get a
+        page's complete content and structured payload.
 
-        Returns the full WikiPage document including ``content_md`` (markdown
-        for human reading), ``kind`` + ``kind_schema`` (structured payload
-        agents can iterate without re-parsing markdown), ``cross_links``
-        (title→slug), ``cross_links_broken`` (titles with no destination
-        page yet), ``pin_state``, and ``last_updated``. Hidden pages are
-        excluded UNLESS the caller's MCP token carries the
-        ``read:hidden_pages`` scope (set in ``BEEVER_MCP_API_KEY_SCOPES``).
+        Disambiguation: this is the slug-keyed redesign surface (arbitrary
+        topic/entity pages). For the seven LEGACY fixed pages (overview, faq,
+        decisions, ...) use get_wiki_page(page_type). Typical sequence:
+        list_wiki_pages -> read_wiki_page(slug). To save tokens when you need
+        only a slice, use read_wiki_module (one module) or read_wiki_section
+        (one narrative section) instead of the whole page.
 
-        Returns ``{error: "wiki_page_not_found"}`` on missing slug,
-        ``{error: "channel_access_denied"}`` on ACL denial.
+        Prerequisites: a channel_id from list_channels and a slug from
+        list_wiki_pages.
+
+        Returns (instant, read-only): the full WikiPage document including
+        ``content_md`` (markdown body), ``kind`` + ``kind_schema`` (structured
+        payload agents can iterate without re-parsing markdown), ``cross_links``
+        (title->slug), ``cross_links_broken`` (linked titles with no page yet),
+        ``pin_state``, and ``last_updated``. Hidden pages are excluded unless the
+        token carries the ``read:hidden_pages`` scope. No side effects.
+
+        Error modes (returned as dicts): 'authentication_missing' (no principal);
+        'channel_access_denied' (token lacks access to channel_id);
+        'wiki_page_not_found' (no such slug, or it is hidden and the token lacks
+        read:hidden_pages); 'wiki_read_failed' (internal error).
         """
         principal_id = _get_principal_id(ctx)
         if not principal_id:
@@ -697,30 +857,47 @@ def register_retrieval_tools(mcp: FastMCP) -> None:
 
     @mcp.tool(name="list_wiki_pages")
     async def list_wiki_pages(
-        channel_id: Annotated[str, "The channel id (from list_channels)"],
+        channel_id: Annotated[
+            str,
+            "Channel id. Get it from list_channels (e.g. 'ch-eng'). Required.",
+        ],
         ctx: Context,
         kind: Annotated[
             str | None,
-            "Optional kind filter: topic / entity / decisions / faq / action_items",
+            "Optional kind filter. One of: 'topic', 'entity', 'decisions', 'faq', "
+            "'action_items'. Omit for all kinds. Default null.",
         ] = None,
         scope: Annotated[
             str,
-            "'human' (default) excludes hidden + merged pages; 'all' returns "
-            "everything when the caller has read:hidden_pages",
+            "Visibility scope. 'human' (default) excludes hidden + merged pages; "
+            "'all' returns everything but requires the read:hidden_pages token "
+            "scope (otherwise it silently downgrades to 'human').",
         ] = "human",
-        target_lang: Annotated[str, "Target language tag (BCP-47)"] = "en",
+        target_lang: Annotated[
+            str,
+            "BCP-47 language tag (e.g. 'en', 'fr'). Default 'en'.",
+        ] = "en",
     ) -> dict:
-        """Return a list of wiki pages for a channel, optionally filtered.
+        """List the wiki pages in one channel as lightweight summaries (no page
+        bodies). The RECOMMENDED first call when exploring the redesigned
+        slug-keyed wiki: use it to discover slugs, then fetch a page with
+        read_wiki_page(slug=...).
 
-        Returns ``{channel_id, target_lang, scope, pages: [<summary>...]}``
-        where each summary carries ``slug``, ``title``, ``kind``,
-        ``last_updated``, ``version``, and ``pin_state.pinned/hidden``. The
-        ``content_md`` body is intentionally NOT included — agents that
-        need the body should follow up with ``read_wiki_page(slug=...)``
-        to keep the per-call payload bounded.
+        When to use: browsing or discovering which pages exist, or finding a slug.
+        When NOT to use: you already know the slug and want the body (call
+        read_wiki_page directly).
 
-        ``scope="all"`` requires the ``read:hidden_pages`` token scope —
-        otherwise the caller silently downgrades to ``scope="human"``.
+        Prerequisites: a channel_id from list_channels.
+
+        Returns (instant, read-only): ``{channel_id, target_lang, scope, pages:
+        [{slug, title, kind, version, last_updated, pinned, hidden}, ...]}``. The
+        ``content_md`` body is intentionally omitted to keep the payload bounded
+        — follow up with read_wiki_page(slug=...) for a page's content. No side
+        effects.
+
+        Error modes (returned as dicts): 'authentication_missing' (no principal);
+        'channel_access_denied' (token lacks access to channel_id);
+        'wiki_list_failed' (internal error).
         """
         principal_id = _get_principal_id(ctx)
         if not principal_id:
@@ -779,16 +956,35 @@ def register_retrieval_tools(mcp: FastMCP) -> None:
 
     @mcp.tool(name="get_wiki_graph")
     async def get_wiki_graph(
-        channel_id: Annotated[str, "The channel id (from list_channels)"],
+        channel_id: Annotated[
+            str,
+            "Channel id. Get it from list_channels (e.g. 'ch-eng'). Required.",
+        ],
         ctx: Context,
     ) -> dict:
-        """Return the channel's wiki cross-link graph in Cytoscape format.
+        """Return the map of how a channel's WIKI PAGES link to one another, as a
+        node/edge graph. Call it to understand the wiki's structure — which pages
+        reference which — or to plan a traversal across related pages.
 
-        Same payload as ``GET /api/channels/{cid}/wiki/graph``:
-        ``{channel_id, nodes: [{data:{id,label,kind,page_kind?,version?,last_updated?}}],
-        edges: [{data:{id,source,target,kind}}]}``. Empty arrays when
-        the graph backend is unavailable so the route remains
-        always-200 across deployments.
+        Disambiguation: this is the WIKI PAGE-LINK graph (nodes are wiki pages,
+        edges are cross-links between them). For the KNOWLEDGE graph of entities
+        and their relationships (people, systems, concepts), use
+        search_relationships instead.
+
+        When to use: visualizing or navigating wiki page structure, or finding
+        clusters of related pages. When NOT to use: reading a page's content (use
+        read_wiki_page) or querying entity relationships (search_relationships).
+
+        Prerequisites: a channel_id from list_channels.
+
+        Returns (instant, read-only): Cytoscape-format
+        ``{channel_id, nodes: [{data: {id, label, kind, page_kind?, version?,
+        last_updated?}}], edges: [{data: {id, source, target, kind}}]}``. Returns
+        empty ``nodes``/``edges`` arrays (not an error) when the graph backend is
+        unavailable, so it is always safe to call. No side effects.
+
+        Error modes (returned as dicts): 'authentication_missing' (no principal);
+        'channel_access_denied' (token lacks access to channel_id).
         """
         principal_id = _get_principal_id(ctx)
         if not principal_id:
@@ -840,31 +1036,51 @@ def register_retrieval_tools(mcp: FastMCP) -> None:
 
     @mcp.tool(name="read_wiki_module")
     async def read_wiki_module(
-        channel_id: Annotated[str, "The channel id (from list_channels)"],
+        channel_id: Annotated[
+            str,
+            "Channel id. Get it from list_channels (e.g. 'ch-eng'). Required.",
+        ],
         page_slug: Annotated[
             str,
-            "The slug of the wiki page that hosts the module",
+            "Slug of the page hosting the module (e.g. 'auth-architecture'). "
+            "Discover slugs via list_wiki_pages. Required.",
         ],
         anchor: Annotated[
             str,
-            "The module anchor — stable in-page id, e.g. 'key-facts', "
-            "'decision-banner', 'tension-callout'",
+            "Module anchor — the stable in-page id of one structured module "
+            "(e.g. 'key-facts', 'decision-banner', 'tension-callout'). Discover "
+            "the available anchors by reading the page once with read_wiki_page. "
+            "Required.",
         ],
         ctx: Context,
-        target_lang: Annotated[str, "Target language tag (BCP-47)"] = "en",
+        target_lang: Annotated[
+            str,
+            "BCP-47 language tag (e.g. 'en', 'fr'). Default 'en'.",
+        ] = "en",
     ) -> dict:
-        """Fetch a single module's structured payload from a wiki page.
-
-        Returns the module's ``data`` dict (e.g. for ``key_facts``, the
-        items list; for ``decision_banner``, the rationale + alternatives
-        rejected). Use this when an agent only needs one slice of a page
-        and reading the entire page via ``read_wiki_page`` would waste
+        """Fetch ONE structured module from a wiki page without downloading the
+        whole page. Call it when you already know the page slug and the module
+        anchor you want, and reading the full page via read_wiki_page would waste
         tokens.
 
-        Returns ``{error: "wiki_page_not_found"}`` when the page does not
-        exist, ``{error: "module_not_found"}`` when the page exists but
-        does not contain the named anchor, or
-        ``{error: "channel_access_denied"}`` on ACL denial.
+        When to use: you need just one module's structured data (e.g. the
+        key_facts items, or a decision_banner's rationale + alternatives). When
+        NOT to use: you need a narrative prose section (use read_wiki_section) or
+        the whole page (use read_wiki_page). To learn a page's module anchors,
+        read it once with read_wiki_page first.
+
+        Prerequisites: a channel_id (list_channels), a page_slug
+        (list_wiki_pages), and an anchor (from the page's modules).
+
+        Returns (instant, read-only): ``{channel_id, page_slug, anchor,
+        module_id, data}`` where ``data`` is the module's structured payload.
+        No side effects.
+
+        Error modes (returned as dicts): 'authentication_missing' (no principal);
+        'channel_access_denied' (token lacks access to channel_id);
+        'wiki_page_not_found' (no such slug); 'module_not_found' (page exists but
+        has no module with that anchor); 'wiki_module_read_failed' (internal
+        error).
         """
         principal_id = _get_principal_id(ctx)
         if not principal_id:
@@ -916,38 +1132,52 @@ def register_retrieval_tools(mcp: FastMCP) -> None:
 
     @mcp.tool(name="find_decisions")
     async def find_decisions(
-        channel_id: Annotated[str, "The channel id (from list_channels)"],
+        channel_id: Annotated[
+            str,
+            "Channel id. Get it from list_channels (e.g. 'ch-eng'). Required.",
+        ],
         ctx: Context,
         since: Annotated[
             str | None,
-            "Optional ISO-8601 date prefix (e.g. '2026-04-01'); only "
-            "decisions on or after this date are returned",
+            "Optional ISO-8601 date prefix (e.g. '2026-04-01'); keeps only "
+            "decisions on or after this date. Omit for all dates. Default null.",
         ] = None,
         author: Annotated[
             str | None,
-            "Optional exact-match author_name filter",
+            "Optional exact-match author name (e.g. 'Alice Chen'). Omit for any "
+            "author. Default null.",
         ] = None,
-        limit: Annotated[int, "Maximum number of decisions to return (1–100)"] = 50,
+        limit: Annotated[
+            int,
+            "Max decisions to return, 1-100 (out-of-range values are clamped). Default 50.",
+        ] = 50,
     ) -> list[dict]:
-        """Find every decision recorded in a channel's wiki / fact store.
+        """List the DECISIONS recorded in one channel, each with its rationale and
+        rejected alternatives. Call it to answer "what did the team decide and
+        why" when you want the structured decision record, not free-text facts.
+        Returns a bare LIST and collapses missing-auth, access-denied, and
+        internal errors into an EMPTY LIST — so ``[]`` means either no decisions
+        OR no access; it never returns a structured error object and never raises.
 
-        Returns a list of decisions sorted by ``decided_at`` descending.
-        Each entry includes ``fact_id``, ``decision`` (first sentence of
-        the fact's memory_text), ``decided_by`` (author_name),
-        ``decided_at`` (YYYY-MM-DD prefix of message_ts), ``rationale``
-        (Phase 3 enrichment — null when not yet extracted),
-        ``alternatives_rejected``, and ``page_slug`` (the wiki page where
-        this decision lives, when known — empty string when no host page
-        has integrated this decision yet).
+        Disambiguation among the decision tools: use find_decisions for the
+        current decision RECORDS in one channel (with rationale +
+        alternatives_rejected). Use trace_decision_history to follow how one
+        decision SUPERSEDED earlier ones over time (a graph timeline). Prefer
+        find_decisions over find_facts(fact_type='decision') because only this
+        tool enriches each result with rationale and alternatives.
 
-        Filters:
-        - ``since="2026-04-01"`` returns decisions whose ``message_ts``
-          starts on or after that date.
-        - ``author="Alice Chen"`` returns decisions with exact-match
-          ``author_name``.
+        Prerequisites: a channel_id from list_channels.
 
-        Use this instead of ``find_facts(fact_type="decision")`` when you
-        also need rationale / alternatives_rejected on each result.
+        Returns (instant, read-only): a LIST (not a dict) of decisions sorted by
+        ``decided_at`` descending, each ``{fact_id, decision (first sentence),
+        decided_by, decided_at (YYYY-MM-DD), rationale (null if not yet
+        extracted), alternatives_rejected, page_slug (empty if no host page yet)}``.
+        No side effects.
+
+        Error handling: on missing auth, access denial, or internal error this
+        tool returns an EMPTY LIST ``[]`` rather than an error object (it never
+        raises). An empty list therefore means either no decisions or no access —
+        confirm access with list_channels if unexpected.
         """
         principal_id = _get_principal_id(ctx)
         if not principal_id:
@@ -1044,28 +1274,41 @@ def register_retrieval_tools(mcp: FastMCP) -> None:
 
     @mcp.tool(name="get_tensions")
     async def get_tensions(
-        channel_id: Annotated[str, "The channel id (from list_channels)"],
+        channel_id: Annotated[
+            str,
+            "Channel id. Get it from list_channels (e.g. 'ch-eng'). Required.",
+        ],
         ctx: Context,
         status: Annotated[
             str | None,
-            "Optional status filter — 'open' | 'blocked' | 'deferred'",
+            "Optional status filter. One of: 'open', 'blocked', 'deferred' "
+            "(e.g. 'open'). Pass null (the default) to return tensions of ALL "
+            "statuses; omit for the same effect.",
         ] = None,
     ) -> list[dict]:
-        """List unresolved tensions across the channel's wiki.
+        """List unresolved TENSIONS in one channel — points of open disagreement or
+        conflicting positions surfaced across its wiki. Call it to find what is
+        still contested or undecided, as opposed to settled decisions
+        (find_decisions).
 
-        Walks every wiki page for the channel and surfaces ``tension_callout``
-        modules. Each result carries ``tension_id``, ``title``, ``status``,
-        ``since`` (YYYY-MM-DD), ``positions`` (list of ``{author, stance,
-        fact_id}``), and ``page_slug`` (the page where the tension lives).
+        When to use: surfacing open conflicts, blockers, or competing stances.
+        When NOT to use: settled decisions (find_decisions) or general fact
+        lookup (find_facts).
 
-        Forward-compatible: tension detection is not yet shipped on this
-        track, so this tool returns ``[]`` for most channels today. The
-        wiring is in place so the same call starts returning real data
-        once tension detection lands without an API change.
+        Prerequisites: a channel_id from list_channels.
 
-        Filters: ``status="open"`` keeps only tensions whose status field
-        equals the requested value. With no filter, every tension on
-        every page is returned.
+        Note: tension detection is currently empty for most channels — the wiring
+        is in place but few channels have tension data yet, so an empty result is
+        normal and does not indicate an error. The same call returns real data
+        automatically once tensions exist, with no signature change.
+
+        Returns (instant, read-only): a LIST (not a dict) of ``{tension_id, title,
+        status, since (YYYY-MM-DD), positions: [{author, stance, fact_id}],
+        page_slug}``. No side effects.
+
+        Error handling: on missing auth, access denial, or internal error this
+        tool returns an EMPTY LIST ``[]`` (it never raises) — indistinguishable
+        from "no tensions"; confirm access with list_channels if unexpected.
         """
         principal_id = _get_principal_id(ctx)
         if not principal_id:
@@ -1137,29 +1380,55 @@ def register_retrieval_tools(mcp: FastMCP) -> None:
 
     @mcp.tool(name="find_facts")
     async def find_facts(
-        channel_id: Annotated[str, "The channel id (from list_channels)"],
-        query: Annotated[str, "Case-insensitive substring to match in memory_text"],
+        channel_id: Annotated[
+            str,
+            "Channel id. Get it from list_channels (e.g. 'ch-eng'). Required.",
+        ],
+        query: Annotated[
+            str,
+            "Case-insensitive substring matched literally inside each fact's text "
+            "(e.g. 'rollback'). NOT semantic — exact substring only. Required.",
+        ],
         ctx: Context,
         fact_type: Annotated[
             str | None,
-            "Optional type filter — 'decision' | 'observation' | 'opinion' | "
-            "'question' | 'action_item'",
+            "Optional type filter. One of: 'decision', 'observation', 'opinion', "
+            "'question', 'action_item'. Omit for all types. Default null.",
         ] = None,
-        limit: Annotated[int, "Maximum number of facts to return (1–100)"] = 20,
+        limit: Annotated[
+            int,
+            "Max facts to return, 1-100 (out-of-range values are clamped). Default 20.",
+        ] = 20,
     ) -> list[dict]:
-        """Search facts by text query within a channel.
+        """Find facts in one channel whose text literally CONTAINS a substring
+        (deterministic, case-insensitive). Call it when you know an exact keyword
+        and want every matching raw fact row, not a ranked or synthesized result.
+        Returns a bare LIST and collapses missing-auth, access-denied,
+        empty-query, and internal errors into an EMPTY LIST — so ``[]`` means no
+        match OR no access; it never returns a structured error object.
 
-        Returns up to ``limit`` facts whose ``memory_text`` contains
-        ``query`` (case-insensitive substring), optionally filtered by
-        ``fact_type``. Each result carries ``fact_id``, ``memory_text``,
-        ``fact_type``, ``importance``, ``author_name``, ``message_ts``,
-        and ``page_slug`` (the wiki page where this fact lives, or empty
-        when not yet integrated).
+        Disambiguation: find_facts is a deterministic substring filter (predictable,
+        no relevance ranking). For meaning-based / fuzzy retrieval use
+        search_channel_facts (BM25+vector). For a synthesized answer use
+        ask_channel. For decisions with rationale use find_decisions.
 
-        Use this when ``ask_channel`` would over-synthesize and you just
-        want raw fact rows that mention a keyword. For semantic / vector
-        search use ``search_channel_facts`` instead — this tool is a
-        deterministic substring filter, not a ranked retriever.
+        When to use: exact-keyword scans ("every fact mentioning 'rollback'"),
+        optionally narrowed by fact_type. When NOT to use: you want semantically
+        related results for a phrase (use search_channel_facts).
+
+        Prerequisites: a channel_id from list_channels.
+
+        Returns (instant, read-only): a LIST (not a dict) of up to ``limit`` facts,
+        sorted by importance DESC then recency (message_ts) DESC. The importance
+        values that drive the sort rank, highest first, are 'critical' > 'high' >
+        'medium' > 'low' (any other/empty value sorts lowest). Each item is
+        ``{fact_id, memory_text, fact_type, importance, author_name, message_ts,
+        page_slug (empty if not yet on a page)}``. No side effects.
+
+        Error handling: on missing auth, access denial, empty query, or internal
+        error this tool returns an EMPTY LIST ``[]`` (it never raises) — an empty
+        list means no match OR no access; confirm with list_channels if
+        unexpected.
         """
         principal_id = _get_principal_id(ctx)
         if not principal_id:
@@ -1253,43 +1522,51 @@ def register_retrieval_tools(mcp: FastMCP) -> None:
 
     @mcp.tool(name="read_wiki_section")
     async def read_wiki_section(
-        channel_id: Annotated[str, "The channel id (from list_channels)"],
+        channel_id: Annotated[
+            str,
+            "Channel id. Get it from list_channels (e.g. 'ch-eng'). Required.",
+        ],
         page_slug: Annotated[
             str,
-            "The slug of the wiki page that hosts the narrative section",
+            "Slug of the page hosting the section (e.g. 'auth-architecture'). "
+            "Discover slugs via list_wiki_pages. Required.",
         ],
         anchor: Annotated[
             str,
-            "The narrative section anchor — kebab-case in-page id "
-            "(e.g. 'context', 'alternatives', 'implications')",
+            "Section anchor — kebab-case in-page id of one narrative section "
+            "(e.g. 'context', 'alternatives', 'implications'). If you don't know "
+            "it, a 'section_not_found' error lists the available anchors. Required.",
         ],
         ctx: Context,
-        target_lang: Annotated[str, "Target language tag (BCP-47)"] = "en",
+        target_lang: Annotated[
+            str,
+            "BCP-47 language tag (e.g. 'en', 'fr'). Default 'en'.",
+        ] = "en",
     ) -> dict:
-        """Fetch ONE narrative section's structured data without loading
-        the full page.
+        """Fetch ONE narrative (prose) section of a wiki page without loading the
+        whole page. Call it when you know the page slug and section anchor and
+        want just that article slice, to save tokens.
 
-        Saves tokens for agents that only need a slice of a wiki article.
-        Returns ``{anchor, heading, paragraphs, citations, visual,
-        page_slug, page_title, channel_id}`` on hit — ``page_title`` and
-        ``channel_id`` are included so the agent can render attribution
-        without a separate ``read_wiki_page`` call. Use this instead of
-        ``read_wiki_page`` when you know the section anchor; use
-        ``read_wiki_module`` for ONE module's structured payload
-        (key_facts, decision_log, etc.); use ``find_facts`` for
-        fact-text search across pages.
+        Disambiguation: read_wiki_section returns PROSE sections (paragraphs +
+        citations); read_wiki_module returns a STRUCTURED module payload
+        (key_facts, decision_banner, etc.); read_wiki_page returns the whole page.
+        Use find_facts for fact-text search across pages.
 
-        Returns ``{error: "page_not_found", channel_id, page_slug}`` when
-        the page does not exist; ``{error: "section_not_found",
-        page_slug, available_anchors: [...]}`` when the page exists but
-        the anchor is missing; ``{error: "narrative_not_available",
-        page_slug, has_modules: bool, suggestion: ...}`` when the page
-        predates narrative generation OR fell back due to validation
-        failure (callers can retry with ``read_wiki_page`` for module-
-        only data); ``{error: "channel_access_denied"}`` on ACL denial.
+        Prerequisites: a channel_id (list_channels), a page_slug
+        (list_wiki_pages), and an anchor (from the page's narrative sections).
 
-        Spec:
-        ``openspec/changes/wiki-narrative-articles/specs/mcp-redesign-tools/``.
+        Returns (instant, read-only): ``{anchor, heading, paragraphs, citations,
+        visual, page_slug, page_title, channel_id}`` — ``page_title`` and
+        ``channel_id`` are included so you can attribute the section without a
+        second call. No side effects.
+
+        Error modes (returned as dicts): 'authentication_missing' (no principal);
+        'channel_access_denied' (token lacks access to channel_id);
+        'page_not_found' (no such slug); 'section_not_found' (page exists but lacks
+        the anchor — the result lists ``available_anchors`` to retry with);
+        'narrative_not_available' (page has no narrative sections — includes
+        ``has_modules`` and a suggestion to use read_wiki_page for module data);
+        'internal_error'.
         """
         principal_id = _get_principal_id(ctx)
         if not principal_id:
@@ -1368,24 +1645,34 @@ def register_retrieval_tools(mcp: FastMCP) -> None:
 
     @mcp.tool(name="read_provenance")
     async def read_provenance(
-        fact_id: Annotated[str, "The fact id whose source message to return"],
+        fact_id: Annotated[
+            str,
+            "Fact id to trace, as returned in the ``fact_id`` field of another "
+            "tool's result (e.g. 'fact_abc123' from find_facts, find_decisions, "
+            "search_channel_facts, or ask_channel citations). Required.",
+        ],
         ctx: Context,
     ) -> dict:
-        """Fetch the original source message for a fact.
+        """Trace ONE fact back to the original chat message it was extracted from.
+        Call it to verify or cite a fact — given a fact_id from another tool, it
+        returns where the fact came from (platform, message, author, timestamp,
+        and the raw message text when reachable).
 
-        Closes the audit loop — given a fact_id surfaced by another tool
-        (``find_decisions``, ``find_facts``, ``ask_channel``...), this
-        returns the platform / message_id / author / timestamp it was
-        extracted from, plus the raw chat message body when reachable.
+        When to use: confirming a fact's source, building a citation, or auditing
+        provenance. Prerequisites: a fact_id surfaced by find_facts,
+        find_decisions, search_channel_facts, search_memory, or an ask_channel
+        citation.
 
-        Returns:
-        ``{fact_id, memory_text, source: {platform, message_id, url,
-        author, ts}, raw_message}``.
+        Returns (instant, read-only): ``{fact_id, memory_text, source: {platform,
+        message_id, url, author, ts}, raw_message}``. ``raw_message`` is the
+        original chat body, or an empty string if the source message is no longer
+        reachable — every other field is still populated in that case. No side
+        effects.
 
-        Returns ``{error: "fact_not_found"}`` when the fact_id is unknown.
-        Does NOT fail hard if the source message itself is unreachable —
-        the ``raw_message`` field is empty in that case but every other
-        field is still populated.
+        Error modes (returned as dicts): 'authentication_missing' (no principal);
+        'fact_not_found' (unknown fact_id — also returned, deliberately, when the
+        caller lacks access to the fact's channel, so cross-tenant existence is
+        never leaked); 'provenance_read_failed' (internal error).
         """
         principal_id = _get_principal_id(ctx)
         if not principal_id:

--- a/src/beever_atlas/api/mcp_server/_tools_session.py
+++ b/src/beever_atlas/api/mcp_server/_tools_session.py
@@ -1,4 +1,4 @@
-"""Session tools: start_new_session (Phase 3, task 3.7)."""
+"""Session tools: start_new_session."""
 
 from __future__ import annotations
 
@@ -16,21 +16,30 @@ def register_session_tools(mcp: FastMCP) -> None:
 
     @mcp.tool(name="start_new_session")
     async def start_new_session(ctx: Context) -> dict:
-        """Reset the conversation session and obtain a new session id.
+        """Mint a fresh conversation session id that starts a new ``ask_channel`` thread.
 
-        Call this when you want to start a fresh conversation thread — for
-        example, after switching topics or to avoid carrying over context from
-        a previous ``ask_channel`` conversation. The returned ``session_id``
-        can be passed as the ``session_id`` parameter to ``ask_channel``.
+        Call this to begin a clean conversation that carries no memory of prior
+        ``ask_channel`` turns — e.g. when the user switches to an unrelated topic
+        or explicitly asks to "start over" / "forget previous context". Pass the
+        returned id as the ``session_id`` argument on subsequent ``ask_channel``
+        calls so they share one continuous thread; reuse the same id for
+        follow-ups, and mint a new one only when you want a clean break.
 
-        Note: this is a Phase 3 stub. Actual ADK session reset is wired in
-        Phase 6. The stub returns a new unique session id that ``ask_channel``
-        will accept as a conversation boundary marker.
+        When NOT to use: do not call this before every question. ``ask_channel``
+        auto-creates a session when ``session_id`` is omitted, so a new session
+        id is only needed to intentionally drop earlier conversation context.
 
-        When to use: explicitly, only when the user asks to "start over" or
-        "forget previous context". Do NOT call before every question.
+        Prerequisites: none. Requires an authenticated MCP principal (the caller's
+        connection token); no ``channel_id`` or other input is needed.
 
-        Returns: ``{session_id: "mcp:<principal>:<short_id>"}``
+        Returns: a dict ``{"session_id": "mcp:<principal>:<short>"}`` where the
+        value is a fresh opaque conversation handle scoped to the caller, e.g.
+        ``{"session_id": "mcp:conn_abc123:9f3c1a2b"}``. On a missing or invalid
+        principal it returns ``{"error": "authentication_missing"}`` instead.
+
+        Side effects: none — this allocates a new conversation boundary marker and
+        does not delete, persist, or mutate any stored data. Latency: instant
+        (no network or LLM call); safe to call synchronously inline.
         """
         principal_id = _get_principal_id(ctx)
         if not principal_id:


### PR DESCRIPTION
## Why

MCP registries grade servers on **tool description quality**, and that grade becomes the public badge on directory listings:
- **Glama TDQS** = 70% of their quality score (Glama listing pending review; the badge gates [awesome-mcp-servers PR #7155](https://github.com/punkpeye/awesome-mcp-servers/pull/7155))
- Cline marketplace, LobeHub, and the Official MCP Registry all display tool descriptions to users choosing servers

Our descriptions were written for internal agents, not a public scorecard. This PR makes them A-tier *before* the first graded release.

## What

| Surface | Change |
|---|---|
| All 28 tool descriptions | Rewritten: purpose + when-to-use vs sibling tools, return shapes, error modes, latency class, `Annotated` parameter descriptions with examples |
| Server instructions (FastMCP) | Orientation + recommended entry sequence (`whoami` → `list_connections` → `list_channels` → retrieval) |
| 3 prompts + `atlas://` resources | Descriptions improved |
| `docs/mcp-server.md` Tool Catalog | Rewritten — documents all **28** actual tools (was stale at ~16); fixes wrong parameter values |
| Module docstrings | Updated to match the real catalog |

**Zero functional changes** — tool names, signatures, parameter types/defaults, return values, behavior, and wire schemas untouched (one exception explicitly avoided: the deprecated shim keeps its bare params so its wire schema stays identical).

## Verification (multi-agent workflow)

- ✅ Full MCP test suite: **475 passed** + standalone introspection tests
- ✅ Docker introspection: 28 tools, schemas unchanged except added param descriptions
- ✅ Adversarial code review: no functional changes smuggled in; descriptions checked against actual implementations
- ✅ Self-graded against Glama's published TDQS rubric: **A tier (4.41/5)**, server coherence 4.5/5
- ⚠️ Known: deprecated `search_channel_knowledge` shim scores 3.4 — intentional (improving it = wire schema change on a deprecated tool)

🤖 Generated with [Claude Code](https://claude.com/claude-code)