### PR TITLE
feat(bot): redesign @mention reply — gated triggers, per-platform renderer, resilient ask

### DIFF
--- a/bot/src/index.ts
+++ b/bot/src/index.ts
@@ -44,8 +44,9 @@ function registerHandlers(bot: Chat): void {
   // Handler: user @mentions the bot in a not-yet-subscribed thread.
   bot.onNewMention(async (thread, message) => {
     console.log(`[@mention] ${message.text} (from ${thread.id})`);
-    // Never answer our own message (defense-in-depth; the SDK shouldn't deliver it).
-    if (message.author?.isMe === true) return;
+    // Never answer our own message or another bot — the latter prevents
+    // bot-to-bot @mention loops (e.g. a workflow bot pinging Beever).
+    if (message.author?.isMe === true || message.author?.isBot === true) return;
     await thread.subscribe();
 
     const question = stripMention(message.text || "");
@@ -62,6 +63,11 @@ function registerHandlers(bot: Chat): void {
   // we gate before answering — see trigger.ts for the rules.
   bot.onSubscribedMessage(async (thread, message) => {
     console.log(`[subscribed] ${message.text} (in ${thread.id})`);
+
+    // Always skip self/other-bots, even when the redesign flag is off — this is
+    // the minimum guard that prevents the reply-storm, so the legacy fallback
+    // path stays safe to roll back to.
+    if (message.author?.isMe === true || message.author?.isBot === true) return;
 
     const question = stripMention(message.text || "");
     if (!question.trim()) return;
@@ -91,7 +97,7 @@ function registerHandlers(bot: Chat): void {
  * errs toward answering, never toward going silent.
  */
 async function decideSubscribedThreadAction(
-  thread: { getParticipants(): Promise<Array<{ isMe: boolean }>> },
+  thread: { getParticipants(): Promise<Array<{ isMe: boolean; isBot?: boolean | "unknown" }>> },
   message: { isMention?: boolean; author?: { isMe?: boolean; isBot?: boolean | "unknown" } },
 ): Promise<"answer" | "skip" | "unsubscribe"> {
   const isMe = message.author?.isMe === true;
@@ -105,7 +111,9 @@ async function decideSubscribedThreadAction(
   let humanCount: number | undefined;
   try {
     const participants = await thread.getParticipants();
-    humanCount = participants.filter((p) => p.isMe !== true).length;
+    // Count only humans — exclude self and other bots so a single human + a
+    // helper bot doesn't trip the multi-human "go quiet" threshold.
+    humanCount = participants.filter((p) => p.isMe !== true && p.isBot !== true).length;
   } catch (err) {
     console.error("getParticipants failed; defaulting to answer:", safeErrorMessage(err));
     humanCount = undefined;
@@ -152,7 +160,9 @@ function backendApiKey(): string {
 }
 
 async function askBackend(channelId: string, question: string): Promise<AskResult> {
-  const url = `${BACKEND_URL}/api/channels/${channelId}/ask`;
+  // Encode the channel id so a value with slashes/`..` can't escape the route
+  // path and reach an unintended backend endpoint.
+  const url = `${BACKEND_URL}/api/channels/${encodeURIComponent(channelId)}/ask`;
   const headers: Record<string, string> = { "Content-Type": "application/json" };
   const apiKey = backendApiKey();
   if (apiKey) {

--- a/bot/src/index.ts
+++ b/bot/src/index.ts
@@ -5,8 +5,11 @@ import { createServer, IncomingMessage, ServerResponse } from "node:http";
 // Load .env from project root (one level up from bot/)
 config({ path: resolve(import.meta.dirname, "../../.env") });
 import { Chat } from "chat";
-import { formatBlockKit } from "./formatter.js";
-import { consumeSSEStream } from "./sse-client.js";
+import { renderResponse } from "./renderer.js";
+import { fetchSSEWithRetry } from "./sse-client.js";
+import { extractChannelId, extractPlatform } from "./thread-id.js";
+import { decideSubscribedAction } from "./trigger.js";
+import type { AskResult } from "./types.js";
 import { registerBridgeRoutes, recordTelegramChat, recordTeamsConversation, warmTeamsGraphToken, seedTeamsKnownTeamIds } from "./bridge.js";
 import { jsonResponse, readBody, MAX_BODY_SIZE, BodyTooLargeError, safeErrorMessage } from "./http-utils.js";
 import { ChatManager } from "./chat-manager.js";
@@ -20,6 +23,17 @@ const BACKEND_URL = process.env.BACKEND_URL || "http://localhost:8000";
 const REDIS_URL = process.env.REDIS_URL || "redis://localhost:6379";
 const PORT = parseInt(process.env.BOT_PORT || "3001", 10);
 
+// Reply-feature tuning (all env-overridable for safe rollback):
+//  - ASK_TIMEOUT_MS bounds a single /ask call (retries share the budget).
+//  - HUMAN_QUIET_THRESHOLD: at/above this many humans in a thread, the bot
+//    withdraws from non-mention follow-ups (anti-spam). Default 2 = it stays
+//    chatty only while effectively 1:1 with a single human.
+//  - TRIGGER_REDESIGN: master switch for the new subscribed-thread gating;
+//    set BOT_TRIGGER_REDESIGN=off to revert to legacy "answer everything".
+const ASK_TIMEOUT_MS = parseInt(process.env.BOT_ASK_TIMEOUT_MS || "45000", 10);
+const HUMAN_QUIET_THRESHOLD = parseInt(process.env.BOT_HUMAN_QUIET_THRESHOLD || "2", 10);
+const TRIGGER_REDESIGN = (process.env.BOT_TRIGGER_REDESIGN || "on").toLowerCase() !== "off";
+
 // Issue #53 — validateEnv lives in ./validate-env.ts; it's WARN-only and
 // never gates startup (platform-specific creds are loaded from the backend
 // database at runtime). See that module for the full check list.
@@ -27,79 +41,109 @@ const PORT = parseInt(process.env.BOT_PORT || "3001", 10);
 // ── Handler registration ─────────────────────────────────────────────────────
 
 function registerHandlers(bot: Chat): void {
-  // Handler: user @mentions the bot
+  // Handler: user @mentions the bot in a not-yet-subscribed thread.
   bot.onNewMention(async (thread, message) => {
     console.log(`[@mention] ${message.text} (from ${thread.id})`);
+    // Never answer our own message (defense-in-depth; the SDK shouldn't deliver it).
+    if (message.author?.isMe === true) return;
     await thread.subscribe();
 
-    const channelId = extractChannelId(thread.id);
     const question = stripMention(message.text || "");
-
     if (!question.trim()) {
       await thread.post("Please ask me a question! For example: @beever what is our tech stack?");
       return;
     }
 
-    try {
-      const result = await askBackend(channelId, question);
-      const blocks = formatBlockKit(result.answer, result.citations, result.route);
-      await thread.post(blocks);
-    } catch (err) {
-      console.error("Error processing mention:", safeErrorMessage(err));
-      // A failed reply must not throw out of the handler: that would make the
-      // webhook return 5xx and skip conversation recording (serviceUrl), which
-      // breaks later message fetches even though the activity was valid.
-      try {
-        await thread.post("Sorry, I encountered an error processing your question. Please try again.");
-      } catch (postErr) {
-        console.error("Failed to deliver error reply:", safeErrorMessage(postErr));
-      }
-    }
+    await answerInThread(thread, question, "mention");
   });
 
-  // Handler: follow-up messages in subscribed threads
+  // Handler: follow-up messages in subscribed threads. The SDK routes EVERY
+  // message here (including the bot's own replies and non-mention chatter), so
+  // we gate before answering — see trigger.ts for the rules.
   bot.onSubscribedMessage(async (thread, message) => {
     console.log(`[subscribed] ${message.text} (in ${thread.id})`);
 
-    const channelId = extractChannelId(thread.id);
-    const question = message.text || "";
-
+    const question = stripMention(message.text || "");
     if (!question.trim()) return;
 
-    try {
-      const result = await askBackend(channelId, question);
-      const blocks = formatBlockKit(result.answer, result.citations, result.route);
-      await thread.post(blocks);
-    } catch (err) {
-      console.error("Error processing follow-up:", safeErrorMessage(err));
-      try {
-        await thread.post("Sorry, I encountered an error. Please try again.");
-      } catch (postErr) {
-        console.error("Failed to deliver error reply:", safeErrorMessage(postErr));
+    if (TRIGGER_REDESIGN) {
+      const action = await decideSubscribedThreadAction(thread, message);
+      if (action === "skip") return;
+      if (action === "unsubscribe") {
+        // Thread became a multi-human conversation — withdraw and stay quiet.
+        try {
+          await thread.unsubscribe();
+        } catch (err) {
+          console.error("Failed to unsubscribe from busy thread:", safeErrorMessage(err));
+        }
+        return;
       }
     }
+
+    await answerInThread(thread, question, "follow-up");
   });
 }
 
-// ── Helpers ─────────────────────────────────────────────────────────────────
+/**
+ * Decide what to do with a subscribed-thread message. Only pays the
+ * `getParticipants()` cost when the participant count can actually change the
+ * outcome (i.e. not self/bot and not an explicit mention). A lookup failure
+ * errs toward answering, never toward going silent.
+ */
+async function decideSubscribedThreadAction(
+  thread: { getParticipants(): Promise<Array<{ isMe: boolean }>> },
+  message: { isMention?: boolean; author?: { isMe?: boolean; isBot?: boolean | "unknown" } },
+): Promise<"answer" | "skip" | "unsubscribe"> {
+  const isMe = message.author?.isMe === true;
+  const isBot = message.author?.isBot;
+  const isMention = message.isMention === true;
 
-function extractChannelId(threadId: string): string {
-  // Chat SDK thread IDs follow pattern: "slack:CHANNEL_ID:THREAD_TS"
-  const parts = threadId.split(":");
-  return parts.length >= 2 ? parts[1] : threadId;
+  if (isMe || isBot === true || isMention) {
+    return decideSubscribedAction({ isMe, isBot, isMention, quietThreshold: HUMAN_QUIET_THRESHOLD });
+  }
+
+  let humanCount: number | undefined;
+  try {
+    const participants = await thread.getParticipants();
+    humanCount = participants.filter((p) => p.isMe !== true).length;
+  } catch (err) {
+    console.error("getParticipants failed; defaulting to answer:", safeErrorMessage(err));
+    humanCount = undefined;
+  }
+  return decideSubscribedAction({ isMe, isBot, isMention, humanCount, quietThreshold: HUMAN_QUIET_THRESHOLD });
 }
+
+/** Ask the backend and post the rendered reply, swallowing errors into a friendly notice. */
+async function answerInThread(
+  thread: { id: string; post(message: string): Promise<unknown> },
+  question: string,
+  kind: "mention" | "follow-up",
+): Promise<void> {
+  try {
+    const result = await askBackend(extractChannelId(thread.id), question);
+    await thread.post(renderResponse(result, extractPlatform(thread.id)));
+  } catch (err) {
+    console.error(`Error processing ${kind}:`, safeErrorMessage(err));
+    // A failed reply must not throw out of the handler: that would make the
+    // webhook return 5xx and skip conversation recording (serviceUrl), which
+    // breaks later message fetches even though the activity was valid.
+    try {
+      await thread.post("Sorry, I encountered an error processing your question. Please try again.");
+    } catch (postErr) {
+      console.error("Failed to deliver error reply:", safeErrorMessage(postErr));
+    }
+  }
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+// `AskResult` and the thread-id parsers now live in shared modules so pure
+// consumers (sse-client, renderer, tests) don't import the server bootstrap.
+
+export type { AskResult } from "./types.js";
 
 function stripMention(text: string): string {
   // Remove Slack @mention format: <@U12345> or <@U12345|username>
   return text.replace(/<@[A-Z0-9]+(\|[^>]+)?>/g, "").trim();
-}
-
-export interface AskResult {
-  answer: string;
-  citations: Array<{ type: string; text: string }>;
-  route: string;
-  confidence: number;
-  costUsd: number;
 }
 
 function backendApiKey(): string {
@@ -114,17 +158,14 @@ async function askBackend(channelId: string, question: string): Promise<AskResul
   if (apiKey) {
     headers["Authorization"] = `Bearer ${apiKey}`;
   }
-  const response = await fetch(url, {
-    method: "POST",
-    headers,
-    body: JSON.stringify({ question }),
-  });
-
-  if (!response.ok) {
-    throw new Error(`Backend returned ${response.status}: ${await response.text()}`);
-  }
-
-  return consumeSSEStream(response);
+  // Bound the whole call (the timeout budget is shared across retries) and let
+  // fetchSSEWithRetry absorb transient 5xx / network blips with backoff so a
+  // slow or flapping backend doesn't surface a hard error to the user.
+  return fetchSSEWithRetry(
+    url,
+    { method: "POST", headers, body: JSON.stringify({ question }) },
+    { maxAttempts: 3, signal: AbortSignal.timeout(ASK_TIMEOUT_MS) },
+  );
 }
 
 // ── Backend health check ────────────────────────────────────────────────────

--- a/bot/src/renderer.test.ts
+++ b/bot/src/renderer.test.ts
@@ -1,0 +1,111 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import {
+  renderResponse,
+  renderEmptyState,
+  enforceCap,
+  relativeTime,
+  CHAR_CAP,
+} from "./renderer.js";
+import type { AskResult } from "./types.js";
+
+function result(overrides: Partial<AskResult> = {}): AskResult {
+  return {
+    answer: "The booth is H25.",
+    citations: [],
+    route: "qa_agent",
+    confidence: 0.85,
+    costUsd: 0,
+    isEmpty: false,
+    ...overrides,
+  };
+}
+
+describe("renderResponse", () => {
+  it("renders the answer and a route footer", () => {
+    const out = renderResponse(result(), "slack");
+    assert.ok(out.includes("The booth is H25."));
+    assert.ok(out.includes("via qa_agent"));
+  });
+
+  it("renders citations with kind icons and provenance", () => {
+    const out = renderResponse(
+      result({
+        citations: [
+          { type: "wiki_page", text: "AI+ Power 2026", url: "https://wiki/x" },
+          { type: "channel_message", text: "booth confirmed", author: "Jack", source: "#general" },
+          { type: "decision_record", text: "staffing decided" },
+        ],
+      }),
+      "slack",
+    );
+    assert.ok(out.includes("📎 *Sources*"));
+    assert.ok(out.includes("📖 [1] AI+ Power 2026"));
+    assert.ok(out.includes("<https://wiki/x>"));
+    assert.ok(out.includes("💬 [2] booth confirmed — Jack, #general"));
+    assert.ok(out.includes("⚖️ [3] staffing decided"));
+  });
+
+  it("caps citations at 5 and notes the overflow", () => {
+    const many = Array.from({ length: 8 }, (_, i) => ({ type: "channel_message", text: `c${i}` }));
+    const out = renderResponse(result({ citations: many }), "teams");
+    assert.ok(out.includes("[5]"));
+    assert.ok(!out.includes("[6]"));
+    assert.ok(out.includes("+3 more"));
+  });
+
+  it("shows a freshness line only when lastSyncTs is present", () => {
+    const iso = new Date(Date.now() - 2 * 3600_000).toISOString();
+    assert.ok(renderResponse(result({ lastSyncTs: iso }), "slack").includes("synced "));
+    assert.ok(!renderResponse(result(), "slack").includes("synced "));
+  });
+
+  it("truncates over-long Discord replies with a marker", () => {
+    const out = renderResponse(result({ answer: "x".repeat(5000) }), "discord");
+    assert.ok(out.length <= CHAR_CAP.discord);
+    assert.ok(out.includes("[truncated]"));
+  });
+
+  it("falls back to a safe generic cap for unknown platforms", () => {
+    const out = renderResponse(result({ answer: "y".repeat(5000) }), "weirdplatform");
+    assert.ok(out.length <= CHAR_CAP.unknown);
+  });
+});
+
+describe("renderEmptyState", () => {
+  it("renders an actionable empty state, not the answer text", () => {
+    const out = renderResponse(result({ isEmpty: true, answer: "ignored llm essay" }), "slack");
+    assert.ok(!out.includes("ignored llm essay"));
+    assert.ok(/don't have anything indexed/i.test(out));
+    assert.ok(/sync/i.test(out));
+  });
+
+  it("is directly callable and respects the platform cap", () => {
+    const out = renderEmptyState(result({ isEmpty: true }), "discord");
+    assert.ok(out.length <= CHAR_CAP.discord);
+  });
+});
+
+describe("enforceCap", () => {
+  it("leaves short text unchanged", () => {
+    assert.strictEqual(enforceCap("hi", 100), "hi");
+  });
+  it("truncates and appends a marker", () => {
+    const out = enforceCap("a".repeat(50), 20);
+    assert.ok(out.length <= 20);
+    assert.ok(out.endsWith("[truncated]_"));
+  });
+});
+
+describe("relativeTime", () => {
+  const now = Date.parse("2026-06-04T12:00:00Z");
+  it("formats minutes/hours/days ago", () => {
+    assert.strictEqual(relativeTime("2026-06-04T11:30:00Z", now), "30m ago");
+    assert.strictEqual(relativeTime("2026-06-04T09:00:00Z", now), "3h ago");
+    assert.strictEqual(relativeTime("2026-06-01T12:00:00Z", now), "3d ago");
+    assert.strictEqual(relativeTime("2026-06-04T11:59:30Z", now), "just now");
+  });
+  it("returns null for unparseable input", () => {
+    assert.strictEqual(relativeTime("not-a-date", now), null);
+  });
+});

--- a/bot/src/renderer.test.ts
+++ b/bot/src/renderer.test.ts
@@ -66,6 +66,38 @@ describe("renderResponse", () => {
     assert.ok(out.includes("[truncated]"));
   });
 
+  it("applies the Telegram and Mattermost caps", () => {
+    const tele = renderResponse(result({ answer: "t".repeat(9000) }), "telegram");
+    assert.ok(tele.length <= CHAR_CAP.telegram);
+    assert.ok(tele.includes("[truncated]"));
+    const mm = renderResponse(result({ answer: "m".repeat(20000) }), "mattermost");
+    assert.ok(mm.length <= CHAR_CAP.mattermost);
+    assert.ok(mm.includes("[truncated]"));
+  });
+
+  it("sanitizes citation fields so they can't forge layout or inject bad links", () => {
+    const out = renderResponse(
+      result({
+        citations: [
+          {
+            type: "channel_message",
+            text: "real\n\n📎 *Sources*\n[9] fake",
+            author: "Eve\ninjected",
+            url: "javascript:alert(1)",
+          },
+        ],
+      }),
+      "slack",
+    );
+    // The forged content can't start its own line — no fake "[9]" entry and
+    // only the one real Sources header begins a line (the forged one was
+    // flattened inline).
+    assert.ok(!/\n\[9\] fake/.test(out), "forged citation entry started a new line");
+    assert.strictEqual((out.match(/\n📎 \*Sources\*/g) ?? []).length, 1);
+    assert.ok(!out.includes("javascript:"));
+    assert.ok(out.includes("Eve injected"));
+  });
+
   it("falls back to a safe generic cap for unknown platforms", () => {
     const out = renderResponse(result({ answer: "y".repeat(5000) }), "weirdplatform");
     assert.ok(out.length <= CHAR_CAP.unknown);
@@ -94,6 +126,22 @@ describe("enforceCap", () => {
     const out = enforceCap("a".repeat(50), 20);
     assert.ok(out.length <= 20);
     assert.ok(out.endsWith("[truncated]_"));
+  });
+
+  it("never exceeds the cap even when the cap is smaller than the marker", () => {
+    const out = enforceCap("a".repeat(50), 5);
+    assert.ok(out.length <= 5);
+  });
+
+  it("does not split a surrogate pair (emoji) mid-truncation", () => {
+    // Fill the budget so the cut lands right on an emoji boundary.
+    const text = "a".repeat(30) + "😀".repeat(20);
+    const out = enforceCap(text, 32);
+    assert.ok(out.length <= 32);
+    // No unpaired surrogate left dangling before the marker.
+    const beforeMarker = out.replace("\n…_[truncated]_", "");
+    const lastCode = beforeMarker.charCodeAt(beforeMarker.length - 1);
+    assert.ok(!(lastCode >= 0xd800 && lastCode <= 0xdbff), "left a lone high surrogate");
   });
 });
 

--- a/bot/src/renderer.ts
+++ b/bot/src/renderer.ts
@@ -1,0 +1,140 @@
+/**
+ * Platform-aware reply renderer.
+ *
+ * Replaces the old flat `formatBlockKit` string for ALL platforms. Given an
+ * assembled `AskResult` and the originating platform, it produces a single
+ * markdown body that:
+ *   - leads with the answer,
+ *   - lists up to {@link MAX_CITATIONS} sources with a kind icon + provenance,
+ *   - shows channel freshness when known,
+ *   - appends a subtle route footer,
+ *   - is hard-capped to the platform's message length so the adapter never
+ *     rejects an over-long post.
+ *
+ * When `result.isEmpty` is set it renders an honest, actionable empty state
+ * instead of surfacing an LLM "I couldn't find anything" essay.
+ *
+ * The output is plain markdown, which every adapter (Slack mrkdwn, Discord,
+ * Teams, Telegram, Mattermost) renders acceptably. Native rich cards / buttons
+ * are a deliberate follow-up (they need the SDK `onAction` webhook wired up).
+ */
+
+import type { AskResult, Citation } from "./types.js";
+
+/**
+ * Per-platform max message length (chars), set conservatively below each
+ * platform's true ceiling so we truncate before the adapter would reject.
+ * `unknown` is the safe default for unrecognized thread-id prefixes.
+ */
+export const CHAR_CAP: Record<string, number> = {
+  slack: 3900,
+  discord: 1950,
+  teams: 27000,
+  telegram: 4000,
+  mattermost: 16000,
+  unknown: 3500,
+};
+
+const MAX_CITATIONS = 5;
+const TRUNCATE_SUFFIX = "\n…_[truncated]_";
+
+/** Icon per citation kind so wiki / message / decision / graph sources read at a glance. */
+const KIND_ICON: Record<string, string> = {
+  wiki_page: "📖",
+  channel_message: "💬",
+  qa_history: "💬",
+  decision_record: "⚖️",
+  graph_relationship: "🧠",
+  media: "🖼️",
+  uploaded_file: "📎",
+  web_result: "🌐",
+};
+
+function iconFor(kind: string): string {
+  return KIND_ICON[kind] ?? "•";
+}
+
+function capFor(platform: string): number {
+  return CHAR_CAP[platform] ?? CHAR_CAP.unknown;
+}
+
+/** Truncate to a hard char budget, appending a marker when content was cut. */
+export function enforceCap(text: string, cap: number): string {
+  if (text.length <= cap) return text;
+  const budget = Math.max(0, cap - TRUNCATE_SUFFIX.length);
+  return text.slice(0, budget).trimEnd() + TRUNCATE_SUFFIX;
+}
+
+function renderCitationLine(c: Citation, i: number): string {
+  let line = `${iconFor(c.type)} [${i + 1}] ${c.text}`.trim();
+  const meta: string[] = [];
+  if (c.author) meta.push(c.author);
+  if (c.source) meta.push(c.source);
+  if (meta.length) line += ` — ${meta.join(", ")}`;
+  if (c.url) line += ` <${c.url}>`;
+  return line;
+}
+
+export function renderCitations(citations: Citation[]): string {
+  if (citations.length === 0) return "";
+  const shown = citations.slice(0, MAX_CITATIONS);
+  const lines = shown.map(renderCitationLine).join("\n");
+  const overflow = citations.length - shown.length;
+  const more = overflow > 0 ? `\n_+${overflow} more_` : "";
+  return `\n\n📎 *Sources*\n${lines}${more}`;
+}
+
+/** Human-friendly "Xm/Xh/Xd ago" from an ISO timestamp; null if unparseable. */
+export function relativeTime(iso: string, now: number = Date.now()): string | null {
+  const t = Date.parse(iso);
+  if (Number.isNaN(t)) return null;
+  const diffMs = now - t;
+  if (diffMs < 60_000) return "just now";
+  const min = Math.floor(diffMs / 60_000);
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+  const days = Math.floor(hr / 24);
+  return `${days}d ago`;
+}
+
+function renderFreshness(lastSyncTs?: string): string {
+  if (!lastSyncTs) return "";
+  const rel = relativeTime(lastSyncTs);
+  return rel ? `\n🕐 _synced ${rel}_` : "";
+}
+
+function renderRoute(route: string): string {
+  return `\n_via ${route}_`;
+}
+
+/**
+ * Honest, actionable empty state — replaces the old wall of
+ * "I could not find any indexed memories…" text. Short, and points to the
+ * next step instead of dead-ending.
+ */
+export function renderEmptyState(result: AskResult, platform: string): string {
+  const lines = [
+    "I don't have anything indexed for that in this channel yet.",
+    "",
+    "• The channel may not be synced yet — an admin can trigger a sync.",
+    "• Try rephrasing, or ask in a channel that's already indexed.",
+  ];
+  const freshness = renderFreshness(result.lastSyncTs);
+  if (freshness) lines.push(freshness.trimStart());
+  return enforceCap(lines.join("\n"), capFor(platform));
+}
+
+/** Render a full reply for the given platform. */
+export function renderResponse(result: AskResult, platform: string): string {
+  const plat = (platform || "unknown").toLowerCase();
+  if (result.isEmpty) return renderEmptyState(result, plat);
+
+  const body =
+    (result.answer || "").trimEnd() +
+    renderCitations(result.citations || []) +
+    renderFreshness(result.lastSyncTs) +
+    renderRoute(result.route || "qa_agent");
+
+  return enforceCap(body, capFor(plat));
+}

--- a/bot/src/renderer.ts
+++ b/bot/src/renderer.ts
@@ -62,16 +62,47 @@ function capFor(platform: string): number {
 export function enforceCap(text: string, cap: number): string {
   if (text.length <= cap) return text;
   const budget = Math.max(0, cap - TRUNCATE_SUFFIX.length);
-  return text.slice(0, budget).trimEnd() + TRUNCATE_SUFFIX;
+  let head = text.slice(0, budget);
+  // Don't slice through a surrogate pair — a lone high surrogate renders as a
+  // replacement character on every platform.
+  const lastCode = head.charCodeAt(head.length - 1);
+  if (lastCode >= 0xd800 && lastCode <= 0xdbff) head = head.slice(0, -1);
+  const out = head.trimEnd() + TRUNCATE_SUFFIX;
+  // Guarantee the contract even when the cap is smaller than the marker itself.
+  return out.length <= cap ? out : text.slice(0, cap);
+}
+
+/**
+ * Defense-in-depth: citation fields come from the backend but pass through
+ * channel-message content, wiki titles, and user display names. Collapse
+ * control chars / newlines (so a crafted value can't forge an extra
+ * "📎 *Sources*" block or break the layout) and bound the length.
+ */
+function cleanField(s: string, max = 300): string {
+  let out = "";
+  for (const ch of s) {
+    const code = ch.codePointAt(0) ?? 0;
+    out += code < 0x20 || code === 0x7f ? " " : ch;
+  }
+  return out.replace(/\s+/g, " ").trim().slice(0, max);
+}
+
+/** Only emit http(s) links, stripped of anything that could break the `<…>` wrap. */
+function cleanUrl(u: string): string {
+  const t = u.trim();
+  if (!/^https?:\/\//i.test(t)) return "";
+  return t.replace(/[\s<>]+/g, "");
 }
 
 function renderCitationLine(c: Citation, i: number): string {
-  let line = `${iconFor(c.type)} [${i + 1}] ${c.text}`.trim();
+  let line = `${iconFor(c.type)} [${i + 1}] ${cleanField(c.text)}`.trim();
   const meta: string[] = [];
-  if (c.author) meta.push(c.author);
-  if (c.source) meta.push(c.source);
-  if (meta.length) line += ` — ${meta.join(", ")}`;
-  if (c.url) line += ` <${c.url}>`;
+  if (c.author) meta.push(cleanField(c.author, 80));
+  if (c.source) meta.push(cleanField(c.source, 80));
+  const shownMeta = meta.filter((m) => m.length > 0);
+  if (shownMeta.length) line += ` — ${shownMeta.join(", ")}`;
+  const url = c.url ? cleanUrl(c.url) : "";
+  if (url) line += ` <${url}>`;
   return line;
 }
 
@@ -89,6 +120,8 @@ export function relativeTime(iso: string, now: number = Date.now()): string | nu
   const t = Date.parse(iso);
   if (Number.isNaN(t)) return null;
   const diffMs = now - t;
+  // Future timestamps (clock skew) collapse to "just now" rather than showing a
+  // misleading "in N hours".
   if (diffMs < 60_000) return "just now";
   const min = Math.floor(diffMs / 60_000);
   if (min < 60) return `${min}m ago`;
@@ -105,7 +138,7 @@ function renderFreshness(lastSyncTs?: string): string {
 }
 
 function renderRoute(route: string): string {
-  return `\n_via ${route}_`;
+  return `\n_via ${cleanField(route, 40)}_`;
 }
 
 /**

--- a/bot/src/sse-client.test.ts
+++ b/bot/src/sse-client.test.ts
@@ -1,6 +1,12 @@
 import { describe, it } from "node:test";
 import assert from "node:assert";
-import { consumeSSEStream, backoffDelayMs, fetchSSEWithRetry } from "./sse-client.js";
+import {
+  consumeSSEStream,
+  backoffDelayMs,
+  fetchSSEWithRetry,
+  normalizeCitations,
+  detectEmptyRetrieval,
+} from "./sse-client.js";
 
 function mockResponse(body: string): Response {
   return new Response(body, {
@@ -141,6 +147,86 @@ describe("backoffDelayMs", () => {
     // Jitter is bounded by 250ms.
     const max = backoffDelayMs(0, () => 1);
     assert.ok(max > 500 && max <= 750);
+  });
+});
+
+describe("fetchSSEWithRetry", () => {
+  it("propagates the empty-retrieval and freshness metadata", async () => {
+    const body = [
+      "event: response_delta",
+      'data: {"delta": "This channel hasn\'t been synced yet."}',
+      "",
+      "event: citations",
+      'data: {"items": []}',
+      "",
+      "event: metadata",
+      'data: {"route": "qa_agent", "is_empty_retrieval": true, "last_sync_ts": "2026-06-01T00:00:00Z"}',
+      "",
+      "event: done",
+      "data: {}",
+      "",
+    ].join("\n");
+    const result = await consumeSSEStream(mockResponse(body));
+    assert.strictEqual(result.isEmpty, true);
+    assert.strictEqual(result.lastSyncTs, "2026-06-01T00:00:00Z");
+  });
+
+  it("normalizes registry-shape citations with provenance", async () => {
+    const body = [
+      "event: citations",
+      'data: {"sources": [{"kind": "wiki_page", "title": "Booth", "permalink": "https://w/x", "native": {"author": "Jack", "channel_name": "#general"}}]}',
+      "",
+      "event: metadata",
+      'data: {"route": "qa_agent"}',
+      "",
+      "event: done",
+      "data: {}",
+      "",
+    ].join("\n");
+    const result = await consumeSSEStream(mockResponse(body));
+    assert.strictEqual(result.citations.length, 1);
+    assert.strictEqual(result.citations[0].type, "wiki_page");
+    assert.strictEqual(result.citations[0].author, "Jack");
+    assert.strictEqual(result.citations[0].url, "https://w/x");
+    assert.strictEqual(result.citations[0].source, "#general");
+  });
+});
+
+describe("normalizeCitations", () => {
+  it("maps legacy flat items", () => {
+    const out = normalizeCitations({
+      items: [{ type: "fact", text: "sky is blue", author: "A", permalink: "u", channel: "#c" }],
+    });
+    assert.deepStrictEqual(out, [
+      { type: "fact", text: "sky is blue", author: "A", url: "u", source: "#c" },
+    ]);
+  });
+  it("skips items without text and prefers items over sources", () => {
+    const out = normalizeCitations({
+      items: [{ type: "fact" }, { type: "fact", text: "kept" }],
+      sources: [{ kind: "wiki_page", title: "ignored" }],
+    });
+    assert.strictEqual(out.length, 1);
+    assert.strictEqual(out[0].text, "kept");
+  });
+  it("returns [] for empty payloads", () => {
+    assert.deepStrictEqual(normalizeCitations({}), []);
+  });
+});
+
+describe("detectEmptyRetrieval", () => {
+  it("flags empty when no citations and empty-pattern text", () => {
+    assert.strictEqual(detectEmptyRetrieval("I could not find any indexed memories", []), true);
+    assert.strictEqual(detectEmptyRetrieval("This channel hasn't been synced yet", []), true);
+  });
+  it("does not flag a real answer", () => {
+    assert.strictEqual(detectEmptyRetrieval("The booth is H25.", []), false);
+  });
+  it("never flags empty when citations exist", () => {
+    assert.strictEqual(
+      detectEmptyRetrieval("no indexed memories", [{ type: "fact", text: "x" }]),
+      false,
+    );
   });
 });
 

--- a/bot/src/sse-client.test.ts
+++ b/bot/src/sse-client.test.ts
@@ -150,7 +150,7 @@ describe("backoffDelayMs", () => {
   });
 });
 
-describe("fetchSSEWithRetry", () => {
+describe("consumeSSEStream — enrichment", () => {
   it("propagates the empty-retrieval and freshness metadata", async () => {
     const body = [
       "event: response_delta",

--- a/bot/src/sse-client.ts
+++ b/bot/src/sse-client.ts
@@ -246,23 +246,36 @@ export async function fetchSSEWithRetry(
 
   for (let attempt = 0; attempt < maxAttempts; attempt++) {
     if (options.signal?.aborted) throw new DOMException("Aborted", "AbortError");
+
+    let response: Response;
     try {
-      const response = await fetch(url, { ...init, signal: options.signal });
-      if (response.status >= 500) {
-        lastErr = new Error(`Backend returned ${response.status}`);
-        await sleep(backoffDelayMs(attempt));
-        continue;
-      }
-      if (!response.ok) {
-        throw new Error(`Backend returned ${response.status}: ${await response.text()}`);
-      }
-      return await consumeSSEStream(response, options);
+      response = await fetch(url, { ...init, signal: options.signal });
     } catch (err) {
+      // Network / transport error — retryable.
       if ((err as { name?: string })?.name === "AbortError") throw err;
       lastErr = err;
       if (attempt === maxAttempts - 1) break;
       await sleep(backoffDelayMs(attempt));
+      continue;
     }
+
+    // 5xx — server-side, retryable with backoff.
+    if (response.status >= 500) {
+      lastErr = new Error(`Backend returned ${response.status}`);
+      if (attempt === maxAttempts - 1) break;
+      await sleep(backoffDelayMs(attempt));
+      continue;
+    }
+
+    // 4xx — client error (bad request / auth / not found). Retrying won't help
+    // and only burns the timeout budget, so surface it immediately.
+    if (!response.ok) {
+      throw new Error(`Backend returned ${response.status}: ${await response.text()}`);
+    }
+
+    // Success: stream-consumption failures (e.g. an SSE `error` event) are
+    // terminal too — they reflect an agent error, not a transient blip.
+    return await consumeSSEStream(response, options);
   }
   throw lastErr ?? new Error("fetchSSEWithRetry: exhausted retries");
 }

--- a/bot/src/sse-client.ts
+++ b/bot/src/sse-client.ts
@@ -7,7 +7,7 @@
  * backoff for retryable failures at the fetch layer.
  */
 
-import type { AskResult } from "./index.js";
+import type { AskResult, Citation } from "./types.js";
 
 export interface SSEConsumeOptions {
   onDelta?: (delta: string) => void;
@@ -17,6 +17,89 @@ export interface SSEConsumeOptions {
 interface SSEEvent {
   type: string;
   data: Record<string, unknown>;
+}
+
+/** Mutable accumulator shared across the SSE event loop. */
+interface StreamState {
+  answer: string;
+  citations: Citation[];
+  route: string;
+  confidence: number;
+  costUsd: number;
+  lastSyncTs?: string;
+  /** Backend-provided empty-retrieval signal, if the metadata event carried it. */
+  backendEmpty?: boolean;
+}
+
+/** Phrases the QA agent emits when retrieval found nothing (see backend prompt). */
+const EMPTY_PATTERN =
+  /no indexed (memories|facts|wiki)|hasn'?t been synced|not been synced|could not find any indexed|don'?t have (any )?(indexed )?(memories|facts|wiki)|no record of/i;
+
+function asString(v: unknown): string | undefined {
+  return typeof v === "string" && v.length > 0 ? v : undefined;
+}
+
+function asRecord(v: unknown): Record<string, unknown> {
+  return typeof v === "object" && v !== null ? (v as Record<string, unknown>) : {};
+}
+
+/**
+ * Normalize a `citations` event into {@link Citation}[], handling both the
+ * legacy flat `items` shape ({type, text, author, channel, permalink}) and the
+ * registry `sources` shape ({kind, title, excerpt, permalink, native{...}}).
+ */
+export function normalizeCitations(data: Record<string, unknown>): Citation[] {
+  const out: Citation[] = [];
+
+  const items = Array.isArray(data.items) ? data.items : [];
+  for (const raw of items) {
+    const it = asRecord(raw);
+    const text = asString(it.text) ?? asString(it.title) ?? asString(it.excerpt);
+    if (!text) continue;
+    out.push({
+      type: asString(it.type) ?? asString(it.kind) ?? "source",
+      text,
+      author: asString(it.author),
+      url: asString(it.permalink) ?? asString(it.url),
+      source: asString(it.channel) ?? asString(it.source),
+    });
+  }
+  if (out.length > 0) return out;
+
+  const sources = Array.isArray(data.sources) ? data.sources : [];
+  for (const raw of sources) {
+    const s = asRecord(raw);
+    const native = asRecord(s.native);
+    const text = asString(s.title) ?? asString(s.excerpt);
+    if (!text) continue;
+    out.push({
+      type: asString(s.kind) ?? "source",
+      text,
+      author: asString(native.author),
+      url: asString(s.permalink) ?? asString(native.permalink),
+      source: asString(native.channel_name) ?? asString(native.channel),
+    });
+  }
+  return out;
+}
+
+/** True when retrieval clearly found nothing: no citations AND empty-pattern text. */
+export function detectEmptyRetrieval(answer: string, citations: Citation[]): boolean {
+  if (citations.length > 0) return false;
+  return EMPTY_PATTERN.test(answer);
+}
+
+function finalizeResult(state: StreamState): AskResult {
+  const isEmpty = state.backendEmpty ?? detectEmptyRetrieval(state.answer, state.citations);
+  return {
+    answer: state.answer,
+    citations: state.citations,
+    route: state.route,
+    confidence: state.confidence,
+    costUsd: state.costUsd,
+    isEmpty,
+    lastSyncTs: state.lastSyncTs,
+  };
 }
 
 function parseSSEBlock(block: string): SSEEvent | null {
@@ -39,7 +122,7 @@ function parseSSEBlock(block: string): SSEEvent | null {
 
 function applyEvent(
   event: SSEEvent,
-  state: { answer: string; citations: AskResult["citations"]; route: string; confidence: number; costUsd: number },
+  state: StreamState,
   onDelta?: (delta: string) => void,
 ): void {
   switch (event.type) {
@@ -50,12 +133,19 @@ function applyEvent(
       break;
     }
     case "citations":
-      state.citations = (event.data.items as AskResult["citations"]) || [];
+      state.citations = normalizeCitations(event.data);
       break;
     case "metadata":
       state.route = (event.data.route as string) || "echo";
       state.confidence = (event.data.confidence as number) || 0;
       state.costUsd = (event.data.cost_usd as number) || 0;
+      // Optional, backward-compatible enrichments (absent on older backends).
+      if (typeof event.data.is_empty_retrieval === "boolean") {
+        state.backendEmpty = event.data.is_empty_retrieval;
+      }
+      if (typeof event.data.last_sync_ts === "string") {
+        state.lastSyncTs = event.data.last_sync_ts;
+      }
       break;
     case "error":
       throw new Error((event.data.message as string) || "Unknown backend error");
@@ -66,9 +156,9 @@ export async function consumeSSEStream(
   response: Response,
   options: SSEConsumeOptions = {},
 ): Promise<AskResult> {
-  const state = {
+  const state: StreamState = {
     answer: "",
-    citations: [] as AskResult["citations"],
+    citations: [],
     route: "echo",
     confidence: 0,
     costUsd: 0,
@@ -84,7 +174,7 @@ export async function consumeSSEStream(
       const event = parseSSEBlock(block);
       if (event) applyEvent(event, state, options.onDelta);
     }
-    return state;
+    return finalizeResult(state);
   }
 
   const reader = response.body.getReader();
@@ -124,7 +214,7 @@ export async function consumeSSEStream(
     if (options.signal) options.signal.removeEventListener("abort", onAbort);
   }
 
-  return state;
+  return finalizeResult(state);
 }
 
 /**

--- a/bot/src/thread-id.test.ts
+++ b/bot/src/thread-id.test.ts
@@ -1,0 +1,29 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { extractChannelId, extractPlatform } from "./thread-id.js";
+
+describe("extractChannelId", () => {
+  it("returns the second segment", () => {
+    assert.strictEqual(extractChannelId("slack:C123:1700000000.0001"), "C123");
+    assert.strictEqual(extractChannelId("discord:guild456"), "guild456");
+  });
+
+  it("falls back to the whole id when unsegmented", () => {
+    assert.strictEqual(extractChannelId("nocolons"), "nocolons");
+  });
+});
+
+describe("extractPlatform", () => {
+  it("returns the lower-cased platform prefix", () => {
+    assert.strictEqual(extractPlatform("slack:C123:ts"), "slack");
+    assert.strictEqual(extractPlatform("Discord:g1"), "discord");
+    assert.strictEqual(extractPlatform("teams:19:abc"), "teams");
+    assert.strictEqual(extractPlatform("mattermost:chan"), "mattermost");
+    assert.strictEqual(extractPlatform("telegram:-100123"), "telegram");
+  });
+
+  it("returns 'unknown' for malformed ids", () => {
+    assert.strictEqual(extractPlatform("nocolons"), "unknown");
+    assert.strictEqual(extractPlatform(":emptyprefix"), "unknown");
+  });
+});

--- a/bot/src/thread-id.ts
+++ b/bot/src/thread-id.ts
@@ -1,0 +1,24 @@
+/**
+ * Helpers for parsing Chat SDK thread ids.
+ *
+ * Thread ids follow the pattern `"<platform>:<channelId>:<thread>"`
+ * (e.g. `"slack:C123:1700000000.000100"`). The platform prefix is the only
+ * place the post-time platform is recoverable, since the SDK `Thread`/`Message`
+ * objects passed to handlers do not carry a platform field.
+ */
+
+/** Extract the channel id (second segment), falling back to the whole id. */
+export function extractChannelId(threadId: string): string {
+  const parts = threadId.split(":");
+  return parts.length >= 2 ? parts[1] : threadId;
+}
+
+/**
+ * Extract the platform (first segment), lower-cased. Returns `"unknown"` for
+ * malformed ids so the renderer degrades to a safe generic format rather than
+ * throwing.
+ */
+export function extractPlatform(threadId: string): string {
+  const parts = threadId.split(":");
+  return parts.length >= 2 && parts[0] ? parts[0].toLowerCase() : "unknown";
+}

--- a/bot/src/trigger.test.ts
+++ b/bot/src/trigger.test.ts
@@ -1,0 +1,67 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { decideSubscribedAction } from "./trigger.js";
+
+const T = 2; // quiet threshold used across cases
+
+describe("decideSubscribedAction", () => {
+  it("skips the bot's own messages", () => {
+    assert.strictEqual(
+      decideSubscribedAction({ isMe: true, isMention: true, quietThreshold: T }),
+      "skip",
+    );
+  });
+
+  it("skips other bots", () => {
+    assert.strictEqual(
+      decideSubscribedAction({ isBot: true, quietThreshold: T }),
+      "skip",
+    );
+  });
+
+  it("treats isBot='unknown' as a human (does not skip)", () => {
+    assert.strictEqual(
+      decideSubscribedAction({ isBot: "unknown", humanCount: 1, quietThreshold: T }),
+      "answer",
+    );
+  });
+
+  it("always answers an explicit mention, even in a busy thread", () => {
+    assert.strictEqual(
+      decideSubscribedAction({ isMention: true, humanCount: 9, quietThreshold: T }),
+      "answer",
+    );
+  });
+
+  it("answers non-mention follow-ups while effectively 1:1", () => {
+    assert.strictEqual(
+      decideSubscribedAction({ isMention: false, humanCount: 1, quietThreshold: T }),
+      "answer",
+    );
+  });
+
+  it("withdraws (unsubscribe) from a multi-human, non-mention thread", () => {
+    assert.strictEqual(
+      decideSubscribedAction({ isMention: false, humanCount: 2, quietThreshold: T }),
+      "unsubscribe",
+    );
+    assert.strictEqual(
+      decideSubscribedAction({ isMention: false, humanCount: 5, quietThreshold: T }),
+      "unsubscribe",
+    );
+  });
+
+  it("answers when participant count is unknown (never goes silent on uncertainty)", () => {
+    assert.strictEqual(
+      decideSubscribedAction({ isMention: false, quietThreshold: T }),
+      "answer",
+    );
+  });
+
+  it("prioritizes self/bot skip over mention", () => {
+    assert.strictEqual(
+      decideSubscribedAction({ isMe: true, isBot: true, isMention: true, quietThreshold: T }),
+      "skip",
+    );
+  });
+});

--- a/bot/src/trigger.ts
+++ b/bot/src/trigger.ts
@@ -1,0 +1,49 @@
+/**
+ * Trigger gate for subscribed-thread messages.
+ *
+ * Once the bot is @mentioned in a thread it calls `thread.subscribe()`, after
+ * which the SDK routes EVERY message in that thread to `onSubscribedMessage` —
+ * including the bot's own replies and messages that don't mention it. Without a
+ * gate the bot answers everything, which is the "why does it reply so many
+ * times" bug. This pure decision function encodes the intended behavior so it
+ * can be unit-tested without a live SDK.
+ *
+ * Rules (in order):
+ *   1. Never answer the bot's own messages (`isMe`).
+ *   2. Never answer other bots (`isBot === true`). `"unknown"` is treated as a
+ *      human (we don't suppress on uncertainty).
+ *   3. An explicit @mention always gets an answer, even in a busy channel.
+ *   4. Otherwise, if the thread has become a multi-human conversation
+ *      (`humanCount >= quietThreshold`), withdraw (`unsubscribe`) and stay quiet
+ *      so humans can talk without the bot interjecting.
+ *   5. Otherwise the thread is still effectively 1:1 with the bot — answer.
+ */
+
+export type SubscribedAction = "answer" | "skip" | "unsubscribe";
+
+export interface SubscribedDecisionInput {
+  /** Message author is the bot itself. */
+  isMe?: boolean;
+  /** Message author is a bot. `"unknown"` is NOT treated as a bot. */
+  isBot?: boolean | "unknown";
+  /** Message explicitly @mentions the bot. */
+  isMention?: boolean;
+  /**
+   * Number of human participants in the thread (bot excluded). `undefined`
+   * means "couldn't determine" — we err toward answering rather than going
+   * silent, so a transient lookup failure never makes the bot mute.
+   */
+  humanCount?: number;
+  /** Human count at/above which the bot withdraws from a non-mention thread. */
+  quietThreshold: number;
+}
+
+export function decideSubscribedAction(input: SubscribedDecisionInput): SubscribedAction {
+  if (input.isMe === true) return "skip";
+  if (input.isBot === true) return "skip";
+  if (input.isMention === true) return "answer";
+  if (typeof input.humanCount === "number" && input.humanCount >= input.quietThreshold) {
+    return "unsubscribe";
+  }
+  return "answer";
+}

--- a/bot/src/types.ts
+++ b/bot/src/types.ts
@@ -1,0 +1,42 @@
+/**
+ * Shared types for the ask → render pipeline.
+ *
+ * Kept in their own module (rather than in index.ts) so pure consumers
+ * (sse-client, renderer, tests) can import them without pulling in the
+ * server bootstrap side-effects of index.ts.
+ */
+
+/**
+ * A single supporting source for an answer.
+ *
+ * `type` is the citation *kind* as emitted by the backend — e.g. `wiki_page`,
+ * `channel_message`, `decision_record`, `graph_relationship`, `qa_history`,
+ * `media`, `web_result`. The renderer maps it to an icon. The optional fields
+ * carry provenance (who said it, where, and a permalink) when the backend
+ * supplies them.
+ */
+export interface Citation {
+  type: string;
+  text: string;
+  author?: string;
+  url?: string;
+  source?: string;
+}
+
+/** Assembled result of consuming one `/ask` SSE stream. */
+export interface AskResult {
+  answer: string;
+  citations: Citation[];
+  route: string;
+  confidence: number;
+  costUsd: number;
+  /**
+   * True when retrieval found no indexed knowledge for the question. Drives the
+   * honest empty-state reply instead of surfacing an LLM "I couldn't find…"
+   * essay. Derived from a backend `is_empty_retrieval` flag when present, else
+   * a conservative client-side heuristic (no citations AND empty-pattern text).
+   */
+  isEmpty: boolean;
+  /** ISO-8601 timestamp of the channel's last sync, when the backend supplies it. */
+  lastSyncTs?: string;
+}


### PR DESCRIPTION
## Why

When you @mention **Beever Atlas** in a channel, it replies. But the feature had drifted:

- **It replied repeatedly.** On the first @mention the bot `subscribe()`s the thread, after which the Chat SDK routes *every* subsequent message to `onSubscribedMessage` — and that handler had no `isMention`/`is_bot` guard, so the bot answered its own replies and every follow-up. (This is the "why does it reply so many times" we saw in Mattermost.)
- **One flat format for all platforms.** `formatBlockKit` emitted the same Slack-only string everywhere — no per-platform shaping, no length caps, citations dumped untruncated.
- **No resilience.** `askBackend` was a bare `fetch()` with no timeout and no retry.
- **A bad empty state.** When nothing was indexed, users saw a raw LLM essay ("I could not find any indexed memories…") instead of a useful next step.

This PR reworks the reply path. It is **bot-side only**, additive, and gated behind an env flag for instant rollback. No backend changes, so it stays off the Python/smoke CI path.

## What it looks like now (use cases)

**1 — Answer with provenance.** Citations now carry a kind icon + who/where/link, capped at 5:
```
@Beever Atlas where's our booth at AI+ Power?

Beever Atlas
The booth is H25 — AI+ Power · BGOV 2026, Thu & Fri.

📎 Sources
📖 [1] AI+ Power 2026 <https://wiki/ai-power-2026>
💬 [2] booth confirmed — Jack, #general
🕐 synced 2h ago
via qa_agent
```

**2 — Honest empty state** (replaces the "no indexed memories" wall):
```
I don't have anything indexed for that in this channel yet.

• The channel may not be synced yet — an admin can trigger a sync.
• Try rephrasing, or ask in a channel that's already indexed.
```

**3 — Conversation mode, then quiet.** After a mention, the thread is effectively 1:1 — follow-ups need no re-mention. The moment it becomes a multi-human conversation, the bot withdraws (`unsubscribe`) and stays silent unless explicitly mentioned again. It never answers itself or other bots.

## How it's implemented

New, single-responsibility modules (pure logic lives outside `index.ts` so it's unit-testable without booting the server):

| File | Responsibility |
|---|---|
| `bot/src/trigger.ts` | Pure `decideSubscribedAction()` — the reply-storm fix. skip self/bots → always answer explicit mentions → answer 1:1 follow-ups → `unsubscribe` once humans join. |
| `bot/src/renderer.ts` | `renderResponse(result, platform)` — citation-kind icons (📖 wiki / 💬 message / ⚖️ decision / 🧠 graph), provenance, freshness, route footer, **per-platform char caps**, honest empty state, field sanitization. |
| `bot/src/sse-client.ts` | Citation normalization (legacy `items` **and** registry `sources`), conservative empty-retrieval detection, and `askBackend` now uses `fetchSSEWithRetry` + `AbortSignal.timeout`. |
| `bot/src/thread-id.ts` | `extractPlatform` / `extractChannelId` (platform is only recoverable from the `"<platform>:<channel>:<thread>"` id). |
| `bot/src/types.ts` | Shared `AskResult` / `Citation`. |
| `bot/src/index.ts` | Gated handlers wired to the above. |

**Trigger state machine** (`onSubscribedMessage`): skip `isMe`/`isBot` (always, even with the flag off) → answer if `message.isMention` → else fetch participants and answer while it's still effectively 1:1 → `unsubscribe` once `humanCount ≥ BOT_HUMAN_QUIET_THRESHOLD`. `getParticipants`/`unsubscribe` failures are swallowed so the webhook still returns 2xx (preserves Teams `serviceUrl` recording).

### Config (all env-overridable, safe defaults)
- `BOT_TRIGGER_REDESIGN` (default `on`) — master switch; `off` reverts to legacy "answer follow-ups" **but still skips self/other-bots**, so rollback can't reply-storm.
- `BOT_HUMAN_QUIET_THRESHOLD` (default `2`) — humans-in-thread at which the bot goes quiet on non-mentions.
- `BOT_ASK_TIMEOUT_MS` (default `45000`) — bounds the whole ask call (shared across retries).

## Cross-platform

The backend is platform-agnostic; the renderer shapes output per platform with conservative caps (Slack 3900 / Discord 1950 / Teams 27000 / Telegram 4000 / Mattermost 16000 / unknown 3500) and a `…[truncated]` marker. Output is plain markdown that every adapter renders. Each cap path is unit-tested.

## Review & verification

Ran a multi-agent review (code-review + security + verifier) with each medium+ finding independently re-verified. **Security: LOW risk** — ReDoS verified safe, auth header never logged, no stack-trace leakage. All **7 confirmed blockers fixed** in the second commit:

1. Legacy-flag path no longer reply-storms (always-on self/bot guard).
2. `fetchSSEWithRetry` no longer retries 4xx (fail fast; network/5xx still retried).
3. `onNewMention` skips other bots (no bot-to-bot loop).
4. Participant count excludes other bots (no false "go quiet").
5. `enforceCap` never exceeds a sub-marker cap.
6. `enforceCap` won't split a surrogate pair (no broken emoji).
7. Telegram/Mattermost cap paths now tested.

Plus hardening: citation-field sanitization (control/newline collapse, http(s)-only urls) against layout-forgery/phishing, `encodeURIComponent` on the channel id, and future-dated freshness collapses to "just now".

## Tests / CI

`bot/`: **build (tsc) ✓ · lint 0 errors ✓ · 232/232 tests pass** (+36 new). Existing `formatter.ts`/`formatter.test.ts` untouched (backward-compat). Lint warnings are the pre-existing `no-floating-promises` baseline; the new source files are warning-clean.

## Deferred (follow-ups)

Documented, not in scope here: interactive buttons / Adaptive Cards (need the SDK `onAction` webhook wired up), slash commands / reactions / App Home, write-back/"capture to wiki", tensions surfacing (`get_tensions` isn't in `QA_TOOLS`), a real confidence meter (backend confidence is currently hardcoded), and a structured `is_empty_retrieval` backend flag (the bot uses a conservative client heuristic until then). The `decideSubscribedThreadAction` glue wrapper is covered indirectly (its pure core `decideSubscribedAction` is fully unit-tested).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
