### PR TITLE
docs(readme): add Glama MCP server dynamic badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@
   <a href="https://beever.ai/"><img src="https://img.shields.io/badge/WEBSITE-beever.ai-15404E?style=for-the-badge&labelColor=4A4A4A" alt="beever.ai" /></a>
 </p>
 
+<div align="center">
+  <a href="https://glama.ai/mcp/servers/Beever-AI/beever-atlas">
+    <img width="380" height="200" src="https://glama.ai/mcp/servers/Beever-AI/beever-atlas/badge" alt="Beever Atlas MCP server on Glama" />
+  </a>
+</div>
+
 ---
 
 Beever Atlas pulls the conversations your team already has on Slack, Discord, Microsoft Teams, and Mattermost, extracts atomic facts, deduplicates them, and clusters them into topic pages with citations. A graph store links the people, decisions, and projects mentioned across channels. Ask questions in natural language and get answers cited back to the source messages — through the dashboard, or through MCP into Claude Code and Cursor.


### PR DESCRIPTION
## Summary
- Beever Atlas was approved on Glama MCP server directory: https://glama.ai/mcp/servers/Beever-AI/beever-atlas
- Adds the Glama-native dynamic badge image (auto-renders quality score, pulls Glama directory traffic)
- The static `MCP-Listed_on_Glama` badge in the top row already existed and is preserved

## Why
- Unblocks PR #7155 on punkpeye/awesome-mcp-servers (currently labeled `missing-glama`)
- Surfaces our MCP server in Glama's discovery — they index all MCP-compatible projects
- Dynamic badge auto-updates with Glama's quality score (no future README maintenance needed)

## Test plan
- [ ] Verify badge image renders at https://glama.ai/mcp/servers/Beever-AI/beever-atlas/badge
- [ ] Verify listing live at https://glama.ai/mcp/servers/Beever-AI/beever-atlas (HTTP 200)
- [ ] Merge → then update PR #7155 on punkpeye/awesome-mcp-servers fork with Glama link

## After merge
1. Update Beever-AI fork of awesome-mcp-servers entry with Glama link
2. Post comment on punkpeye/awesome-mcp-servers#7155 requesting `missing-glama` label clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)