### PR TITLE
feat(bot): reply v2+v3 — memory, multi-language, confidence, tensions, experts, rate-limit, rich formatting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -108,6 +108,31 @@ ADAPTER_MOCK=false
 BOT_PORT=3001
 BACKEND_URL=http://localhost:8000
 BRIDGE_URL=http://localhost:3001
+
+# ── Reply-feature tuning (all optional; safe defaults shown) ─────────────────
+# BOT_SESSION_SECRET: HMAC key for per-thread conversation-memory session ids.
+#   SET THIS IN PRODUCTION — when unset, session ids are derived from a known
+#   default, making them predictable to anyone who knows a thread id.
+BOT_SESSION_SECRET=
+# BOT_TRIGGER_REDESIGN: master switch for the gated triggers (mention / 1:1 /
+#   go-quiet-when-humans-join). "off" reverts to legacy behavior but still skips
+#   self/other-bots so it can't reply-storm. Default: on.
+BOT_TRIGGER_REDESIGN=on
+# BOT_HUMAN_QUIET_THRESHOLD: humans in a thread at/above which the bot withdraws
+#   from non-mention follow-ups (anti-spam). Default: 2.
+BOT_HUMAN_QUIET_THRESHOLD=2
+# BOT_DM_ENABLED: answer direct messages (private 1:1 Q&A). Default: on.
+BOT_DM_ENABLED=on
+# BOT_RATELIMIT_PER_MIN: max questions answered per (platform, channel, user)
+#   per minute before a one-time notice, then silent drop. Default: 12.
+BOT_RATELIMIT_PER_MIN=12
+# BOT_ASK_TIMEOUT_MS: total budget for one /ask call (shared across retries).
+#   Default: 45000.
+BOT_ASK_TIMEOUT_MS=45000
+# BOT_PARTICIPANT_CACHE_TTL_MS: cache a thread's human count to avoid a
+#   getParticipants() call per non-mention message. 0 disables. Default: 30000.
+BOT_PARTICIPANT_CACHE_TTL_MS=30000
+
 BRIDGE_API_KEY=
 BRIDGE_ALLOW_UNAUTH=
 BEEVER_BRIDGE_HMAC_DUAL=false

--- a/bot/README.md
+++ b/bot/README.md
@@ -34,6 +34,18 @@ See [`.env.example`](../.env.example) for the canonical list and descriptions. K
 | `BOT_PORT` | Port the bot HTTP server listens on (default: `3001`) |
 | `BACKEND_URL` | URL of the Python backend the bot forwards requests to |
 
+### Reply-feature tuning (all optional; safe defaults)
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `BOT_SESSION_SECRET` | _(dev default)_ | **Set in production.** HMAC key for per-thread conversation-memory session ids; when unset they are predictable to anyone who knows a thread id. |
+| `BOT_TRIGGER_REDESIGN` | `on` | Master switch for the gated triggers (mention / 1:1 / quiet-when-humans-join). `off` reverts to legacy behavior but still skips self/other-bots. |
+| `BOT_HUMAN_QUIET_THRESHOLD` | `2` | Humans in a thread at/above which the bot withdraws from non-mention follow-ups. |
+| `BOT_DM_ENABLED` | `on` | Answer direct messages (private 1:1 Q&A). |
+| `BOT_RATELIMIT_PER_MIN` | `12` | Max questions per (platform, channel, user) per minute before a one-time notice, then silent drop. |
+| `BOT_ASK_TIMEOUT_MS` | `45000` | Total budget for one `/ask` call (shared across retries). |
+| `BOT_PARTICIPANT_CACHE_TTL_MS` | `30000` | TTL cache for a thread's human count (avoids a `getParticipants()` call per non-mention message). `0` disables. |
+
 ### Platform Credentials (in `.env.example` section 5a)
 
 | Variable | Platform |

--- a/bot/src/index.ts
+++ b/bot/src/index.ts
@@ -53,7 +53,8 @@ const participantCache = new ParticipantCache(PARTICIPANT_CACHE_TTL_MS);
 function registerHandlers(bot: Chat): void {
   // Handler: user @mentions the bot in a not-yet-subscribed thread.
   bot.onNewMention(async (thread, message) => {
-    console.log(`[@mention] ${message.text} (from ${thread.id})`);
+    // Log length, not content — message text can carry PII/secrets.
+    console.log(`[@mention] (${(message.text || "").length} chars) from ${thread.id}`);
     // Never answer our own message or another bot — the latter prevents
     // bot-to-bot @mention loops (e.g. a workflow bot pinging Beever).
     if (message.author?.isMe === true || message.author?.isBot === true) return;
@@ -73,7 +74,8 @@ function registerHandlers(bot: Chat): void {
   // message here (including the bot's own replies and non-mention chatter), so
   // we gate before answering — see trigger.ts for the rules.
   bot.onSubscribedMessage(async (thread, message) => {
-    console.log(`[subscribed] ${message.text} (in ${thread.id})`);
+    // Log length, not content — message text can carry PII/secrets.
+    console.log(`[subscribed] (${(message.text || "").length} chars) in ${thread.id}`);
 
     // Always skip self/other-bots, even when the redesign flag is off — this is
     // the minimum guard that prevents the reply-storm, so the legacy fallback

--- a/bot/src/index.ts
+++ b/bot/src/index.ts
@@ -8,7 +8,10 @@ import { Chat } from "chat";
 import { renderResponse } from "./renderer.js";
 import { fetchSSEWithRetry } from "./sse-client.js";
 import { extractChannelId, extractPlatform } from "./thread-id.js";
-import { decideSubscribedAction } from "./trigger.js";
+import { decideSubscribedThreadActionWithLookup } from "./trigger.js";
+import { stripMention } from "./mentions.js";
+import { ParticipantCache } from "./participant-cache.js";
+import { logReplySent, type ReplySurface } from "./reply-metrics.js";
 import type { AskResult } from "./types.js";
 import { registerBridgeRoutes, recordTelegramChat, recordTeamsConversation, warmTeamsGraphToken, seedTeamsKnownTeamIds } from "./bridge.js";
 import { jsonResponse, readBody, MAX_BODY_SIZE, BodyTooLargeError, safeErrorMessage } from "./http-utils.js";
@@ -33,6 +36,13 @@ const PORT = parseInt(process.env.BOT_PORT || "3001", 10);
 const ASK_TIMEOUT_MS = parseInt(process.env.BOT_ASK_TIMEOUT_MS || "45000", 10);
 const HUMAN_QUIET_THRESHOLD = parseInt(process.env.BOT_HUMAN_QUIET_THRESHOLD || "2", 10);
 const TRIGGER_REDESIGN = (process.env.BOT_TRIGGER_REDESIGN || "on").toLowerCase() !== "off";
+//  - DM_ENABLED: answer direct messages (1:1 Q&A). Set BOT_DM_ENABLED=off to disable.
+//  - PARTICIPANT_CACHE_TTL_MS: cache a thread's human count to avoid a
+//    getParticipants() round-trip per non-mention message. 0 disables the cache.
+const DM_ENABLED = (process.env.BOT_DM_ENABLED || "on").toLowerCase() !== "off";
+const PARTICIPANT_CACHE_TTL_MS = parseInt(process.env.BOT_PARTICIPANT_CACHE_TTL_MS || "30000", 10);
+
+const participantCache = new ParticipantCache(PARTICIPANT_CACHE_TTL_MS);
 
 // Issue #53 — validateEnv lives in ./validate-env.ts; it's WARN-only and
 // never gates startup (platform-specific creds are loaded from the backend
@@ -49,7 +59,8 @@ function registerHandlers(bot: Chat): void {
     if (message.author?.isMe === true || message.author?.isBot === true) return;
     await thread.subscribe();
 
-    const question = stripMention(message.text || "");
+    const platform = extractPlatform(thread.id);
+    const question = stripMention(message.text || "", platform);
     if (!question.trim()) {
       await thread.post("Please ask me a question! For example: @beever what is our tech stack?");
       return;
@@ -69,7 +80,8 @@ function registerHandlers(bot: Chat): void {
     // path stays safe to roll back to.
     if (message.author?.isMe === true || message.author?.isBot === true) return;
 
-    const question = stripMention(message.text || "");
+    const platform = extractPlatform(thread.id);
+    const question = stripMention(message.text || "", platform);
     if (!question.trim()) return;
 
     if (TRIGGER_REDESIGN) {
@@ -88,50 +100,89 @@ function registerHandlers(bot: Chat): void {
 
     await answerInThread(thread, question, "follow-up");
   });
+
+  // Handler: direct messages — a private 1:1 Q&A surface. DMs route through the
+  // same webhook dispatch, so no manifest config or new endpoint is needed.
+  if (DM_ENABLED) {
+    bot.onDirectMessage(async (thread, message) => {
+      console.log(`[dm] (from ${thread.id})`);
+      if (message.author?.isMe === true || message.author?.isBot === true) return;
+
+      const platform = extractPlatform(thread.id);
+      const question = stripMention(message.text || "", platform);
+      if (!question.trim()) {
+        await thread.post("Ask me anything about this workspace's knowledge.");
+        return;
+      }
+      await answerInThread(thread, question, "dm");
+    });
+  }
 }
 
+type ThreadForParticipants = {
+  id: string;
+  getParticipants(): Promise<Array<{ isMe: boolean; isBot?: boolean | "unknown" }>>;
+};
+
 /**
- * Decide what to do with a subscribed-thread message. Only pays the
- * `getParticipants()` cost when the participant count can actually change the
- * outcome (i.e. not self/bot and not an explicit mention). A lookup failure
- * errs toward answering, never toward going silent.
+ * Decide what to do with a subscribed-thread message. Delegates the rules to the
+ * pure `decideSubscribedThreadActionWithLookup`, injecting a cached human-count
+ * lookup so a busy thread doesn't trigger a getParticipants() call per message.
  */
 async function decideSubscribedThreadAction(
-  thread: { getParticipants(): Promise<Array<{ isMe: boolean; isBot?: boolean | "unknown" }>> },
+  thread: ThreadForParticipants,
   message: { isMention?: boolean; author?: { isMe?: boolean; isBot?: boolean | "unknown" } },
 ): Promise<"answer" | "skip" | "unsubscribe"> {
-  const isMe = message.author?.isMe === true;
-  const isBot = message.author?.isBot;
-  const isMention = message.isMention === true;
+  return decideSubscribedThreadActionWithLookup(
+    {
+      isMe: message.author?.isMe === true,
+      isBot: message.author?.isBot,
+      isMention: message.isMention === true,
+      quietThreshold: HUMAN_QUIET_THRESHOLD,
+    },
+    () => getHumanCount(thread),
+  );
+}
 
-  if (isMe || isBot === true || isMention) {
-    return decideSubscribedAction({ isMe, isBot, isMention, quietThreshold: HUMAN_QUIET_THRESHOLD });
-  }
-
-  let humanCount: number | undefined;
+/** Human participant count for a thread, served from a short TTL cache. */
+async function getHumanCount(thread: ThreadForParticipants): Promise<number | undefined> {
+  const cached = participantCache.get(thread.id);
+  if (cached !== undefined) return cached;
   try {
     const participants = await thread.getParticipants();
     // Count only humans — exclude self and other bots so a single human + a
     // helper bot doesn't trip the multi-human "go quiet" threshold.
-    humanCount = participants.filter((p) => p.isMe !== true && p.isBot !== true).length;
+    const humanCount = participants.filter((p) => p.isMe !== true && p.isBot !== true).length;
+    participantCache.set(thread.id, humanCount);
+    return humanCount;
   } catch (err) {
     console.error("getParticipants failed; defaulting to answer:", safeErrorMessage(err));
-    humanCount = undefined;
+    return undefined;
   }
-  return decideSubscribedAction({ isMe, isBot, isMention, humanCount, quietThreshold: HUMAN_QUIET_THRESHOLD });
 }
 
 /** Ask the backend and post the rendered reply, swallowing errors into a friendly notice. */
 async function answerInThread(
   thread: { id: string; post(message: string): Promise<unknown> },
   question: string,
-  kind: "mention" | "follow-up",
+  surface: ReplySurface,
 ): Promise<void> {
+  const platform = extractPlatform(thread.id);
+  const startedAt = Date.now();
   try {
     const result = await askBackend(extractChannelId(thread.id), question);
-    await thread.post(renderResponse(result, extractPlatform(thread.id)));
+    await thread.post(renderResponse(result, platform));
+    logReplySent({
+      surface,
+      platform,
+      route: result.route,
+      latencyMs: Date.now() - startedAt,
+      isEmpty: result.isEmpty,
+      citationCount: result.citations.length,
+      followUpCount: result.followUps?.length ?? 0,
+    });
   } catch (err) {
-    console.error(`Error processing ${kind}:`, safeErrorMessage(err));
+    console.error(`Error processing ${surface}:`, safeErrorMessage(err));
     // A failed reply must not throw out of the handler: that would make the
     // webhook return 5xx and skip conversation recording (serviceUrl), which
     // breaks later message fetches even though the activity was valid.
@@ -148,11 +199,6 @@ async function answerInThread(
 // consumers (sse-client, renderer, tests) don't import the server bootstrap.
 
 export type { AskResult } from "./types.js";
-
-function stripMention(text: string): string {
-  // Remove Slack @mention format: <@U12345> or <@U12345|username>
-  return text.replace(/<@[A-Z0-9]+(\|[^>]+)?>/g, "").trim();
-}
 
 function backendApiKey(): string {
   const raw = process.env.BEEVER_API_KEYS || "";

--- a/bot/src/index.ts
+++ b/bot/src/index.ts
@@ -12,6 +12,8 @@ import { decideSubscribedThreadActionWithLookup } from "./trigger.js";
 import { stripMention } from "./mentions.js";
 import { ParticipantCache } from "./participant-cache.js";
 import { logReplySent, type ReplySurface } from "./reply-metrics.js";
+import { deriveSessionId } from "./session-id.js";
+import { RateLimiter } from "./rate-limiter.js";
 import type { AskResult } from "./types.js";
 import { registerBridgeRoutes, recordTelegramChat, recordTeamsConversation, warmTeamsGraphToken, seedTeamsKnownTeamIds } from "./bridge.js";
 import { jsonResponse, readBody, MAX_BODY_SIZE, BodyTooLargeError, safeErrorMessage } from "./http-utils.js";
@@ -41,8 +43,15 @@ const TRIGGER_REDESIGN = (process.env.BOT_TRIGGER_REDESIGN || "on").toLowerCase(
 //    getParticipants() round-trip per non-mention message. 0 disables the cache.
 const DM_ENABLED = (process.env.BOT_DM_ENABLED || "on").toLowerCase() !== "off";
 const PARTICIPANT_CACHE_TTL_MS = parseInt(process.env.BOT_PARTICIPANT_CACHE_TTL_MS || "30000", 10);
+//  - RATELIMIT_PER_MIN: max questions answered per (platform,channel,user) per
+//    minute before a one-time "give me a moment" notice and silent drop.
+const RATE_LIMIT_PER_MIN = parseInt(process.env.BOT_RATELIMIT_PER_MIN || "12", 10);
+const RATE_WINDOW_MS = 60_000;
 
 const participantCache = new ParticipantCache(PARTICIPANT_CACHE_TTL_MS);
+const rateLimiter = new RateLimiter(RATE_LIMIT_PER_MIN, RATE_WINDOW_MS);
+// A second 1-per-window limiter so the throttle notice itself can't spam.
+const noticeLimiter = new RateLimiter(1, RATE_WINDOW_MS);
 
 // Issue #53 — validateEnv lives in ./validate-env.ts; it's WARN-only and
 // never gates startup (platform-specific creds are loaded from the backend
@@ -67,6 +76,7 @@ function registerHandlers(bot: Chat): void {
       return;
     }
 
+    if (!(await passesRateLimit(thread, message))) return;
     await answerInThread(thread, question, "mention");
   });
 
@@ -100,6 +110,7 @@ function registerHandlers(bot: Chat): void {
       }
     }
 
+    if (!(await passesRateLimit(thread, message))) return;
     await answerInThread(thread, question, "follow-up");
   });
 
@@ -116,9 +127,34 @@ function registerHandlers(bot: Chat): void {
         await thread.post("Ask me anything about this workspace's knowledge.");
         return;
       }
+      if (!(await passesRateLimit(thread, message))) return;
       await answerInThread(thread, question, "dm");
     });
   }
+}
+
+/**
+ * Inbound rate gate, keyed per (platform, channel, user) so one user can't
+ * exhaust a shared channel's budget. On the first block within a window it posts
+ * a single friendly notice (the notice itself is rate-limited), then drops
+ * silently. Returns true when the request may proceed.
+ */
+async function passesRateLimit(
+  thread: { id: string; post(message: string): Promise<unknown> },
+  message: { author?: { userId?: string } },
+): Promise<boolean> {
+  const key = `${extractPlatform(thread.id)}:${extractChannelId(thread.id)}:${message.author?.userId || "unknown"}`;
+  const decision = rateLimiter.check(key);
+  if (decision.allowed) return true;
+  if (noticeLimiter.check(key).allowed) {
+    const secs = Math.max(1, Math.ceil(decision.retryAfterMs / 1000));
+    try {
+      await thread.post(`You're asking a lot — give me a moment 🙂 (try again in ~${secs}s)`);
+    } catch (err) {
+      console.error("Failed to post rate-limit notice:", safeErrorMessage(err));
+    }
+  }
+  return false;
 }
 
 type ThreadForParticipants = {
@@ -172,7 +208,14 @@ async function answerInThread(
   const platform = extractPlatform(thread.id);
   const startedAt = Date.now();
   try {
-    const result = await askBackend(extractChannelId(thread.id), question);
+    // Stable per-thread session id → backend resumes the thread's history so
+    // follow-ups remember the prior exchange. See session-id.ts for the
+    // thread-scoped (not channel/user) security rationale.
+    const result = await askBackend(
+      extractChannelId(thread.id),
+      question,
+      deriveSessionId(thread.id),
+    );
     await thread.post(renderResponse(result, platform));
     logReplySent({
       surface,
@@ -207,7 +250,11 @@ function backendApiKey(): string {
   return raw.split(",").map((k) => k.trim()).find(Boolean) || "";
 }
 
-async function askBackend(channelId: string, question: string): Promise<AskResult> {
+async function askBackend(
+  channelId: string,
+  question: string,
+  sessionId: string,
+): Promise<AskResult> {
   // Encode the channel id so a value with slashes/`..` can't escape the route
   // path and reach an unintended backend endpoint.
   const url = `${BACKEND_URL}/api/channels/${encodeURIComponent(channelId)}/ask`;
@@ -221,7 +268,7 @@ async function askBackend(channelId: string, question: string): Promise<AskResul
   // slow or flapping backend doesn't surface a hard error to the user.
   return fetchSSEWithRetry(
     url,
-    { method: "POST", headers, body: JSON.stringify({ question }) },
+    { method: "POST", headers, body: JSON.stringify({ question, session_id: sessionId }) },
     { maxAttempts: 3, signal: AbortSignal.timeout(ASK_TIMEOUT_MS) },
   );
 }

--- a/bot/src/integration.test.ts
+++ b/bot/src/integration.test.ts
@@ -1,0 +1,126 @@
+/**
+ * End-to-end seam test: a realistic backend SSE byte stream → consumeSSEStream →
+ * AskResult → renderResponse, asserting the whole reply pipeline composes
+ * correctly (not just each unit in isolation).
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { consumeSSEStream } from "./sse-client.js";
+import { renderResponse } from "./renderer.js";
+
+function streamFrom(lines: string[]): Response {
+  return new Response(lines.join("\n"), {
+    status: 200,
+    headers: { "Content-Type": "text/event-stream" },
+  });
+}
+
+describe("integration: SSE stream → rendered reply", () => {
+  it("renders a full rich reply with every section in order", async () => {
+    const syncTs = new Date(Date.now() - 2 * 3600_000).toISOString();
+    const body = [
+      "event: response_delta",
+      'data: {"delta": "We chose GridFS as the OSS default. "}',
+      "",
+      "event: response_delta",
+      'data: {"delta": "MinIO is opt-in via config."}',
+      "",
+      "event: citations",
+      'data: {"sources": [' +
+        '{"kind": "wiki_page", "title": "Media storage", "permalink": "https://wiki/media"},' +
+        '{"kind": "channel_message", "title": "no object store on OSS", "native": {"author": "Alan", "channel_name": "#tech"}},' +
+        '{"kind": "decision_record", "title": "GridFS default decision"},' +
+        '{"kind": "graph_relationship", "title": "Alan owns media-storage"}' +
+        "]}",
+      "",
+      "event: follow_ups",
+      'data: {"suggestions": ["How do I switch to MinIO?", "GridFS size limit?"]}',
+      "",
+      "event: related_context",
+      'data: {"tensions": [{"title": "GridFS scalability disputed", "detail": "Alan: fine vs Thomas: risky"}]}',
+      "",
+      "event: metadata",
+      `data: {"route": "qa_agent", "confidence": 0.91, "last_sync_ts": "${syncTs}"}`,
+      "",
+      "event: done",
+      "data: {}",
+      "",
+    ];
+
+    const result = await consumeSSEStream(streamFrom(body));
+
+    // Parsed model is correct.
+    assert.ok(result.answer.includes("GridFS as the OSS default"));
+    assert.strictEqual(result.citations.length, 4);
+    assert.deepStrictEqual(result.followUps, ["How do I switch to MinIO?", "GridFS size limit?"]);
+    assert.strictEqual(result.tensions?.[0].title, "GridFS scalability disputed");
+    assert.strictEqual(result.confidence, 0.91);
+    assert.strictEqual(result.isEmpty, false);
+
+    const out = renderResponse(result, "slack");
+    // Answer first.
+    assert.ok(out.startsWith("We chose GridFS"));
+    // Sources block has the direct sources with provenance.
+    assert.ok(out.includes("📎 *Sources*"));
+    assert.ok(out.includes("📖 [1] Media storage <https://wiki/media>"));
+    assert.ok(out.includes("💬 [2] no object store on OSS — Alan, #tech"));
+    // Related block has the graph/decision citations, with ORIGINAL indices.
+    assert.ok(out.includes("🧠 *Related*"));
+    assert.ok(out.includes("⚖️ [3] GridFS default decision"));
+    assert.ok(out.includes("🧠 [4] Alan owns media-storage"));
+    // Proactive tension heads-up.
+    assert.ok(out.includes("⚠️ *Heads up — possible tension*"));
+    assert.ok(out.includes("GridFS scalability disputed — Alan: fine vs Thomas: risky"));
+    // Freshness + follow-ups + route.
+    assert.ok(out.includes("🕐 _synced 2h ago_"));
+    assert.ok(out.includes("_You might also ask:_"));
+    assert.ok(out.includes("• How do I switch to MinIO?"));
+    assert.ok(out.includes("_via qa_agent_"));
+    // High confidence → NO warning.
+    assert.ok(!out.includes("low confidence"));
+  });
+
+  it("renders the honest empty state when the backend flags empty retrieval", async () => {
+    const body = [
+      "event: response_delta",
+      'data: {"delta": "This channel hasn\'t been synced yet."}',
+      "",
+      "event: citations",
+      'data: {"items": []}',
+      "",
+      "event: metadata",
+      'data: {"route": "qa_agent", "confidence": 0.15, "is_empty_retrieval": true}',
+      "",
+      "event: done",
+      "data: {}",
+      "",
+    ];
+    const result = await consumeSSEStream(streamFrom(body));
+    assert.strictEqual(result.isEmpty, true);
+    const out = renderResponse(result, "discord");
+    assert.ok(/don't have anything indexed/i.test(out));
+    assert.ok(!out.includes("📎 *Sources*"));
+  });
+
+  it("shows a low-confidence warning (right under the answer) when retrieval is thin", async () => {
+    const body = [
+      "event: response_delta",
+      'data: {"delta": "Possibly, but I am not certain."}',
+      "",
+      "event: citations",
+      'data: {"items": [{"type": "channel_message", "text": "a single weak hit"}]}',
+      "",
+      "event: metadata",
+      'data: {"route": "qa_agent", "confidence": 0.2}',
+      "",
+      "event: done",
+      "data: {}",
+      "",
+    ];
+    const result = await consumeSSEStream(streamFrom(body));
+    const out = renderResponse(result, "slack");
+    assert.ok(out.includes("⚠️ _low confidence"));
+    // Warning precedes the Sources block (truncation-safe placement).
+    assert.ok(out.indexOf("low confidence") < out.indexOf("📎 *Sources*"));
+  });
+});

--- a/bot/src/mentions.test.ts
+++ b/bot/src/mentions.test.ts
@@ -31,6 +31,10 @@ describe("stripMention", () => {
     assert.strictEqual(stripMention("please ping @bob about it", "mattermost"), "please ping @bob about it");
   });
 
+  it("strips only the leading bot @handle, keeping a following @user", () => {
+    assert.strictEqual(stripMention("@beever @bob what happened", "mattermost"), "@bob what happened");
+  });
+
   it("returns empty string for a mention-only message", () => {
     assert.strictEqual(stripMention("<@U123>", "slack"), "");
     assert.strictEqual(stripMention("   ", "slack"), "");

--- a/bot/src/mentions.test.ts
+++ b/bot/src/mentions.test.ts
@@ -1,0 +1,42 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { stripMention } from "./mentions.js";
+
+describe("stripMention", () => {
+  it("strips Slack mentions (with and without label)", () => {
+    assert.strictEqual(stripMention("<@U123> what is our stack?", "slack"), "what is our stack?");
+    assert.strictEqual(stripMention("<@U123|beever> hi", "slack"), "hi");
+  });
+
+  it("strips Discord user, nickname, and role mentions", () => {
+    assert.strictEqual(stripMention("<@123456> question", "discord"), "question");
+    assert.strictEqual(stripMention("<@!123456> question", "discord"), "question");
+    assert.strictEqual(stripMention("<@&987> question", "discord"), "question");
+  });
+
+  it("strips Teams <at> mentions", () => {
+    assert.strictEqual(stripMention("<at>Beever Atlas</at> what's new?", "teams"), "what's new?");
+  });
+
+  it("strips a leading @handle on Mattermost/Telegram only", () => {
+    assert.strictEqual(stripMention("@beever what's up", "mattermost"), "what's up");
+    assert.strictEqual(stripMention("@beever_bot hello", "telegram"), "hello");
+  });
+
+  it("does NOT strip a leading @handle on Slack (bracket-only platform)", () => {
+    assert.strictEqual(stripMention("@channel please answer", "slack"), "@channel please answer");
+  });
+
+  it("leaves a mid-sentence @handle intact on Mattermost", () => {
+    assert.strictEqual(stripMention("please ping @bob about it", "mattermost"), "please ping @bob about it");
+  });
+
+  it("returns empty string for a mention-only message", () => {
+    assert.strictEqual(stripMention("<@U123>", "slack"), "");
+    assert.strictEqual(stripMention("   ", "slack"), "");
+  });
+
+  it("leaves plain text untouched", () => {
+    assert.strictEqual(stripMention("what is our roadmap?", "discord"), "what is our roadmap?");
+  });
+});

--- a/bot/src/mentions.ts
+++ b/bot/src/mentions.ts
@@ -1,0 +1,28 @@
+/**
+ * Strip a bot @mention from inbound text, per platform.
+ *
+ * Previously only Slack's `<@U123>` form was removed, so Discord/Teams/Telegram/
+ * Mattermost mention tokens leaked into the question and degraded the answer.
+ * The bracketed forms (Slack/Discord/Teams) are always safe to strip; the bare
+ * `@handle` form (Mattermost/Telegram) is only stripped at the start of the
+ * message and only for those platforms, to avoid eating a legitimate "@channel"
+ * inside a question.
+ */
+
+// Slack `<@U123>` / `<@U123|name>` and Discord `<@123>` / `<@!123>` / `<@&123>`.
+const BRACKET_USER = /<@[!&]?[A-Z0-9]+(\|[^>]+)?>/gi;
+// Teams HTML mention `<at>Display Name</at>`.
+const TEAMS_AT = /<at>[^<]*<\/at>/gi;
+// Bare `@handle` at the very start of the message (Mattermost / Telegram).
+const LEADING_HANDLE = /^\s*@[\w.-]+\s*/;
+
+export function stripMention(text: string, platform?: string): string {
+  let out = text.replace(BRACKET_USER, " ").replace(TEAMS_AT, " ");
+
+  const p = (platform || "").toLowerCase();
+  if (p === "mattermost" || p === "telegram") {
+    out = out.replace(LEADING_HANDLE, " ");
+  }
+
+  return out.replace(/\s+/g, " ").trim();
+}

--- a/bot/src/participant-cache.test.ts
+++ b/bot/src/participant-cache.test.ts
@@ -1,0 +1,36 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { ParticipantCache } from "./participant-cache.js";
+
+describe("ParticipantCache", () => {
+  it("returns undefined on a miss and the value after set", () => {
+    const c = new ParticipantCache(1000, () => 0);
+    assert.strictEqual(c.get("t1"), undefined);
+    c.set("t1", 3);
+    assert.strictEqual(c.get("t1"), 3);
+  });
+
+  it("expires entries after the TTL (injected clock)", () => {
+    let now = 0;
+    const c = new ParticipantCache(1000, () => now);
+    c.set("t1", 2);
+    now = 999;
+    assert.strictEqual(c.get("t1"), 2);
+    now = 1000;
+    assert.strictEqual(c.get("t1"), undefined);
+  });
+
+  it("isolates entries per thread", () => {
+    const c = new ParticipantCache(1000, () => 0);
+    c.set("a", 1);
+    c.set("b", 5);
+    assert.strictEqual(c.get("a"), 1);
+    assert.strictEqual(c.get("b"), 5);
+  });
+
+  it("is disabled when TTL <= 0", () => {
+    const c = new ParticipantCache(0, () => 0);
+    c.set("t1", 9);
+    assert.strictEqual(c.get("t1"), undefined);
+  });
+});

--- a/bot/src/participant-cache.test.ts
+++ b/bot/src/participant-cache.test.ts
@@ -33,4 +33,12 @@ describe("ParticipantCache", () => {
     c.set("t1", 9);
     assert.strictEqual(c.get("t1"), undefined);
   });
+
+  it("bounds memory: never exceeds maxEntries", () => {
+    const c = new ParticipantCache(10_000, () => 0, 3);
+    for (let i = 0; i < 50; i++) c.set(`t${i}`, i);
+    let live = 0;
+    for (let i = 0; i < 50; i++) if (c.get(`t${i}`) !== undefined) live += 1;
+    assert.ok(live <= 3, `expected <=3 live entries, got ${live}`);
+  });
 });

--- a/bot/src/participant-cache.ts
+++ b/bot/src/participant-cache.ts
@@ -11,11 +11,13 @@
 export class ParticipantCache {
   private readonly ttlMs: number;
   private readonly now: () => number;
+  private readonly maxEntries: number;
   private readonly entries = new Map<string, { count: number; expires: number }>();
 
-  constructor(ttlMs: number, now: () => number = Date.now) {
+  constructor(ttlMs: number, now: () => number = Date.now, maxEntries = 5000) {
     this.ttlMs = ttlMs;
     this.now = now;
+    this.maxEntries = Math.max(1, maxEntries);
   }
 
   /** Cached human count for a thread, or undefined if absent/expired/disabled. */
@@ -33,5 +35,19 @@ export class ParticipantCache {
   set(threadId: string, count: number): void {
     if (this.ttlMs <= 0) return;
     this.entries.set(threadId, { count, expires: this.now() + this.ttlMs });
+    if (this.entries.size > this.maxEntries) this.evict();
+  }
+
+  /** Bound memory: drop expired entries first, then oldest, until within cap. */
+  private evict(): void {
+    const now = this.now();
+    for (const [key, value] of this.entries) {
+      if (value.expires <= now) this.entries.delete(key);
+    }
+    while (this.entries.size > this.maxEntries) {
+      const oldest = this.entries.keys().next().value;
+      if (oldest === undefined) break;
+      this.entries.delete(oldest);
+    }
   }
 }

--- a/bot/src/participant-cache.ts
+++ b/bot/src/participant-cache.ts
@@ -1,0 +1,37 @@
+/**
+ * Tiny TTL cache for a thread's human participant count.
+ *
+ * `getParticipants()` is called on every non-mention message in a subscribed
+ * thread to decide whether the bot should stay quiet. On a busy thread that can
+ * be a network round-trip per message; this caches the derived human count for
+ * a short TTL so a burst of chatter doesn't hammer the platform API.
+ *
+ * Pure and clock-injectable so it's unit-testable without timers.
+ */
+export class ParticipantCache {
+  private readonly ttlMs: number;
+  private readonly now: () => number;
+  private readonly entries = new Map<string, { count: number; expires: number }>();
+
+  constructor(ttlMs: number, now: () => number = Date.now) {
+    this.ttlMs = ttlMs;
+    this.now = now;
+  }
+
+  /** Cached human count for a thread, or undefined if absent/expired/disabled. */
+  get(threadId: string): number | undefined {
+    if (this.ttlMs <= 0) return undefined;
+    const hit = this.entries.get(threadId);
+    if (!hit) return undefined;
+    if (hit.expires <= this.now()) {
+      this.entries.delete(threadId);
+      return undefined;
+    }
+    return hit.count;
+  }
+
+  set(threadId: string, count: number): void {
+    if (this.ttlMs <= 0) return;
+    this.entries.set(threadId, { count, expires: this.now() + this.ttlMs });
+  }
+}

--- a/bot/src/rate-limiter.test.ts
+++ b/bot/src/rate-limiter.test.ts
@@ -1,0 +1,43 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { RateLimiter } from "./rate-limiter.js";
+
+describe("RateLimiter", () => {
+  it("allows up to the limit then blocks with a retry hint", () => {
+    const now = 0;
+    const rl = new RateLimiter(3, 1000, () => now);
+    assert.strictEqual(rl.check("k").allowed, true);
+    assert.strictEqual(rl.check("k").allowed, true);
+    assert.strictEqual(rl.check("k").allowed, true);
+    const blocked = rl.check("k");
+    assert.strictEqual(blocked.allowed, false);
+    assert.ok(blocked.retryAfterMs > 0 && blocked.retryAfterMs <= 1000);
+  });
+
+  it("slides: allows again once the window passes", () => {
+    let now = 0;
+    const rl = new RateLimiter(1, 1000, () => now);
+    assert.strictEqual(rl.check("k").allowed, true);
+    assert.strictEqual(rl.check("k").allowed, false);
+    now = 1001;
+    assert.strictEqual(rl.check("k").allowed, true);
+  });
+
+  it("isolates keys (one user can't exhaust another)", () => {
+    const now = 0;
+    const rl = new RateLimiter(1, 1000, () => now);
+    assert.strictEqual(rl.check("a").allowed, true);
+    assert.strictEqual(rl.check("b").allowed, true);
+    assert.strictEqual(rl.check("a").allowed, false);
+  });
+
+  it("stays functional after exceeding maxKeys (bounded memory)", () => {
+    let now = 0;
+    const rl = new RateLimiter(5, 1000, () => now, 3);
+    for (let i = 0; i < 100; i++) {
+      rl.check(`k${i}`);
+      now += 1;
+    }
+    assert.strictEqual(rl.check("fresh").allowed, true);
+  });
+});

--- a/bot/src/rate-limiter.ts
+++ b/bot/src/rate-limiter.ts
@@ -1,0 +1,59 @@
+/**
+ * In-memory sliding-window rate limiter.
+ *
+ * Gates inbound questions so a burst from one user can't hammer the backend.
+ * Keyed per (platform, channel, user) — including the user id so one abuser
+ * can't exhaust a shared channel's budget for everyone. Bounded + clock-
+ * injectable for tests; no external dependency.
+ */
+export interface RateDecision {
+  allowed: boolean;
+  /** Milliseconds until the next request would be allowed (0 when allowed). */
+  retryAfterMs: number;
+}
+
+export class RateLimiter {
+  private readonly limit: number;
+  private readonly windowMs: number;
+  private readonly now: () => number;
+  private readonly maxKeys: number;
+  private readonly hits = new Map<string, number[]>();
+
+  constructor(limit: number, windowMs: number, now: () => number = Date.now, maxKeys = 10_000) {
+    this.limit = Math.max(1, limit);
+    this.windowMs = Math.max(1, windowMs);
+    this.now = now;
+    this.maxKeys = Math.max(1, maxKeys);
+  }
+
+  /** Record an attempt and decide whether it's allowed under the window. */
+  check(key: string): RateDecision {
+    const t = this.now();
+    const cutoff = t - this.windowMs;
+    const recent = (this.hits.get(key) ?? []).filter((ts) => ts > cutoff);
+
+    if (recent.length >= this.limit) {
+      this.hits.set(key, recent);
+      return { allowed: false, retryAfterMs: Math.max(0, recent[0] + this.windowMs - t) };
+    }
+
+    recent.push(t);
+    this.hits.set(key, recent);
+    if (this.hits.size > this.maxKeys) this.evict(cutoff);
+    return { allowed: true, retryAfterMs: 0 };
+  }
+
+  /** Bound memory: drop empty/expired key buckets, then oldest, until within cap. */
+  private evict(cutoff: number): void {
+    for (const [key, arr] of this.hits) {
+      const live = arr.filter((ts) => ts > cutoff);
+      if (live.length === 0) this.hits.delete(key);
+      else this.hits.set(key, live);
+    }
+    while (this.hits.size > this.maxKeys) {
+      const oldest = this.hits.keys().next().value;
+      if (oldest === undefined) break;
+      this.hits.delete(oldest);
+    }
+  }
+}

--- a/bot/src/renderer.test.ts
+++ b/bot/src/renderer.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert";
 import {
   renderResponse,
   renderEmptyState,
+  renderFollowUps,
   enforceCap,
   relativeTime,
   CHAR_CAP,
@@ -101,6 +102,30 @@ describe("renderResponse", () => {
   it("falls back to a safe generic cap for unknown platforms", () => {
     const out = renderResponse(result({ answer: "y".repeat(5000) }), "weirdplatform");
     assert.ok(out.length <= CHAR_CAP.unknown);
+  });
+});
+
+describe("follow-ups", () => {
+  it("renders a 'You might also ask' block, capped at 3", () => {
+    const out = renderResponse(
+      result({ followUps: ["What is A?", "What is B?", "What is C?", "What is D?"] }),
+      "slack",
+    );
+    assert.ok(out.includes("You might also ask:"));
+    assert.ok(out.includes("• What is A?"));
+    assert.ok(out.includes("• What is C?"));
+    assert.ok(!out.includes("What is D?"));
+  });
+
+  it("omits the block on the empty state", () => {
+    const out = renderResponse(result({ isEmpty: true, followUps: ["X?"] }), "slack");
+    assert.ok(!out.includes("You might also ask:"));
+  });
+
+  it("renderFollowUps returns '' for empty/undefined", () => {
+    assert.strictEqual(renderFollowUps(undefined), "");
+    assert.strictEqual(renderFollowUps([]), "");
+    assert.strictEqual(renderFollowUps(["   "]), "");
   });
 });
 

--- a/bot/src/renderer.test.ts
+++ b/bot/src/renderer.test.ts
@@ -4,6 +4,8 @@ import {
   renderResponse,
   renderEmptyState,
   renderFollowUps,
+  renderConfidence,
+  renderTensions,
   enforceCap,
   relativeTime,
   CHAR_CAP,
@@ -126,6 +128,68 @@ describe("follow-ups", () => {
     assert.strictEqual(renderFollowUps(undefined), "");
     assert.strictEqual(renderFollowUps([]), "");
     assert.strictEqual(renderFollowUps(["   "]), "");
+  });
+});
+
+describe("related-context grouping", () => {
+  it("splits decision/graph citations into a Related block, keeping original indices", () => {
+    const out = renderResponse(
+      result({
+        citations: [
+          { type: "wiki_page", text: "Wiki A" },
+          { type: "decision_record", text: "Decided X" },
+          { type: "channel_message", text: "Msg B", author: "Jack" },
+          { type: "graph_relationship", text: "Alice → owns → X" },
+        ],
+      }),
+      "slack",
+    );
+    assert.ok(out.includes("📎 *Sources*"));
+    assert.ok(out.includes("🧠 *Related*"));
+    // Sources keeps indices [1] and [3]; Related keeps [2] and [4].
+    assert.ok(out.includes("📖 [1] Wiki A"));
+    assert.ok(out.includes("💬 [3] Msg B — Jack"));
+    assert.ok(out.includes("⚖️ [2] Decided X"));
+    assert.ok(out.includes("🧠 [4] Alice → owns → X"));
+  });
+});
+
+describe("renderConfidence", () => {
+  it("warns only on a real low score", () => {
+    assert.ok(renderConfidence(0.2, false).includes("low confidence"));
+    assert.strictEqual(renderConfidence(0.35, false).includes("low confidence"), true);
+    assert.strictEqual(renderConfidence(0.36, false), "");
+    assert.strictEqual(renderConfidence(0.85, false), "");
+  });
+  it("stays silent for no-signal (0) and on the empty state", () => {
+    assert.strictEqual(renderConfidence(0, false), "");
+    assert.strictEqual(renderConfidence(0.1, true), "");
+  });
+  it("appears in a full reply only when low", () => {
+    assert.ok(renderResponse(result({ confidence: 0.2 }), "slack").includes("low confidence"));
+    assert.ok(!renderResponse(result({ confidence: 0.9 }), "slack").includes("low confidence"));
+  });
+});
+
+describe("renderTensions", () => {
+  it("renders a heads-up block (max 2) with detail", () => {
+    const out = renderTensions([
+      { title: "Launch order disputed", detail: "marketing vs general" },
+      { title: "Booth staffing", detail: "unresolved" },
+      { title: "Third one", detail: "dropped" },
+    ]);
+    assert.ok(out.includes("Heads up — possible tension"));
+    assert.ok(out.includes("• Launch order disputed — marketing vs general"));
+    assert.ok(!out.includes("Third one"));
+  });
+  it("returns '' for empty/undefined", () => {
+    assert.strictEqual(renderTensions(undefined), "");
+    assert.strictEqual(renderTensions([]), "");
+  });
+  it("appears in a full reply when present", () => {
+    const out = renderResponse(result({ tensions: [{ title: "Conflict A" }] }), "slack");
+    assert.ok(out.includes("possible tension"));
+    assert.ok(out.includes("• Conflict A"));
   });
 });
 

--- a/bot/src/renderer.ts
+++ b/bot/src/renderer.ts
@@ -142,6 +142,21 @@ function renderRoute(route: string): string {
 }
 
 /**
+ * Suggested related questions as a short "You might also ask" list (max 3).
+ * Rendered before the route footer so that, under truncation, the chips are the
+ * sacrificial tail and the answer is always preserved.
+ */
+export function renderFollowUps(followUps?: string[]): string {
+  if (!followUps || followUps.length === 0) return "";
+  const items = followUps
+    .map((q) => cleanField(q, 120))
+    .filter((q) => q.length > 0)
+    .slice(0, 3);
+  if (items.length === 0) return "";
+  return `\n\n_You might also ask:_\n${items.map((q) => `• ${q}`).join("\n")}`;
+}
+
+/**
  * Honest, actionable empty state — replaces the old wall of
  * "I could not find any indexed memories…" text. Short, and points to the
  * next step instead of dead-ending.
@@ -167,6 +182,7 @@ export function renderResponse(result: AskResult, platform: string): string {
     (result.answer || "").trimEnd() +
     renderCitations(result.citations || []) +
     renderFreshness(result.lastSyncTs) +
+    renderFollowUps(result.followUps) +
     renderRoute(result.route || "qa_agent");
 
   return enforceCap(body, capFor(plat));

--- a/bot/src/renderer.ts
+++ b/bot/src/renderer.ts
@@ -235,11 +235,13 @@ export function renderResponse(result: AskResult, platform: string): string {
   const { sources, related } = partitionCitations(result.citations || []);
   const body =
     (result.answer || "").trimEnd() +
+    // A low-confidence warning sits right under the answer so truncation can
+    // never drop this trust signal.
+    renderConfidence(result.confidence, result.isEmpty) +
     renderCitationBlock("📎 *Sources*", sources) +
     renderCitationBlock("🧠 *Related*", related) +
     renderTensions(result.tensions) +
     renderFreshness(result.lastSyncTs) +
-    renderConfidence(result.confidence, result.isEmpty) +
     renderFollowUps(result.followUps) +
     renderRoute(result.route || "qa_agent");
 

--- a/bot/src/renderer.ts
+++ b/bot/src/renderer.ts
@@ -19,7 +19,7 @@
  * are a deliberate follow-up (they need the SDK `onAction` webhook wired up).
  */
 
-import type { AskResult, Citation } from "./types.js";
+import type { AskResult, Citation, Tension } from "./types.js";
 
 /**
  * Per-platform max message length (chars), set conservatively below each
@@ -94,8 +94,11 @@ function cleanUrl(u: string): string {
   return t.replace(/[\s<>]+/g, "");
 }
 
-function renderCitationLine(c: Citation, i: number): string {
-  let line = `${iconFor(c.type)} [${i + 1}] ${cleanField(c.text)}`.trim();
+/** Citation kinds that read as "related context" (graph) rather than direct sources. */
+const RELATED_KINDS = new Set(["decision_record", "graph_relationship"]);
+
+function renderCitationLine(c: Citation, num: number): string {
+  let line = `${iconFor(c.type)} [${num}] ${cleanField(c.text)}`.trim();
   const meta: string[] = [];
   if (c.author) meta.push(cleanField(c.author, 80));
   if (c.source) meta.push(cleanField(c.source, 80));
@@ -106,13 +109,64 @@ function renderCitationLine(c: Citation, i: number): string {
   return line;
 }
 
-export function renderCitations(citations: Citation[]): string {
-  if (citations.length === 0) return "";
-  const shown = citations.slice(0, MAX_CITATIONS);
-  const lines = shown.map(renderCitationLine).join("\n");
-  const overflow = citations.length - shown.length;
+/**
+ * Render one citation block under a heading. Entries carry their ORIGINAL
+ * 1-based index so inline `[n]` markers in the answer stay valid even though
+ * sources and related context are shown in separate blocks.
+ */
+function renderCitationBlock(heading: string, entries: Array<{ c: Citation; num: number }>): string {
+  if (entries.length === 0) return "";
+  const shown = entries.slice(0, MAX_CITATIONS);
+  const lines = shown.map(({ c, num }) => renderCitationLine(c, num)).join("\n");
+  const overflow = entries.length - shown.length;
   const more = overflow > 0 ? `\n_+${overflow} more_` : "";
-  return `\n\n📎 *Sources*\n${lines}${more}`;
+  return `\n\n${heading}\n${lines}${more}`;
+}
+
+/** Backward-compatible: render all citations as a single Sources block. */
+export function renderCitations(citations: Citation[]): string {
+  return renderCitationBlock("📎 *Sources*", citations.map((c, i) => ({ c, num: i + 1 })));
+}
+
+/** Group citations into direct sources vs graph "related context", keeping indices. */
+export function partitionCitations(citations: Citation[]): {
+  sources: Array<{ c: Citation; num: number }>;
+  related: Array<{ c: Citation; num: number }>;
+} {
+  const sources: Array<{ c: Citation; num: number }> = [];
+  const related: Array<{ c: Citation; num: number }> = [];
+  citations.forEach((c, i) => {
+    (RELATED_KINDS.has(c.type) ? related : sources).push({ c, num: i + 1 });
+  });
+  return { sources, related };
+}
+
+const LOW_CONFIDENCE = 0.35;
+
+/**
+ * A subtle low-confidence warning — shown ONLY when the backend reports a real
+ * score at/below the threshold. `0` means "no signal" (older backend) → silent;
+ * a high score → silent. Never fabricates a number.
+ */
+export function renderConfidence(confidence: number, isEmpty: boolean): string {
+  if (isEmpty) return "";
+  if (typeof confidence !== "number" || confidence <= 0 || confidence > LOW_CONFIDENCE) return "";
+  return `\n⚠️ _low confidence — please verify against the sources_`;
+}
+
+/** Proactive "heads up" when the answer touches a documented tension (max 2). */
+export function renderTensions(tensions?: Tension[]): string {
+  if (!tensions || tensions.length === 0) return "";
+  const items = tensions
+    .slice(0, 2)
+    .map((t) => {
+      const title = cleanField(t.title, 140);
+      const detail = t.detail ? cleanField(t.detail, 160) : "";
+      return detail ? `• ${title} — ${detail}` : `• ${title}`;
+    })
+    .filter((l) => l.length > 2);
+  if (items.length === 0) return "";
+  return `\n\n⚠️ *Heads up — possible tension*\n${items.join("\n")}`;
 }
 
 /** Human-friendly "Xm/Xh/Xd ago" from an ISO timestamp; null if unparseable. */
@@ -178,10 +232,14 @@ export function renderResponse(result: AskResult, platform: string): string {
   const plat = (platform || "unknown").toLowerCase();
   if (result.isEmpty) return renderEmptyState(result, plat);
 
+  const { sources, related } = partitionCitations(result.citations || []);
   const body =
     (result.answer || "").trimEnd() +
-    renderCitations(result.citations || []) +
+    renderCitationBlock("📎 *Sources*", sources) +
+    renderCitationBlock("🧠 *Related*", related) +
+    renderTensions(result.tensions) +
     renderFreshness(result.lastSyncTs) +
+    renderConfidence(result.confidence, result.isEmpty) +
     renderFollowUps(result.followUps) +
     renderRoute(result.route || "qa_agent");
 

--- a/bot/src/reply-metrics.test.ts
+++ b/bot/src/reply-metrics.test.ts
@@ -1,0 +1,56 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { buildReplyMetric, logReplySent, type ReplyMetric } from "./reply-metrics.js";
+
+const base = {
+  surface: "mention" as const,
+  platform: "slack",
+  route: "qa_agent",
+  latencyMs: 1234.6,
+  isEmpty: false,
+  citationCount: 3,
+  followUpCount: 2,
+};
+
+describe("buildReplyMetric", () => {
+  it("produces the reply_sent record with rounded latency", () => {
+    const m = buildReplyMetric(base);
+    assert.strictEqual(m.event, "reply_sent");
+    assert.strictEqual(m.surface, "mention");
+    assert.strictEqual(m.latencyMs, 1235);
+    assert.strictEqual(m.citationCount, 3);
+    assert.strictEqual(m.followUpCount, 2);
+  });
+
+  it("clamps negative latency/counts to zero", () => {
+    const m = buildReplyMetric({ ...base, latencyMs: -5, citationCount: -1, followUpCount: -9 });
+    assert.strictEqual(m.latencyMs, 0);
+    assert.strictEqual(m.citationCount, 0);
+    assert.strictEqual(m.followUpCount, 0);
+  });
+
+  it("carries NO PII (no thread/author/question/answer fields)", () => {
+    const m = buildReplyMetric(base);
+    const keys = Object.keys(m).sort();
+    assert.deepStrictEqual(keys, [
+      "citationCount",
+      "event",
+      "followUpCount",
+      "isEmpty",
+      "latencyMs",
+      "platform",
+      "route",
+      "surface",
+    ]);
+  });
+});
+
+describe("logReplySent", () => {
+  it("emits the built metric to the injected sink", () => {
+    const seen: ReplyMetric[] = [];
+    logReplySent(base, (m) => seen.push(m));
+    assert.strictEqual(seen.length, 1);
+    assert.strictEqual(seen[0].event, "reply_sent");
+    assert.strictEqual(seen[0].platform, "slack");
+  });
+});

--- a/bot/src/reply-metrics.ts
+++ b/bot/src/reply-metrics.ts
@@ -1,0 +1,52 @@
+/**
+ * Structured, PII-free observability for sent replies.
+ *
+ * Emits one `reply_sent` record per answered request so we can see — per
+ * platform and surface — latency, route, empty rate, and how often citations /
+ * follow-ups are present. Deliberately carries NO thread id, author id, question
+ * text, or answer text, so logs are safe to ship.
+ */
+import { logger } from "./logger.js";
+
+export type ReplySurface = "mention" | "follow-up" | "dm";
+
+export interface ReplyMetric {
+  event: "reply_sent";
+  surface: ReplySurface;
+  platform: string;
+  route: string;
+  latencyMs: number;
+  isEmpty: boolean;
+  citationCount: number;
+  followUpCount: number;
+}
+
+export interface ReplyMetricInput {
+  surface: ReplySurface;
+  platform: string;
+  route: string;
+  latencyMs: number;
+  isEmpty: boolean;
+  citationCount: number;
+  followUpCount: number;
+}
+
+export function buildReplyMetric(input: ReplyMetricInput): ReplyMetric {
+  return {
+    event: "reply_sent",
+    surface: input.surface,
+    platform: input.platform,
+    route: input.route,
+    latencyMs: Math.max(0, Math.round(input.latencyMs)),
+    isEmpty: input.isEmpty,
+    citationCount: Math.max(0, input.citationCount),
+    followUpCount: Math.max(0, input.followUpCount),
+  };
+}
+
+export function logReplySent(
+  input: ReplyMetricInput,
+  sink: (m: ReplyMetric) => void = (m) => logger.info(JSON.stringify(m)),
+): void {
+  sink(buildReplyMetric(input));
+}

--- a/bot/src/session-id.test.ts
+++ b/bot/src/session-id.test.ts
@@ -1,0 +1,22 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { deriveSessionId } from "./session-id.js";
+
+describe("deriveSessionId", () => {
+  it("is stable for the same thread", () => {
+    assert.strictEqual(deriveSessionId("slack:C1:t1"), deriveSessionId("slack:C1:t1"));
+  });
+
+  it("differs across threads, channels, and platforms (no merge, no bleed)", () => {
+    assert.notStrictEqual(deriveSessionId("slack:C1:t1"), deriveSessionId("slack:C1:t2"));
+    assert.notStrictEqual(deriveSessionId("slack:C1:t1"), deriveSessionId("slack:C2:t1"));
+    assert.notStrictEqual(deriveSessionId("slack:C1:t1"), deriveSessionId("discord:C1:t1"));
+  });
+
+  it("is an opaque hash that doesn't leak the raw thread id", () => {
+    const id = deriveSessionId("slack:C123:1700.0001");
+    assert.match(id, /^botmem_[0-9a-f]{64}$/);
+    assert.ok(!id.includes("slack"));
+    assert.ok(!id.includes("C123"));
+  });
+});

--- a/bot/src/session-id.ts
+++ b/bot/src/session-id.ts
@@ -1,4 +1,4 @@
-import { createHash } from "node:crypto";
+import { createHmac } from "node:crypto";
 
 /**
  * Derive a STABLE, thread-scoped session id for backend conversation memory.
@@ -12,11 +12,14 @@ import { createHash } from "node:crypto";
  * Everyone who can see a thread already shares its messages, so thread-scoping
  * crosses no new privacy boundary; the platform's own ACL gates thread access.
  * For DMs the thread id encodes the DM pair, so the session is naturally private.
- * The value is hashed so platform/channel topology never leaks into stored
- * session keys, and to give a fixed-width opaque id. The integrity of this
- * derivation IS the security boundary — do not key it on anything broader.
+ * The value is HMAC-hashed (keyed by BOT_SESSION_SECRET) so platform/channel
+ * topology never leaks into stored session keys AND the id is unpredictable even
+ * to an insider who knows the raw thread id — set BOT_SESSION_SECRET in prod.
+ * The integrity of this derivation IS the security boundary — do not key it on
+ * anything broader than the thread.
  */
 export function deriveSessionId(threadId: string): string {
-  const hash = createHash("sha256").update(`bot-thread:${threadId}`).digest("hex");
+  const secret = process.env.BOT_SESSION_SECRET || "beever-bot-default-secret";
+  const hash = createHmac("sha256", secret).update(`bot-thread:${threadId}`).digest("hex");
   return `botmem_${hash}`;
 }

--- a/bot/src/session-id.ts
+++ b/bot/src/session-id.ts
@@ -1,0 +1,22 @@
+import { createHash } from "node:crypto";
+
+/**
+ * Derive a STABLE, thread-scoped session id for backend conversation memory.
+ *
+ * Passing a stable `session_id` to `/ask` lets the backend resume the thread's
+ * chat history, so follow-up questions remember the prior exchange.
+ *
+ * SECURITY — the id is keyed on the THREAD, never the channel or the user:
+ *  - channel-only would merge unrelated threads into one history;
+ *  - user-only would bleed a user's history across channels.
+ * Everyone who can see a thread already shares its messages, so thread-scoping
+ * crosses no new privacy boundary; the platform's own ACL gates thread access.
+ * For DMs the thread id encodes the DM pair, so the session is naturally private.
+ * The value is hashed so platform/channel topology never leaks into stored
+ * session keys, and to give a fixed-width opaque id. The integrity of this
+ * derivation IS the security boundary — do not key it on anything broader.
+ */
+export function deriveSessionId(threadId: string): string {
+  const hash = createHash("sha256").update(`bot-thread:${threadId}`).digest("hex");
+  return `botmem_${hash}`;
+}

--- a/bot/src/sse-client.test.ts
+++ b/bot/src/sse-client.test.ts
@@ -6,6 +6,7 @@ import {
   fetchSSEWithRetry,
   normalizeCitations,
   detectEmptyRetrieval,
+  resolveIsEmpty,
 } from "./sse-client.js";
 
 function mockResponse(body: string): Response {
@@ -211,6 +212,60 @@ describe("normalizeCitations", () => {
   });
   it("returns [] for empty payloads", () => {
     assert.deepStrictEqual(normalizeCitations({}), []);
+  });
+});
+
+describe("consumeSSEStream — follow_ups", () => {
+  it("captures up to 3 non-empty string suggestions", async () => {
+    const body = [
+      "event: response_delta",
+      'data: {"delta": "answer"}',
+      "",
+      "event: follow_ups",
+      'data: {"suggestions": ["What is X?", "  ", "How about Y?", 42, "Z?", "W?"]}',
+      "",
+      "event: metadata",
+      'data: {"route": "qa_agent"}',
+      "",
+      "event: done",
+      "data: {}",
+      "",
+    ].join("\n");
+    const result = await consumeSSEStream(mockResponse(body));
+    assert.deepStrictEqual(result.followUps, ["What is X?", "How about Y?", "Z?"]);
+  });
+
+  it("defaults followUps to [] when the event is absent", async () => {
+    const body = [
+      "event: response_delta",
+      'data: {"delta": "answer"}',
+      "",
+      "event: metadata",
+      'data: {"route": "qa_agent"}',
+      "",
+      "event: done",
+      "data: {}",
+      "",
+    ].join("\n");
+    const result = await consumeSSEStream(mockResponse(body));
+    assert.deepStrictEqual(result.followUps, []);
+  });
+});
+
+describe("resolveIsEmpty", () => {
+  const noCites: never[] = [];
+  it("trusts the backend empty flag for a short, uncited answer", () => {
+    assert.strictEqual(resolveIsEmpty("nothing here", noCites, true), true);
+  });
+  it("does NOT hide a substantive answer even if backend flags empty", () => {
+    assert.strictEqual(resolveIsEmpty("x".repeat(600), noCites, true), false);
+  });
+  it("is never empty when citations exist", () => {
+    assert.strictEqual(resolveIsEmpty("could not find any indexed", [{ type: "f", text: "t" }], true), false);
+  });
+  it("falls back to the text heuristic with no backend signal", () => {
+    assert.strictEqual(resolveIsEmpty("I could not find any indexed memories", noCites, undefined), true);
+    assert.strictEqual(resolveIsEmpty("The booth is H25.", noCites, undefined), false);
   });
 });
 

--- a/bot/src/sse-client.test.ts
+++ b/bot/src/sse-client.test.ts
@@ -7,6 +7,7 @@ import {
   normalizeCitations,
   detectEmptyRetrieval,
   resolveIsEmpty,
+  normalizeTensions,
 } from "./sse-client.js";
 
 function mockResponse(body: string): Response {
@@ -249,6 +250,63 @@ describe("consumeSSEStream — follow_ups", () => {
     ].join("\n");
     const result = await consumeSSEStream(mockResponse(body));
     assert.deepStrictEqual(result.followUps, []);
+  });
+});
+
+describe("consumeSSEStream — related_context", () => {
+  it("captures tensions from the related_context event", async () => {
+    const body = [
+      "event: response_delta",
+      'data: {"delta": "answer"}',
+      "",
+      "event: related_context",
+      'data: {"tensions": [{"title": "Launch order", "detail": "marketing vs general"}], "extracted_entities": ["launch"]}',
+      "",
+      "event: metadata",
+      'data: {"route": "qa_agent"}',
+      "",
+      "event: done",
+      "data: {}",
+      "",
+    ].join("\n");
+    const result = await consumeSSEStream(mockResponse(body));
+    assert.strictEqual(result.tensions?.length, 1);
+    assert.strictEqual(result.tensions?.[0].title, "Launch order");
+    assert.strictEqual(result.tensions?.[0].detail, "marketing vs general");
+  });
+
+  it("defaults tensions to [] when the event is absent", async () => {
+    const body = [
+      "event: metadata",
+      'data: {"route": "qa_agent"}',
+      "",
+      "event: done",
+      "data: {}",
+      "",
+    ].join("\n");
+    const result = await consumeSSEStream(mockResponse(body));
+    assert.deepStrictEqual(result.tensions, []);
+  });
+});
+
+describe("normalizeTensions", () => {
+  it("maps alt field names and caps at 3", () => {
+    const out = normalizeTensions({
+      tensions: [
+        { topic: "A", description: "da" },
+        { title: "B" },
+        { summary: "C" },
+        { title: "D" },
+      ],
+    });
+    assert.strictEqual(out.length, 3);
+    assert.strictEqual(out[0].title, "A");
+    assert.strictEqual(out[0].detail, "da");
+    assert.strictEqual(out[1].title, "B");
+  });
+  it("skips entries with no title and tolerates junk", () => {
+    assert.deepStrictEqual(normalizeTensions({ tensions: [{ detail: "x" }, 42, null] }), []);
+    assert.deepStrictEqual(normalizeTensions({}), []);
   });
 });
 

--- a/bot/src/sse-client.test.ts
+++ b/bot/src/sse-client.test.ts
@@ -260,6 +260,11 @@ describe("resolveIsEmpty", () => {
   it("does NOT hide a substantive answer even if backend flags empty", () => {
     assert.strictEqual(resolveIsEmpty("x".repeat(600), noCites, true), false);
   });
+  it("treats the 600-char threshold as the substantive boundary", () => {
+    // 599 chars is still collapsible when flagged empty; 600 is protected.
+    assert.strictEqual(resolveIsEmpty("x".repeat(599), noCites, true), true);
+    assert.strictEqual(resolveIsEmpty("x".repeat(600), noCites, true), false);
+  });
   it("is never empty when citations exist", () => {
     assert.strictEqual(resolveIsEmpty("could not find any indexed", [{ type: "f", text: "t" }], true), false);
   });

--- a/bot/src/sse-client.ts
+++ b/bot/src/sse-client.ts
@@ -7,7 +7,7 @@
  * backoff for retryable failures at the fetch layer.
  */
 
-import type { AskResult, Citation } from "./types.js";
+import type { AskResult, Citation, Tension } from "./types.js";
 
 export interface SSEConsumeOptions {
   onDelta?: (delta: string) => void;
@@ -31,6 +31,8 @@ interface StreamState {
   backendEmpty?: boolean;
   /** Suggested related questions from the backend `follow_ups` event. */
   followUps: string[];
+  /** Documented tensions from the backend `related_context` event. */
+  tensions: Tension[];
 }
 
 /**
@@ -92,6 +94,23 @@ export function normalizeCitations(data: Record<string, unknown>): Citation[] {
   return out;
 }
 
+/**
+ * Normalize the `related_context` event's `tensions` into {@link Tension}[].
+ * Tolerant of backend field naming (title/topic/summary, detail/description).
+ */
+export function normalizeTensions(data: Record<string, unknown>): Tension[] {
+  const raw = Array.isArray(data.tensions) ? data.tensions : [];
+  const out: Tension[] = [];
+  for (const item of raw) {
+    const t = asRecord(item);
+    const title = asString(t.title) ?? asString(t.topic) ?? asString(t.summary);
+    if (!title) continue;
+    out.push({ title, detail: asString(t.detail) ?? asString(t.description) ?? asString(t.summary) });
+    if (out.length >= 3) break;
+  }
+  return out;
+}
+
 /** True when retrieval clearly found nothing: no citations AND empty-pattern text. */
 export function detectEmptyRetrieval(answer: string, citations: Citation[]): boolean {
   if (citations.length > 0) return false;
@@ -126,6 +145,7 @@ function finalizeResult(state: StreamState): AskResult {
     isEmpty: resolveIsEmpty(state.answer, state.citations, state.backendEmpty),
     lastSyncTs: state.lastSyncTs,
     followUps: state.followUps,
+    tensions: state.tensions,
   };
 }
 
@@ -183,6 +203,9 @@ function applyEvent(
       }
       break;
     }
+    case "related_context":
+      state.tensions = normalizeTensions(event.data);
+      break;
     case "error":
       throw new Error((event.data.message as string) || "Unknown backend error");
   }
@@ -199,6 +222,7 @@ export async function consumeSSEStream(
     confidence: 0,
     costUsd: 0,
     followUps: [],
+    tensions: [],
   };
 
   if (!response.body) {

--- a/bot/src/sse-client.ts
+++ b/bot/src/sse-client.ts
@@ -29,7 +29,16 @@ interface StreamState {
   lastSyncTs?: string;
   /** Backend-provided empty-retrieval signal, if the metadata event carried it. */
   backendEmpty?: boolean;
+  /** Suggested related questions from the backend `follow_ups` event. */
+  followUps: string[];
 }
+
+/**
+ * Answers at/above this length are treated as substantive and never collapsed
+ * into the empty state, even if the backend flags empty retrieval — guards
+ * against hiding a real (if uncited) answer.
+ */
+const SUBSTANTIVE_ANSWER_CHARS = 600;
 
 /** Phrases the QA agent emits when retrieval found nothing (see backend prompt). */
 const EMPTY_PATTERN =
@@ -89,16 +98,34 @@ export function detectEmptyRetrieval(answer: string, citations: Citation[]): boo
   return EMPTY_PATTERN.test(answer);
 }
 
+/**
+ * Decide the final empty-state, combining the backend signal with the client
+ * heuristic safely. Requirements to render the empty state:
+ *  - no citations (a cited answer is never "empty"), AND
+ *  - the backend flagged empty retrieval OR the text matches the empty pattern, AND
+ *  - the answer is not substantive (so a long real answer is never hidden even
+ *    if the backend flag misfires).
+ */
+export function resolveIsEmpty(
+  answer: string,
+  citations: Citation[],
+  backendEmpty: boolean | undefined,
+): boolean {
+  if (citations.length > 0) return false;
+  if (answer.trim().length >= SUBSTANTIVE_ANSWER_CHARS) return false;
+  return backendEmpty === true || EMPTY_PATTERN.test(answer);
+}
+
 function finalizeResult(state: StreamState): AskResult {
-  const isEmpty = state.backendEmpty ?? detectEmptyRetrieval(state.answer, state.citations);
   return {
     answer: state.answer,
     citations: state.citations,
     route: state.route,
     confidence: state.confidence,
     costUsd: state.costUsd,
-    isEmpty,
+    isEmpty: resolveIsEmpty(state.answer, state.citations, state.backendEmpty),
     lastSyncTs: state.lastSyncTs,
+    followUps: state.followUps,
   };
 }
 
@@ -147,6 +174,15 @@ function applyEvent(
         state.lastSyncTs = event.data.last_sync_ts;
       }
       break;
+    case "follow_ups": {
+      const suggestions = event.data.suggestions;
+      if (Array.isArray(suggestions)) {
+        state.followUps = suggestions
+          .filter((s): s is string => typeof s === "string" && s.trim().length > 0)
+          .slice(0, 3);
+      }
+      break;
+    }
     case "error":
       throw new Error((event.data.message as string) || "Unknown backend error");
   }
@@ -162,6 +198,7 @@ export async function consumeSSEStream(
     route: "echo",
     confidence: 0,
     costUsd: 0,
+    followUps: [],
   };
 
   if (!response.body) {

--- a/bot/src/sse-client.ts
+++ b/bot/src/sse-client.ts
@@ -105,7 +105,10 @@ export function normalizeTensions(data: Record<string, unknown>): Tension[] {
     const t = asRecord(item);
     const title = asString(t.title) ?? asString(t.topic) ?? asString(t.summary);
     if (!title) continue;
-    out.push({ title, detail: asString(t.detail) ?? asString(t.description) ?? asString(t.summary) });
+    // Avoid "X — X": only use summary as detail when it wasn't promoted to title.
+    let detail = asString(t.detail) ?? asString(t.description);
+    if (!detail && asString(t.summary) !== title) detail = asString(t.summary);
+    out.push({ title, detail });
     if (out.length >= 3) break;
   }
   return out;

--- a/bot/src/trigger.test.ts
+++ b/bot/src/trigger.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "node:assert";
-import { decideSubscribedAction } from "./trigger.js";
+import { decideSubscribedAction, decideSubscribedThreadActionWithLookup } from "./trigger.js";
 
 const T = 2; // quiet threshold used across cases
 
@@ -63,5 +63,45 @@ describe("decideSubscribedAction", () => {
       decideSubscribedAction({ isMe: true, isBot: true, isMention: true, quietThreshold: T }),
       "skip",
     );
+  });
+});
+
+describe("decideSubscribedThreadActionWithLookup", () => {
+  it("answers a mention WITHOUT calling the participant lookup", async () => {
+    let calls = 0;
+    const action = await decideSubscribedThreadActionWithLookup(
+      { isMention: true, quietThreshold: T },
+      async () => { calls += 1; return 9; },
+    );
+    assert.strictEqual(action, "answer");
+    assert.strictEqual(calls, 0);
+  });
+
+  it("skips self/bot without calling the lookup", async () => {
+    let calls = 0;
+    const a = await decideSubscribedThreadActionWithLookup(
+      { isMe: true, quietThreshold: T },
+      async () => { calls += 1; return 0; },
+    );
+    assert.strictEqual(a, "skip");
+    assert.strictEqual(calls, 0);
+  });
+
+  it("unsubscribes a multi-human non-mention thread (one lookup call)", async () => {
+    let calls = 0;
+    const action = await decideSubscribedThreadActionWithLookup(
+      { isMention: false, quietThreshold: T },
+      async () => { calls += 1; return 2; },
+    );
+    assert.strictEqual(action, "unsubscribe");
+    assert.strictEqual(calls, 1);
+  });
+
+  it("answers when the lookup returns undefined (never silent on unknown)", async () => {
+    const action = await decideSubscribedThreadActionWithLookup(
+      { isMention: false, quietThreshold: T },
+      async () => undefined,
+    );
+    assert.strictEqual(action, "answer");
   });
 });

--- a/bot/src/trigger.ts
+++ b/bot/src/trigger.ts
@@ -47,3 +47,28 @@ export function decideSubscribedAction(input: SubscribedDecisionInput): Subscrib
   }
   return "answer";
 }
+
+export interface SubscribedThreadInput {
+  isMe?: boolean;
+  isBot?: boolean | "unknown";
+  isMention?: boolean;
+  quietThreshold: number;
+}
+
+/**
+ * Orchestrate the subscribed-thread decision, fetching the human count ONLY
+ * when it can change the outcome (not self/bot, not a mention). `getHumanCount`
+ * is injected — so this stays unit-testable without a live SDK — and may return
+ * `undefined` for "unknown", in which case we never go silent.
+ */
+export async function decideSubscribedThreadActionWithLookup(
+  input: SubscribedThreadInput,
+  getHumanCount: () => Promise<number | undefined>,
+): Promise<SubscribedAction> {
+  const { isMe, isBot, isMention, quietThreshold } = input;
+  if (isMe === true || isBot === true || isMention === true) {
+    return decideSubscribedAction({ isMe, isBot, isMention, quietThreshold });
+  }
+  const humanCount = await getHumanCount();
+  return decideSubscribedAction({ isMe, isBot, isMention, humanCount, quietThreshold });
+}

--- a/bot/src/types.ts
+++ b/bot/src/types.ts
@@ -23,6 +23,12 @@ export interface Citation {
   source?: string;
 }
 
+/** A documented tension/contradiction relevant to the answer (proactive nudge). */
+export interface Tension {
+  title: string;
+  detail?: string;
+}
+
 /** Assembled result of consuming one `/ask` SSE stream. */
 export interface AskResult {
   answer: string;
@@ -41,4 +47,6 @@ export interface AskResult {
   lastSyncTs?: string;
   /** Suggested related questions surfaced as chips at the reply tail. */
   followUps?: string[];
+  /** Documented tensions relevant to the answer (from the related_context event). */
+  tensions?: Tension[];
 }

--- a/bot/src/types.ts
+++ b/bot/src/types.ts
@@ -39,4 +39,6 @@ export interface AskResult {
   isEmpty: boolean;
   /** ISO-8601 timestamp of the channel's last sync, when the backend supplies it. */
   lastSyncTs?: string;
+  /** Suggested related questions surfaced as chips at the reply tail. */
+  followUps?: string[];
 }

--- a/scripts/smoke_reply.py
+++ b/scripts/smoke_reply.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python
+"""Local smoke test for the bot-reply SSE contract.
+
+Drives the REAL ``POST /api/channels/{id}/ask`` endpoint in-process (httpx
+ASGITransport) with mocked stores + a stubbed agent runner — no external
+services, database, or LLM keys needed — and asserts the v2/v3 SSE contract
+fields the chat bot relies on:
+
+  - ``metadata.confidence`` is COMPUTED (not the old hardcoded ``0.85``)
+  - ``metadata.is_empty_retrieval`` is present (honest empty-state signal)
+  - ``metadata.last_sync_ts`` key is present (freshness signal)
+  - the conversation-memory ``session_id`` is accepted (no 500)
+  - the stream terminates with ``done``
+
+Run:  uv run python scripts/smoke_reply.py
+Exit 0 = PASS, 1 = FAIL.
+"""
+
+from __future__ import annotations
+
+import os
+
+# Must be set before importing the app (auth + dev-mode wiring).
+os.environ.setdefault("BEEVER_ENV", "test")
+os.environ.setdefault("BEEVER_API_KEYS", "test-key")
+
+import asyncio  # noqa: E402
+import json  # noqa: E402
+import sys  # noqa: E402
+from unittest.mock import AsyncMock, MagicMock, patch  # noqa: E402
+
+from httpx import ASGITransport, AsyncClient  # noqa: E402
+
+
+def _make_event(text: str, *, partial: bool = False, turn_complete: bool = False):
+    part = MagicMock()
+    part.text = text
+    content = MagicMock()
+    content.parts = [part]
+    ev = MagicMock()
+    ev.content = content
+    ev.partial = partial
+    ev.turn_complete = turn_complete
+    ev.error_code = None
+    ev.error_message = None
+    ev.get_function_calls.return_value = []
+    ev.get_function_responses.return_value = []
+    return ev
+
+
+async def _fake_runner(**_kwargs):
+    """Stand-in ADK runner: stream a short answer, then complete the turn."""
+    yield _make_event("GridFS is the OSS default; MinIO is opt-in.", partial=True)
+    yield _make_event("", turn_complete=True)
+
+
+def _install_mock_stores():
+    import beever_atlas.stores as stores_mod
+
+    fake = MagicMock(name="MockStoreClients")
+    fake.mongodb = MagicMock()
+    fake.mongodb.get_channel_sync_state = AsyncMock(return_value=None)
+    fake.qa_history = MagicMock()
+    fake.qa_history.write_qa_entry = AsyncMock()
+    fake.chat_history = MagicMock()
+    stores_mod._stores = fake
+    stores_mod._stores_ready.set()
+
+
+def _parse_sse(text: str) -> list[tuple[str, dict | None]]:
+    events: list[tuple[str, dict | None]] = []
+    for block in text.split("\n\n"):
+        etype: str | None = None
+        data: dict | None = None
+        for line in block.split("\n"):
+            if line.startswith("event: "):
+                etype = line[7:].strip()
+            elif line.startswith("data: "):
+                try:
+                    data = json.loads(line[6:])
+                except Exception:
+                    data = None
+        if etype:
+            events.append((etype, data))
+    return events
+
+
+async def main() -> int:
+    _install_mock_stores()
+
+    from beever_atlas.infra.auth import Principal, require_user
+    from beever_atlas.server.app import app
+
+    app.dependency_overrides[require_user] = lambda: Principal("user:test", kind="user")
+
+    with (
+        patch("beever_atlas.agents.query.qa_agent.get_agent_for_mode", return_value=MagicMock()),
+        patch("beever_atlas.api.ask.create_runner") as mock_cr,
+        patch("beever_atlas.api.ask.create_session", new_callable=AsyncMock) as mock_cs,
+        patch("beever_atlas.api.ask._build_decomposed_prompt", side_effect=lambda q, _c: (q, None)),
+        patch("beever_atlas.api.ask._load_chat_history_parts", side_effect=lambda _s: []),
+        patch("beever_atlas.api.ask._assert_session_ownership_or_new", new_callable=AsyncMock),
+        # ACL is verified by the dedicated channel-access tests; no-op it here so
+        # the smoke can focus on the SSE contract without wiring real connections.
+        patch("beever_atlas.api.ask.assert_channel_access", new_callable=AsyncMock),
+    ):
+        runner = MagicMock()
+        runner.run_async = _fake_runner
+        mock_cr.return_value = runner
+        sess = MagicMock()
+        sess.user_id = "user:test"
+        sess.id = "smoke-session"
+        mock_cs.return_value = sess
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post(
+                "/api/channels/test-channel/ask",
+                json={"question": "why GridFS?", "session_id": "botmem_smoke"},
+                headers={"Authorization": "Bearer test-key"},
+            )
+            body = resp.text
+
+    events = _parse_sse(body)
+    types = [e for e, _ in events]
+    meta = next((d for e, d in events if e == "metadata"), None)
+
+    checks: list[tuple[str, bool, str]] = []
+
+    def check(name: str, ok: bool, detail: str = "") -> None:
+        checks.append((name, ok, detail))
+
+    check("HTTP 200", resp.status_code == 200, f"status={resp.status_code}")
+    check("metadata event present", meta is not None)
+    if meta is not None:
+        conf = meta.get("confidence")
+        check("confidence is numeric", isinstance(conf, (int, float)), f"confidence={conf}")
+        check(
+            "confidence is computed, not the old 0.85 constant", conf != 0.85, f"confidence={conf}"
+        )
+        check(
+            "is_empty_retrieval present",
+            "is_empty_retrieval" in meta,
+            f"={meta.get('is_empty_retrieval')}",
+        )
+        check("last_sync_ts key present", "last_sync_ts" in meta)
+    check("stream terminates with done", "done" in types)
+
+    print("Observed SSE event types:", types)
+    print("Metadata payload:", json.dumps(meta, indent=2) if meta else None)
+    print()
+    ok_all = True
+    for name, ok, detail in checks:
+        flag = "PASS" if ok else "FAIL"
+        print(f"  [{flag}] {name}{(' — ' + detail) if detail else ''}")
+        ok_all = ok_all and ok
+    print()
+    print("SMOKE:", "PASS ✅" if ok_all else "FAIL ❌")
+    return 0 if ok_all else 1
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/src/beever_atlas/agents/citations/registry.py
+++ b/src/beever_atlas/agents/citations/registry.py
@@ -212,6 +212,19 @@ class SourceRegistry:
                 out[s.kind] = out.get(s.kind, 0) + 1
         return out
 
+    def retrieval_scores(self) -> list[float]:
+        """Non-null retrieval scores across registered sources.
+
+        Used to compute an honest answer confidence; empty when no source
+        carried a numeric score.
+        """
+        out: list[float] = []
+        for s in self._sources.values():
+            score = s.retrieved_by.get("score")
+            if isinstance(score, (int, float)) and not isinstance(score, bool):
+                out.append(float(score))
+        return out
+
 
 # ----- ContextVar management -------------------------------------------
 

--- a/src/beever_atlas/api/ask.py
+++ b/src/beever_atlas/api/ask.py
@@ -303,6 +303,28 @@ def _compute_confidence(registry) -> float:
     return round(max(0.1, min(0.95, blended)), 2)
 
 
+async def _related_context_payload(
+    channel_id: str, principal_id: str, answer_text: str
+) -> dict | None:
+    """Best-effort inline proactive context (tensions relevant to the answer).
+
+    Computed AFTER the answer has finished streaming, so it never delays the
+    visible reply, and time-bounded to 0.8s so a slow wiki scan can't stall the
+    trailing events. Returns ``None`` (emit nothing) when there's nothing
+    relevant or on any error.
+    """
+    try:
+        from beever_atlas.capabilities.proactive import get_relevant_tensions
+
+        tensions = await asyncio.wait_for(
+            get_relevant_tensions(channel_id, principal_id, answer_text, limit=2),
+            timeout=0.8,
+        )
+    except Exception:  # pragma: no cover - defensive; proactive context is best-effort
+        return None
+    return {"tensions": tensions} if tensions else None
+
+
 async def _build_metadata_event(
     *,
     channel_id: str,
@@ -858,6 +880,9 @@ async def _run_agent_stream(
                         registry=_registry,
                     ),
                 )
+                _rc = await _related_context_payload(channel_id, user_id, accumulated_text)
+                if _rc:
+                    yield _sse_event("related_context", _rc)
                 await _persist_qa_history(
                     question=question,
                     answer=accumulated_text,
@@ -987,6 +1012,9 @@ async def _run_agent_stream(
                         registry=_registry,
                     ),
                 )
+                _rc = await _related_context_payload(channel_id, user_id, accumulated_text)
+                if _rc:
+                    yield _sse_event("related_context", _rc)
                 await _persist_qa_history(
                     question=question,
                     answer=accumulated_text,

--- a/src/beever_atlas/api/ask.py
+++ b/src/beever_atlas/api/ask.py
@@ -277,6 +277,32 @@ async def _load_chat_history_parts(session_id: str) -> list[genai_types.Content]
         return []
 
 
+def _compute_confidence(registry) -> float:
+    """Honest answer confidence in [0.1, 0.95] from retrieval signals.
+
+    No extra model call — blends signals already collected on the citation
+    registry:
+      - coverage (40%): how much of the answer is actually cited
+        (referenced markers / registered sources);
+      - breadth (30%): how many distinct sources were found (4+ = full);
+      - quality (30%): average retrieval score of those sources.
+    Returns a low ``0.15`` when nothing was retrieved or the registry is off, so
+    the signal is honest rather than the old fabricated ``0.85`` constant.
+    """
+    if registry is None:
+        return 0.15
+    registered = registry.registered_count
+    if registered == 0:
+        return 0.15
+    coverage = min(1.0, registry.referenced_count / registered)
+    breadth = min(1.0, registered / 4.0)
+    scores = registry.retrieval_scores()
+    quality = sum(scores) / len(scores) if scores else 0.5
+    quality = max(0.0, min(1.0, quality))
+    blended = 0.4 * coverage + 0.3 * breadth + 0.3 * quality
+    return round(max(0.1, min(0.95, blended)), 2)
+
+
 async def _build_metadata_event(
     *,
     channel_id: str,
@@ -309,7 +335,7 @@ async def _build_metadata_event(
 
     return {
         "route": "qa_agent",
-        "confidence": 0.85,
+        "confidence": _compute_confidence(registry),
         "cost_usd": 0.0,
         "channel_id": channel_id,
         "session_id": session_id,

--- a/src/beever_atlas/api/ask.py
+++ b/src/beever_atlas/api/ask.py
@@ -277,6 +277,48 @@ async def _load_chat_history_parts(session_id: str) -> list[genai_types.Content]
         return []
 
 
+async def _build_metadata_event(
+    *,
+    channel_id: str,
+    session_id: str,
+    mode: str,
+    registry,
+) -> dict:
+    """Assemble the SSE ``metadata`` payload.
+
+    Centralized so the non-deep and deep emit paths cannot drift. Adds two
+    additive, backward-compatible signals consumed by the chat bot:
+
+    - ``is_empty_retrieval``: ``True`` when retrieval registered no sources, so
+      the client can render an honest "nothing indexed" state instead of
+      guessing from the answer text. Falls back to ``False`` when the citation
+      registry is off (legacy path), leaving the client heuristic in charge.
+    - ``last_sync_ts``: the channel's last sync time (ISO-8601) for a freshness
+      hint. A store hiccup degrades it to ``None`` rather than breaking the
+      stream — freshness is best-effort.
+    """
+    from beever_atlas.stores import get_stores
+
+    last_sync_ts: str | None = None
+    try:
+        _state = await get_stores().mongodb.get_channel_sync_state(channel_id)
+        if _state is not None:
+            last_sync_ts = _state.last_sync_ts
+    except Exception:  # pragma: no cover - defensive; freshness is best-effort
+        last_sync_ts = None
+
+    return {
+        "route": "qa_agent",
+        "confidence": 0.85,
+        "cost_usd": 0.0,
+        "channel_id": channel_id,
+        "session_id": session_id,
+        "mode": mode,
+        "is_empty_retrieval": registry is not None and registry.registered_count == 0,
+        "last_sync_ts": last_sync_ts,
+    }
+
+
 async def _run_agent_stream(
     question: str,
     channel_id: str,
@@ -783,14 +825,12 @@ async def _run_agent_stream(
 
                 yield _sse_event(
                     "metadata",
-                    {
-                        "route": "qa_agent",
-                        "confidence": 0.85,
-                        "cost_usd": 0.0,
-                        "channel_id": channel_id,
-                        "session_id": session_id,
-                        "mode": mode,
-                    },
+                    await _build_metadata_event(
+                        channel_id=channel_id,
+                        session_id=session_id,
+                        mode=mode,
+                        registry=_registry,
+                    ),
                 )
                 await _persist_qa_history(
                     question=question,
@@ -914,14 +954,12 @@ async def _run_agent_stream(
 
                 yield _sse_event(
                     "metadata",
-                    {
-                        "route": "qa_agent",
-                        "confidence": 0.85,
-                        "cost_usd": 0.0,
-                        "channel_id": channel_id,
-                        "session_id": session_id,
-                        "mode": mode,
-                    },
+                    await _build_metadata_event(
+                        channel_id=channel_id,
+                        session_id=session_id,
+                        mode=mode,
+                        registry=_registry,
+                    ),
                 )
                 await _persist_qa_history(
                     question=question,

--- a/src/beever_atlas/capabilities/proactive.py
+++ b/src/beever_atlas/capabilities/proactive.py
@@ -1,0 +1,149 @@
+"""Proactive intelligence helpers for the chat reply path.
+
+Surfaces documented TENSIONS (open disagreements) that are relevant to an
+answer, so the bot can warn inline when a reply touches contested ground. Reuses
+the wiki ``tension_callout`` modules (the same source as the ``get_tensions`` MCP
+tool). ACL-enforced and never raises — returns ``[]`` on denial or any error, so
+the reply path can call it best-effort.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+
+logger = logging.getLogger(__name__)
+
+_WORD_RE = re.compile(r"[a-zA-Z][a-zA-Z0-9'\-]{3,}")
+_STOPWORDS = {
+    "this",
+    "that",
+    "these",
+    "those",
+    "with",
+    "from",
+    "about",
+    "their",
+    "there",
+    "have",
+    "will",
+    "would",
+    "should",
+    "could",
+    "what",
+    "when",
+    "where",
+    "which",
+    "into",
+    "than",
+    "then",
+    "they",
+    "them",
+    "your",
+    "ours",
+    "been",
+    "were",
+    "also",
+    "does",
+    "done",
+    "such",
+    "some",
+    "more",
+    "most",
+    "over",
+    "under",
+    "here",
+}
+
+
+def _keywords(text: str) -> set[str]:
+    """Significant lowercase word stems from text (len>=4, minus stopwords)."""
+    return {w.lower() for w in _WORD_RE.findall(text or "")} - _STOPWORDS
+
+
+def _summarize_positions(item: dict) -> str:
+    """Build a short 'A: stance vs B: stance' detail, or fall back to status."""
+    parts: list[str] = []
+    for pos in (item.get("positions") or [])[:2]:
+        if not isinstance(pos, dict):
+            continue
+        author = (pos.get("author") or "").strip()
+        stance = (pos.get("stance") or "").strip()
+        if author and stance:
+            parts.append(f"{author}: {stance}")
+        elif stance:
+            parts.append(stance)
+    if parts:
+        return " vs ".join(parts)
+    status = (item.get("status") or "").strip()
+    return f"status: {status}" if status else ""
+
+
+async def get_relevant_tensions(
+    channel_id: str,
+    principal_id: str,
+    answer_text: str,
+    *,
+    limit: int = 2,
+) -> list[dict]:
+    """Documented tensions whose topic overlaps the answer.
+
+    Relevance is keyword overlap between each tension's title and the answer,
+    so an answer about an unrelated topic surfaces NO tension (avoids false
+    alarms). Returns at most ``limit`` ``{title, detail}`` dicts; ``[]`` on
+    access denial or any error.
+    """
+    if not channel_id or not principal_id:
+        return []
+    try:
+        from beever_atlas.infra.channel_access import assert_channel_access
+
+        await assert_channel_access(principal_id, channel_id)
+    except Exception:
+        return []
+
+    try:
+        from beever_atlas.stores import get_stores
+        from beever_atlas.wiki.page_store import WikiPageStore
+
+        page_store = WikiPageStore(db=get_stores().mongodb.db)
+        pages = await page_store.list_pages(channel_id, target_lang="en")
+    except Exception:
+        logger.debug("get_relevant_tensions: page load failed channel=%s", channel_id)
+        return []
+
+    return extract_relevant_tensions(pages, answer_text, limit=limit)
+
+
+def extract_relevant_tensions(pages, answer_text: str, *, limit: int = 2) -> list[dict]:
+    """Pure core: scan wiki pages for ``tension_callout`` modules and keep those
+    whose title keywords overlap the answer. Each ``page`` only needs a
+    ``modules`` attribute. Returns at most ``limit`` ``{title, detail}`` dicts.
+    """
+    answer_kw = _keywords(answer_text)
+    if not answer_kw:
+        return []
+
+    out: list[dict] = []
+    for page in pages:
+        for module in getattr(page, "modules", None) or []:
+            if not isinstance(module, dict) or module.get("id") != "tension_callout":
+                continue
+            data = module.get("data") or {}
+            if not isinstance(data, dict):
+                continue
+            raw = data.get("tensions")
+            items = raw if isinstance(raw, list) else [data]
+            for item in items:
+                if not isinstance(item, dict):
+                    continue
+                title = (item.get("title") or item.get("summary") or "").strip()
+                if not title:
+                    continue
+                # Only surface a tension the answer actually touches.
+                if answer_kw.isdisjoint(_keywords(title)):
+                    continue
+                out.append({"title": title, "detail": _summarize_positions(item)})
+                if len(out) >= limit:
+                    return out
+    return out

--- a/tests/test_ask_endpoint.py
+++ b/tests/test_ask_endpoint.py
@@ -418,3 +418,44 @@ class TestComputeConfidence:
         assert many > few
         assert 0.1 <= few <= 0.95
         assert 0.1 <= many <= 0.95
+
+
+class TestReplyContractV2V3:
+    """Guards the SSE metadata fields the chat bot renders.
+
+    These are the v2/v3 additions the bot depends on; a regression here (e.g.
+    reverting confidence to a constant, or dropping a field) would silently
+    degrade the bot with no other test catching it.
+    """
+
+    @staticmethod
+    def _metadata(body: str) -> dict:
+        for block in body.split("\n\n"):
+            if "event: metadata" in block:
+                for line in block.split("\n"):
+                    if line.startswith("data:"):
+                        return json.loads(line[5:].strip())
+        raise AssertionError("no metadata event in stream")
+
+    @pytest.mark.asyncio
+    async def test_metadata_carries_computed_confidence_and_signals(
+        self, client: AsyncClient, mock_runner
+    ):
+        response = await client.post(
+            "/api/channels/C123/ask",
+            json={"question": "what is our stack?"},
+        )
+        assert response.status_code == 200
+        meta = self._metadata(response.text)
+
+        # Confidence is COMPUTED, never the old hardcoded 0.85 constant. The
+        # mock runner produces no citations, so the honest value is the 0.15
+        # floor (same whether the registry is empty or disabled).
+        assert isinstance(meta["confidence"], (int, float))
+        assert meta["confidence"] != 0.85
+        assert meta["confidence"] == 0.15
+
+        # Honest-empty-state and freshness signals are always present (the bot
+        # reads these keys; value may be null/false depending on data).
+        assert "is_empty_retrieval" in meta
+        assert "last_sync_ts" in meta

--- a/tests/test_ask_endpoint.py
+++ b/tests/test_ask_endpoint.py
@@ -367,3 +367,54 @@ class TestDoneEventGuarantee:
                 assert data["code"] == "AGENT_ERROR"
                 assert "Unexpected agent crash" in data["message"]
                 break
+
+
+class _FakeRegistry:
+    """Minimal stand-in for SourceRegistry for confidence-scoring tests."""
+
+    def __init__(self, registered: int, referenced: int, scores: list[float]):
+        self._registered = registered
+        self._referenced = referenced
+        self._scores = scores
+
+    @property
+    def registered_count(self) -> int:
+        return self._registered
+
+    @property
+    def referenced_count(self) -> int:
+        return self._referenced
+
+    def retrieval_scores(self) -> list[float]:
+        return self._scores
+
+
+class TestComputeConfidence:
+    """Honest confidence replaces the old hardcoded 0.85."""
+
+    def test_none_or_empty_registry_is_low(self):
+        from beever_atlas.api.ask import _compute_confidence
+
+        assert _compute_confidence(None) == 0.15
+        assert _compute_confidence(_FakeRegistry(0, 0, [])) == 0.15
+
+    def test_rich_retrieval_is_high_but_computed(self):
+        from beever_atlas.api.ask import _compute_confidence
+
+        val = _compute_confidence(_FakeRegistry(6, 6, [0.9, 0.9, 0.8]))
+        assert 0.85 <= val <= 0.95
+
+    def test_thin_retrieval_is_low_enough_to_warn(self):
+        from beever_atlas.api.ask import _compute_confidence
+
+        # one source, not cited inline, mediocre score
+        assert _compute_confidence(_FakeRegistry(1, 0, [0.4])) <= 0.35
+
+    def test_increases_with_breadth(self):
+        from beever_atlas.api.ask import _compute_confidence
+
+        few = _compute_confidence(_FakeRegistry(1, 1, [0.7]))
+        many = _compute_confidence(_FakeRegistry(6, 6, [0.7]))
+        assert many > few
+        assert 0.1 <= few <= 0.95
+        assert 0.1 <= many <= 0.95

--- a/tests/test_proactive.py
+++ b/tests/test_proactive.py
@@ -69,3 +69,22 @@ def test_keywords_drops_short_and_stopwords():
     kw = _keywords("The budget allocation is disputed")
     assert {"budget", "allocation", "disputed"} <= kw
     assert "the" not in kw and "is" not in kw
+
+
+from unittest.mock import AsyncMock, patch  # noqa: E402
+
+from beever_atlas.capabilities.proactive import get_relevant_tensions  # noqa: E402
+
+
+async def test_get_relevant_tensions_rejects_empty_args():
+    assert await get_relevant_tensions("", "principal", "text") == []
+    assert await get_relevant_tensions("channel", "", "text") == []
+
+
+async def test_get_relevant_tensions_returns_empty_on_access_denied():
+    with patch(
+        "beever_atlas.infra.channel_access.assert_channel_access",
+        new=AsyncMock(side_effect=PermissionError("denied")),
+    ):
+        out = await get_relevant_tensions("ch-eng", "user:abc", "the budget is disputed")
+    assert out == []

--- a/tests/test_proactive.py
+++ b/tests/test_proactive.py
@@ -1,0 +1,71 @@
+"""Tests for proactive tension surfacing (pure relevance logic, no I/O)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from beever_atlas.capabilities.proactive import (
+    _keywords,
+    _summarize_positions,
+    extract_relevant_tensions,
+)
+
+
+def _page(modules):
+    return SimpleNamespace(modules=modules)
+
+
+def _tension_module(title, positions=None, status="open"):
+    return {
+        "id": "tension_callout",
+        "data": {"title": title, "status": status, "positions": positions or []},
+    }
+
+
+class TestExtractRelevantTensions:
+    def test_surfaces_tension_when_answer_overlaps_title(self):
+        pages = [
+            _page(
+                [
+                    _tension_module(
+                        "Launch order disputed",
+                        [
+                            {"author": "Jacy", "stance": "MAGIC first"},
+                            {"author": "Pak", "stance": "Atlas first"},
+                        ],
+                    )
+                ]
+            )
+        ]
+        out = extract_relevant_tensions(pages, "Are we launching in a certain order?", limit=2)
+        assert len(out) == 1
+        assert out[0]["title"] == "Launch order disputed"
+        assert "Jacy: MAGIC first" in out[0]["detail"]
+
+    def test_no_false_tension_when_topic_unrelated(self):
+        pages = [_page([_tension_module("Launch order disputed")])]
+        assert extract_relevant_tensions(pages, "What is our refund policy?", limit=2) == []
+
+    def test_empty_answer_returns_nothing(self):
+        pages = [_page([_tension_module("Launch order disputed")])]
+        assert extract_relevant_tensions(pages, "", limit=2) == []
+
+    def test_caps_at_limit(self):
+        mods = [_tension_module(f"Budget item {i} disputed") for i in range(5)]
+        out = extract_relevant_tensions([_page(mods)], "the budget is disputed", limit=2)
+        assert len(out) == 2
+
+    def test_ignores_non_tension_modules_and_junk(self):
+        pages = [_page([{"id": "summary", "data": {}}, "junk", _tension_module("")])]
+        assert extract_relevant_tensions(pages, "anything relevant here", limit=2) == []
+
+
+def test_summarize_positions():
+    assert _summarize_positions({"status": "blocked"}) == "status: blocked"
+    assert _summarize_positions({"positions": [{"author": "A", "stance": "x"}]}) == "A: x"
+
+
+def test_keywords_drops_short_and_stopwords():
+    kw = _keywords("The budget allocation is disputed")
+    assert {"budget", "allocation", "disputed"} <= kw
+    assert "the" not in kw and "is" not in kw


### PR DESCRIPTION
> **Stacked on #230** (`feat/bot-reply-redesign`). This branch holds the **whole feature** (v1 + v2 + v3) for end-to-end testing; the PR diff is the increment over #230. Merge #230 first, then retarget this to `main` so the full unit-test CI runs (only the smoke job runs on a feature-base PR).

This PR turns the @mention bot from "answers questions" into a fast, multi-surface, market-competitive assistant. Built in reviewed, CI-green phases.

## What it can do now (use cases)

**1 — Answer with provenance, related context, freshness, and follow-ups**
```
@Beever Atlas why did we pick GridFS over MinIO?

Beever Atlas
We made GridFS the OSS default to keep the install single-dependency; MinIO/S3
is opt-in via config.

📎 Sources
📖 [1] Media storage  <https://wiki/media>
💬 [2] "let's not force an object store on OSS" — Alan, #tech-beever-atlas

🧠 Related
⚖️ [3] Decision: GridFS default (Jun 4)

🕐 synced 2h ago

_You might also ask:_
• How do I switch to MinIO?
• What's the GridFS size limit?
via qa_agent
```

**2 — Conversation memory** — follow-ups in a thread remember the prior turn (no re-stating context):
```
@Beever Atlas who owns the Teams integration?
→ Thomas — he shipped the aadGroupId persistence stack.
is it on EE prod?           ← no @mention, no context repeated
→ Yes, EE auto-deploys on merge to ee/main; it shipped Jun 1.
```

**3 — Proactive heads-up** when an answer touches contested ground:
```
⚠️ Heads up — possible tension
• Launch order disputed — Jacy: MAGIC first vs Pak: Atlas first
```

**4 — Honest confidence** — a subtle warning appears only when retrieval was thin:
```
⚠️ low confidence — please verify against the sources
```

**5 — Multi-language** — ask in 中文 / 日本語 / Español and the answer (and follow-up chips) come back in that language.

**6 — DM the bot** for private 1:1 Q&A. **7 — Rate-limited** so a burst can't hammer the backend.

## Feature status (all 9 requested + the v2 base)

| Feature | How | Latency |
|---|---|---|
| Conversation memory | per-thread `session_id` (HMAC) → backend resumes history | ~0 |
| Multi-language | already in the prompt (`LANGUAGE_DIRECTIVE`) — no change | 0 |
| Real confidence | `_compute_confidence` (coverage/breadth/quality) replaces hardcoded 0.85 | 0 |
| Tensions | `related_context` SSE event, ACL-enforced, entity-filtered | computed *after* answer, 0.8s-capped |
| Proactive (inline) | tension heads-up in the reply | shares tensions |
| Expert routing | rendered from existing `graph_relationship` citations | 0 |
| Decision tracing | rendered from existing `decision_record` citations | 0 |
| Rate limiting | sliding-window per (platform,channel,user), bounded | <1ms |
| Rich formatting | Related grouping + confidence + tensions + caps | 0 |

**Performance contract:** net added latency on the hot path is **<2ms**; tensions are computed only after the answer has streamed and are timeout-bounded; **no unconditional graph call** was added (experts/decisions reuse citations the agent already produced).

## Implementation

**Backend** (`src/beever_atlas/`, all additive/backward-compatible):
- `api/ask.py`: `_compute_confidence(registry)` (real score), `_related_context_payload(...)` (time-bounded tensions emit at both metadata sites, never breaks the `done` guarantee).
- `capabilities/proactive.py` (new): `get_relevant_tensions` — ACL via `assert_channel_access`, scans wiki `tension_callout` modules, keyword-filtered to the answer (no false alarms), never raises. Pure `extract_relevant_tensions` core.
- `agents/citations/registry.py`: `retrieval_scores()` accessor.

**Bot** (`bot/src/`):
- `session-id.ts` (new): HMAC, thread-scoped session id.
- `rate-limiter.ts` (new): bounded sliding-window limiter.
- `renderer.ts`: Related grouping (original `[n]` indices preserved), `renderConfidence`, `renderTensions`.
- `sse-client.ts`: capture `related_context` + `normalizeTensions`; `tensions`/`followUps` on `AskResult`.
- `index.ts`: session id wired to `askBackend`; rate gate on all 3 surfaces (mention/follow-up/DM); logs redacted.

## Review & security

Two multi-agent review passes (code + security + verify), every medium+ finding adversarially re-verified. **0 blockers.** Security **LOW** — session-id bleed analysis: thread-scoped + HMAC, crosses no new boundary (thread members already share context), requires the bot API key. The shared-bot-principal note is acceptable-by-design and documented.

## Test plan for the whole bot-reply feature

**Automated (this PR):** bot `npm run build && npm run lint && npm test` → **282 pass / 0 lint errors**; backend `ruff check` + `pytest tests/test_ask_endpoint.py tests/test_proactive.py` → **26 pass**. New suites: `session-id`, `rate-limiter`, `proactive`, plus renderer/sse extensions and `_compute_confidence`.

**Manual matrix — run per platform (Slack · Discord · Teams · Mattermost · Telegram), `BOT_TRIGGER_REDESIGN=on` then `=off`:**

| Check | Pass criterion |
|---|---|
| Mention / DM | answers; DM works with no @mention |
| **Conversation memory** | "what about X" after a topic uses prior context |
| **Multi-language** | ask in zh/ja/es → reply + chips in that language |
| **Speed** | first token <2s; `related_context` arrives *after* the answer, never delays it |
| **Efficiency** | logs show `get_tensions`/wiki scan ≤1× per reply; no graph call in quick/summarize |
| **Confidence** | rich answer → no warning; thin/empty → ⚠️ low-confidence |
| **Tensions** | overlapping topic → heads-up; unrelated topic → none (no false alarm) |
| **Experts/decisions** | deep-mode answers show ⚖️/🧠 Related entries from real citations |
| **Rate limit** | 13th rapid question/min → one friendly notice, then silent; no backend hit |
| **Security — no bleed** | user B in a different thread can't see user A's thread history |
| **Graph/wiki down** | reply still works; no related_context; no error surfaced |
| **Caps** | long reply respects each platform's char cap, truncates with `…[truncated]` |

## Deferred (separate PRs)
Interactive buttons (need an `onAction` Card pipeline), write-back/capture (new `POST /capture` + ACL), scheduled proactive digests (new worker + opt-in), slash/reaction (manifest config / feedback endpoint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
