### PR TITLE
ci(audit): ignore apscheduler CVE-2026-31072 (not exposed; no fix exists)

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -50,7 +50,17 @@ jobs:
         # google-adk (even latest 2.1.0) pins `starlette<1.0.0`. We can't reach
         # 1.0.1 without google-adk catching up. Revisit when google-adk relaxes
         # its starlette pin.
-        run: uv run --with pip-audit pip-audit --requirement /tmp/requirements-audit.txt --ignore-vuln PYSEC-2025-183 --ignore-vuln PYSEC-2026-161
+        #
+        # CVE-2026-31072 (apscheduler, GHSA-9cfw-f3f9-7mm7): RCE via insecure
+        # deserialization in APScheduler's JSONSerializer / CBORSerializer, used
+        # only by *persistent* data stores (MongoDB / SQLAlchemy). NOT EXPOSED:
+        # we use the in-process MemoryDataStore (services/scheduler.py) with
+        # schedules defined in code via Cron/Interval triggers — the vulnerable
+        # deserialization path is never reached and no untrusted serialized job
+        # data is ever loaded. No fixed release exists (4.0.0a6 is the latest
+        # alpha). Revisit when APScheduler ships a patched version, or if we ever
+        # switch to a persistent data store.
+        run: uv run --with pip-audit pip-audit --requirement /tmp/requirements-audit.txt --ignore-vuln PYSEC-2025-183 --ignore-vuln PYSEC-2026-161 --ignore-vuln CVE-2026-31072
 
       - name: Set up Node
         uses: actions/setup-node@v6


### PR DESCRIPTION
## Why CI is red on main

The HIGH/CRITICAL audit gate started failing on `main` (commit `45205a4c`, the README badge merge #231) — **not** caused by that change. A fresh advisory was disclosed between #231's PR checks (which passed) and the push-to-main run:

- **GHSA-9cfw-f3f9-7mm7 / CVE-2026-31072** — critical RCE via insecure deserialization in APScheduler's `JSONSerializer` / `CBORSerializer` (CVSS `AV:N/AC:L/PR:N/UI:N/C:H/I:H/A:H`).
- `apscheduler` is pinned `>=4.0.0a5`, locked at `4.0.0a6`, which **PyPI confirms is the newest release** — **no fixed version exists.**

## Are we exposed? → No.

The vulnerable deserialization path is reached only by APScheduler's **persistent** data stores (MongoDB / SQLAlchemy), where an attacker could inject a malicious serialized payload. We use the in-process **`MemoryDataStore`** (`services/scheduler.py:53`) with schedules defined **in code** via Cron/Interval triggers. No untrusted serialized job data is ever loaded. Verified: no `JSONSerializer` / `CBORSerializer` / persistent store anywhere in `src/`.

## Fix

Add `--ignore-vuln CVE-2026-31072` to the pip-audit gate, with a justification comment — same pattern already used for the disputed pyjwt and the not-yet-reachable starlette advisories. **Directive in the code:** if APScheduler is ever switched to a persistent data store, remove this ignore (the RCE path becomes reachable).

## Notes
- The **CI/Web failure** seen alongside this was a **flaky vitest test** (passed on re-run with identical code) — not addressed here, no fix needed.
- Local pip-audit A/B was blocked by a py3.13/litellm-wheel env quirk; **CI (Python 3.12) is the authoritative verification** of the ignore id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)