### PR TITLE
fix(extraction): stream long Gemini calls to fix ServerDisconnected → 0 facts (#223)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -288,6 +288,16 @@ BATCH_MAX_OUTPUT_TOKENS=24000
 LLM_OUTAGE_BREAKER_THRESHOLD=3
 FACT_MAX_RETRIES=3
 STALE_JOB_THRESHOLD_HOURS=1.0
+# Issue #223 — stream the long extraction call so a >120s gemini-2.5-pro
+# generate_content does not idle past the ~127-131s edge-proxy disconnect
+# threshold (aiohttp ServerDisconnectedError → rows succeeded=0 total_facts=0).
+# Routes the ingestion runner through ADK SSE streaming
+# (RunConfig(streaming_mode=SSE)). Default ON — this IS the fix; with it off the
+# long call still disconnects and yields 0 facts. Set 0 to revert. No-streaming
+# fallback knobs (keep each call under the idle ceiling): lower BATCH_MAX_MESSAGES
+# (default 30) to ~12-16, cap BATCH_MAX_OUTPUT_TOKENS, and/or set
+# LLM_QUALITY_MODEL=gemini-2.5-flash.
+INGEST_ADK_STREAMING_SSE=true
 
 # --- 3.5b LLM rate-limit overrides (B2 token-bucket throttle) -------
 # Tune to your provider's published RPM/TPM if you upgrade beyond the

--- a/src/beever_atlas/infra/config.py
+++ b/src/beever_atlas/infra/config.py
@@ -424,6 +424,28 @@ class Settings(BaseSettings):
     # DEFAULT OFF. Flip QA_ADK_STREAMING_SSE=1 to enable.
     qa_adk_streaming_sse: bool = Field(default=False, alias="QA_ADK_STREAMING_SSE")
 
+    # Ingestion/extraction ADK SSE streaming mode (Issue #223).
+    # When ON, the BatchProcessor's runner.run_async() receives
+    # RunConfig(streaming_mode=StreamingMode.SSE) so ADK dispatches the
+    # native google-genai generate_content_stream for the extraction stages
+    # (fact/entity/coref/contradiction/validator/summarizer). Streaming keeps
+    # the socket warm with incremental chunks so a long (>120s) gemini-2.5-pro
+    # call no longer idles past the ~127-131s edge-proxy disconnect threshold
+    # that surfaced as aiohttp.ServerDisconnectedError → rows succeeded=0
+    # total_facts=0. ADK aggregates the streamed JSON chunks into one assembled
+    # LlmResponse BEFORE the after_agent_callback, so the existing partial-JSON
+    # recovery + retry ladder runs unchanged on the same assembled text. Safe
+    # here because these agents use only response_mime_type=application/json
+    # (no output_schema, no tools) and therefore do NOT trigger ADK bug #3599.
+    # DEFAULT ON — this is the actual Issue #223 fix; with it OFF the long
+    # extraction call still idle-disconnects and yields 0 facts. Verified safe:
+    # the same SSE path runs in QA prod, ADK aggregates the streamed JSON before
+    # the recovery callback, and an end-to-end re-extraction confirmed facts>0.
+    # Set INGEST_ADK_STREAMING_SSE=0 to revert. No-streaming fallback knob:
+    # lower BATCH_MAX_MESSAGES (see batch_max_messages above) to ~12-16 and/or
+    # cap BATCH_MAX_OUTPUT_TOKENS so each call finishes under the idle ceiling.
+    ingest_adk_streaming_sse: bool = Field(default=True, alias="INGEST_ADK_STREAMING_SSE")
+
     # Multilingual memory & wiki/QA rendering (change: multilingual-native-memory).
     # When ON, ingestion detects BCP-47 source_lang per channel/message,
     # facts/entities are stored in source language, wiki/QA render in requested

--- a/src/beever_atlas/services/batch_processor.py
+++ b/src/beever_atlas/services/batch_processor.py
@@ -15,9 +15,11 @@ import time
 from dataclasses import asdict, dataclass, field
 from typing import TYPE_CHECKING, Any
 
+import aiohttp
 import httpx
 import json
 from aiolimiter import AsyncLimiter
+from google.adk.agents.run_config import RunConfig, StreamingMode
 from google.genai import types
 from google.genai.errors import ServerError
 from pydantic import ValidationError as PydanticValidationError
@@ -257,6 +259,49 @@ def _is_resumable(exc: Exception) -> bool:
     return False
 
 
+def _is_transient_net_error(exc: BaseException) -> bool:
+    """Return True if ``exc`` is a transient connection-level network drop.
+
+    Issue #223: a long, non-streaming ``gemini-2.5-pro`` ``generate_content``
+    call sits idle past the ~127-131s edge-proxy ceiling and the peer closes
+    the idle socket → ``aiohttp.ServerDisconnectedError``. This is NONE of the
+    four types caught at the resumable-retry site (``ServerError`` / 5xx
+    ``httpx.HTTPStatusError`` / ``PydanticValidationError`` / ``JSONDecodeError``)
+    and ``_is_truncation_error`` returns False for it, so without this predicate
+    it would hit the terminal ``else: raise`` on the very FIRST attempt with no
+    backoff. Worse, concurrent batches' disconnects feed the circuit breaker and
+    open it, fast-failing every remaining sub-batch into ``total_facts=0``.
+
+    Matches: aiohttp ServerDisconnectedError / ClientConnectionError /
+    ClientOSError, the stdlib ConnectionResetError, httpx RemoteProtocolError /
+    ReadError, and asyncio/builtin TimeoutError. ADK/anyio TaskGroups wrap the
+    real cause in an ``ExceptionGroup`` (``BaseExceptionGroup``), so we recurse
+    into ``.exceptions`` and report True if ANY leaf is a transient net error.
+
+    NOTE: ``httpx.RemoteProtocolError`` / ``ReadError`` are deliberately NOT
+    matched here — they are ambiguous (a mid-stream truncation surfaces the same
+    way) and are already handled by ``_is_truncation_error``'s reduce→halve
+    ladder. The genuine Issue #223 drop is the aiohttp ``ServerDisconnectedError``
+    on the google-genai aio path, so keeping the httpx truncation routing
+    unchanged avoids replaying an oversized request without shrinking it.
+    """
+    if isinstance(exc, BaseExceptionGroup):
+        return any(_is_transient_net_error(sub) for sub in exc.exceptions)
+    if isinstance(
+        exc,
+        (
+            aiohttp.ServerDisconnectedError,
+            aiohttp.ClientConnectionError,
+            aiohttp.ClientOSError,
+            ConnectionResetError,
+            asyncio.TimeoutError,
+            TimeoutError,
+        ),
+    ):
+        return True
+    return False
+
+
 @dataclass
 class BatchBreakdown:
     """Per-batch extraction breakdown with sample data."""
@@ -451,6 +496,25 @@ class BatchProcessor:
         )
 
         runner = create_runner(create_ingestion_pipeline())
+
+        # Issue #223 / Layer 1 (ROOT) — make the long extraction call stream.
+        # When INGEST_ADK_STREAMING_SSE is on, hand ADK a RunConfig with
+        # StreamingMode.SSE so base_llm_flow dispatches the native google-genai
+        # generate_content_stream instead of the blocking generate_content. The
+        # incremental chunks keep the socket warm so a >120s gemini-2.5-pro call
+        # never idles to the edge-proxy disconnect threshold. Built once per job
+        # and reused for every sub-batch runner.run_async() below; left None when
+        # the flag is off so ADK keeps its current non-streaming default.
+        # ``is True`` (not mere truthiness) so an incomplete MagicMock settings
+        # in older tests — whose auto-created attribute is truthy but not a real
+        # bool — keeps ADK's non-streaming default instead of spuriously
+        # streaming. Real Settings stores a genuine ``bool`` so production is
+        # unaffected; the streaming test sets the attribute to ``True`` explicitly.
+        _ingest_run_config = (
+            RunConfig(streaming_mode=StreamingMode.SSE)
+            if getattr(settings, "ingest_adk_streaming_sse", False) is True
+            else None
+        )
 
         known_entities: list[dict[str, Any]] = await stores.entity_registry.get_all_canonical()
         cumulative_timings: dict[str, float] = {}
@@ -799,14 +863,20 @@ class BatchProcessor:
                         _limiter_wait_gemini = 0.0
                         _limiter_wait_embedding = 0.0
                         _evt_count = 0
-                        async for _event in runner.run_async(
-                            user_id="system",
-                            session_id=session.id,
-                            new_message=types.Content(
+                        # Issue #223 / Layer 1 — only pass run_config when SSE
+                        # streaming is enabled so ADK keeps its own default
+                        # RunConfig (non-streaming) when the flag is off.
+                        _run_async_kwargs: dict[str, Any] = {
+                            "user_id": "system",
+                            "session_id": session.id,
+                            "new_message": types.Content(
                                 role="user",
                                 parts=[types.Part(text="process batch")],
                             ),
-                        ):
+                        }
+                        if _ingest_run_config is not None:
+                            _run_async_kwargs["run_config"] = _ingest_run_config
+                        async for _event in runner.run_async(**_run_async_kwargs):
                             author = getattr(_event, "author", "") or ""
                             label = _STAGE_LABELS.get(author)
                             if label and author != _last_stage:
@@ -1550,6 +1620,46 @@ class BatchProcessor:
                         await self._breaker.record_failure(exc)
                         raise
                 except Exception as exc:
+                    # Issue #223 / Layer 2 (ROBUSTNESS) — transient connection
+                    # drops MUST be handled BEFORE the truncation ladder and MUST
+                    # NOT feed the breaker. A long extraction call whose idle
+                    # socket is closed by an edge proxy raises
+                    # aiohttp.ServerDisconnectedError, which is neither a
+                    # resumable type nor a truncation marker, so it would
+                    # otherwise hit the terminal ``raise`` below on attempt 0 with
+                    # zero backoff — and concurrent batches' drops would open the
+                    # breaker and fast-fail the rest of the job into total_facts=0.
+                    if _is_transient_net_error(exc):
+                        if attempt < _LLM_MAX_RETRIES:
+                            logger.warning(
+                                "BatchProcessor: transient network drop job_id=%s "
+                                "batch=%d/%d attempt=%d/%d — retrying with backoff "
+                                "(not counted toward outage breaker): %s",
+                                sync_job_id,
+                                batch_index,
+                                max_batches,
+                                attempt + 1,
+                                _LLM_MAX_RETRIES + 1,
+                                _summarize_exception(exc),
+                            )
+                            # Loop top sleeps (backoff ladder) and reloads the
+                            # checkpoint, so the streamed retry resumes cheaply.
+                            continue
+                        # Terminal: exhausted retries on a transient drop. Raise so
+                        # THIS row fails, but DO NOT call record_failure — an
+                        # idle-proxy disconnect storm must never advance the
+                        # breaker toward its threshold and wipe the whole batch.
+                        logger.error(
+                            "BatchProcessor: transient network drop job_id=%s "
+                            "batch=%d/%d — exhausted %d retries; failing this row "
+                            "WITHOUT tripping the outage breaker: %s",
+                            sync_job_id,
+                            batch_index,
+                            max_batches,
+                            _LLM_MAX_RETRIES + 1,
+                            _summarize_exception(exc),
+                        )
+                        raise
                     # Catch ValidationError (truncated LLM JSON) and similar parse failures.
                     # Strategy: attempt 1 → reduce max_facts to 1, attempt 2 → halve batch.
                     is_validation = _is_truncation_error(exc)

--- a/tests/services/test_batch_processor.py
+++ b/tests/services/test_batch_processor.py
@@ -1,0 +1,388 @@
+"""Issue #223 — transient-net-error resilience + ingestion SSE streaming.
+
+Covers the two-layer fix that stops a long, non-streaming gemini-2.5-pro call
+from dropping at the ~127-131s idle-proxy ceiling and cascading (via the circuit
+breaker) into ``rows=N succeeded=0 total_facts=0``:
+
+Layer 1 (ROOT) — when ``INGEST_ADK_STREAMING_SSE`` is on, the ingestion runner
+receives ``RunConfig(streaming_mode=StreamingMode.SSE)`` so ADK streams the call
+and the socket never idles to the disconnect threshold.
+
+Layer 2 (ROBUSTNESS) — ``_is_transient_net_error`` classifies a clean idle
+disconnect; such drops retry with the existing backoff ladder and, critically,
+are NEVER fed to the circuit breaker, so a disconnect storm can no longer open
+the breaker and fast-fail the rest of the job.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import aiohttp
+import httpx
+import pytest
+from google.adk.agents.run_config import StreamingMode
+from google.genai.errors import ServerError
+from pydantic import BaseModel, ValidationError
+
+from beever_atlas.services.batch_processor import (
+    BatchProcessor,
+    _is_transient_net_error,
+    _is_truncation_error,
+)
+
+
+# ---------------------------------------------------------------------------
+# get_settings lru_cache fragility — rebuild Settings around every test so a
+# fresh module that reads get_settings() at import/collection time can't pin a
+# stale cache. Mirrors the sibling media tests' fixture.
+# ---------------------------------------------------------------------------
+@pytest.fixture(autouse=True)
+def _fresh_settings():
+    from beever_atlas.infra.config import get_settings
+
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+class _Model(BaseModel):
+    x: int
+
+
+# ===========================================================================
+# (a) _is_transient_net_error truthiness matrix
+# ===========================================================================
+class TestIsTransientNetError:
+    def test_server_disconnected_error(self):
+        assert _is_transient_net_error(aiohttp.ServerDisconnectedError()) is True
+
+    def test_client_connection_error(self):
+        assert _is_transient_net_error(aiohttp.ClientConnectionError()) is True
+
+    def test_client_os_error(self):
+        assert _is_transient_net_error(aiohttp.ClientOSError()) is True
+
+    def test_connection_reset_error(self):
+        assert _is_transient_net_error(ConnectionResetError()) is True
+
+    def test_httpx_remote_protocol_error_is_not_transient(self):
+        # Ambiguous with mid-stream truncation — routed to the truncation
+        # reduce→halve ladder, NOT the transient checkpoint-replay retry.
+        err = httpx.RemoteProtocolError("peer closed")
+        assert _is_transient_net_error(err) is False
+        assert _is_truncation_error(err) is True
+
+    def test_httpx_read_error_is_not_transient(self):
+        assert _is_transient_net_error(httpx.ReadError("read failed")) is False
+
+    def test_timeout_error(self):
+        assert _is_transient_net_error(TimeoutError()) is True
+
+    def test_asyncio_timeout_error(self):
+        assert _is_transient_net_error(asyncio.TimeoutError()) is True
+
+    def test_exception_group_wrapping_transient(self):
+        # ADK/anyio TaskGroups wrap the real cause in an ExceptionGroup; the
+        # predicate must recurse into .exceptions and report True.
+        eg = ExceptionGroup("task group", [aiohttp.ServerDisconnectedError()])
+        assert _is_transient_net_error(eg) is True
+
+    def test_exception_group_nested(self):
+        eg = ExceptionGroup(
+            "outer",
+            [ExceptionGroup("inner", [ConnectionResetError()])],
+        )
+        assert _is_transient_net_error(eg) is True
+
+    def test_server_error_is_not_transient(self):
+        # Genuine provider 5xx — must still count toward the breaker, so NOT
+        # classified as a transient net drop.
+        assert _is_transient_net_error(ServerError(503, {"error": "x"})) is False
+
+    def test_validation_error_is_not_transient(self):
+        try:
+            _Model(x="not-an-int")  # type: ignore[arg-type]
+        except ValidationError as exc:
+            assert _is_transient_net_error(exc) is False
+
+    def test_json_decode_error_is_not_transient(self):
+        try:
+            json.loads("{")
+        except json.JSONDecodeError as exc:
+            assert _is_transient_net_error(exc) is False
+
+    def test_exception_group_of_non_transient_is_false(self):
+        eg = ExceptionGroup("g", [ServerError(503, {"error": "x"})])
+        assert _is_transient_net_error(eg) is False
+
+
+# ---------------------------------------------------------------------------
+# Full-flow harness helpers (drive BatchProcessor.process_messages with mocks).
+# ---------------------------------------------------------------------------
+def _make_stores_mock() -> MagicMock:
+    stores = MagicMock()
+    stores.mongodb.update_sync_progress = AsyncMock(return_value=None)
+    stores.mongodb.update_batch_stage = AsyncMock(return_value=None)
+    stores.mongodb.push_activity_log_entry = AsyncMock(return_value=None)
+    stores.mongodb.load_pipeline_checkpoint = AsyncMock(return_value=None)
+    stores.mongodb.save_pipeline_checkpoint = AsyncMock(return_value=None)
+    stores.mongodb.delete_pipeline_checkpoint = AsyncMock(return_value=None)
+    stores.mongodb.increment_batches_completed = AsyncMock(return_value=None)
+    stores.entity_registry.get_all_canonical = AsyncMock(return_value=[])
+    return stores
+
+
+def _make_settings_mock() -> MagicMock:
+    settings = MagicMock()
+    settings.sync_batch_size = 1
+    settings.batch_max_prompt_tokens = 0
+    settings.batch_max_output_tokens = 0
+    settings.batch_time_window_seconds = 0
+    settings.batch_max_messages = 0
+    settings.max_facts_per_message = 2
+    settings.ingest_batch_concurrency = 1
+    settings.language_detection_enabled = False
+    settings.llm_outage_breaker_threshold = 3
+    settings.defer_contradiction = True
+    settings.ingest_adk_streaming_sse = False
+    return settings
+
+
+def _success_event() -> MagicMock:
+    event = MagicMock()
+    event.author = "persister"
+    actions = MagicMock()
+    actions.state_delta = {
+        "persist_result": {
+            "weaviate_ids": ["id1"],
+            "entity_count": 1,
+            "relationship_count": 0,
+        }
+    }
+    actions.stateDelta = None
+    event.actions = actions
+    return event
+
+
+def _final_session_with_result() -> MagicMock:
+    sess = MagicMock()
+    sess.state = {
+        "persist_result": {
+            "weaviate_ids": ["id1"],
+            "entity_count": 1,
+            "relationship_count": 0,
+        }
+    }
+    return sess
+
+
+class _SpyBreaker:
+    """Records record_failure / record_success calls; never opens.
+
+    Lets a test prove that transient drops do NOT advance the breaker while a
+    genuine ServerError does.
+    """
+
+    def __init__(self) -> None:
+        self.failure_calls: list[BaseException | None] = []
+        self.success_calls = 0
+
+    async def allow(self) -> bool:
+        return True
+
+    async def record_failure(self, exc: BaseException | None = None) -> None:
+        self.failure_calls.append(exc)
+
+    async def record_success(self) -> None:
+        self.success_calls += 1
+
+    def snapshot(self) -> MagicMock:
+        snap = MagicMock()
+        snap.consecutive_failures = len(self.failure_calls)
+        snap.threshold = 3
+        snap.state = "closed"
+        return snap
+
+
+async def _run_processor(processor: BatchProcessor, runner: MagicMock, settings: MagicMock):
+    """Drive process_messages with a fully mocked environment."""
+    stores = _make_stores_mock()
+    fake_session = MagicMock()
+    fake_session.id = "sess-1"
+
+    session_service = MagicMock()
+    session_service.get_session = AsyncMock(return_value=_final_session_with_result())
+
+    async def _no_sleep(_secs: float) -> None:
+        return None
+
+    with (
+        patch("beever_atlas.services.batch_processor.random.uniform", return_value=0.0),
+        patch(
+            "beever_atlas.services.batch_processor.asyncio.sleep",
+            side_effect=_no_sleep,
+        ),
+        patch("beever_atlas.services.batch_processor.get_stores", return_value=stores),
+        patch(
+            "beever_atlas.services.batch_processor.get_settings",
+            return_value=settings,
+        ),
+        patch(
+            "beever_atlas.services.batch_processor.create_ingestion_pipeline",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "beever_atlas.services.batch_processor.create_runner",
+            return_value=runner,
+        ),
+        patch(
+            "beever_atlas.services.batch_processor.create_session",
+            new=AsyncMock(return_value=fake_session),
+        ),
+        patch(
+            "beever_atlas.services.batch_processor.get_llm_provider",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "beever_atlas.agents.runner.get_session_service",
+            return_value=session_service,
+        ),
+    ):
+        return await processor.process_messages(
+            messages=[{"content": "hello", "message_id": "msg-1", "channel_id": "C123"}],
+            channel_id="C123",
+            channel_name="test",
+            sync_job_id="job-223",
+        )
+
+
+# ===========================================================================
+# (b) ServerDisconnected on attempt 0 → retry (continue), not immediate raise
+# ===========================================================================
+@pytest.mark.asyncio
+async def test_server_disconnected_triggers_retry_not_immediate_raise():
+    """First attempt disconnects, second succeeds → run_async called twice."""
+    settings = _make_settings_mock()
+    breaker = _SpyBreaker()
+    call_count = 0
+
+    async def _run_async(**_kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise aiohttp.ServerDisconnectedError()
+        yield _success_event()
+
+    runner = MagicMock()
+    runner.run_async = _run_async
+
+    processor = BatchProcessor(breaker=breaker)  # type: ignore[arg-type]
+    result = await _run_processor(processor, runner, settings)
+
+    # Retried: run_async invoked more than once (disconnect → backoff → success).
+    assert call_count >= 2
+    # Transient drop must NEVER feed the breaker.
+    assert breaker.failure_calls == []
+    # Batch ultimately succeeded → the persisted fact id from the success event
+    # reaches the result (fact_ids is the reliable signal under minimal mocks).
+    assert result.fact_ids == ["id1"]
+    # And the row did NOT surface as an error (the disconnect was absorbed).
+    assert result.errors == []
+
+
+# ===========================================================================
+# (c) Terminal transient exhaustion does NOT call breaker.record_failure,
+#     while a genuine ServerError DOES — proving a disconnect storm can't open
+#     the breaker.
+# ===========================================================================
+@pytest.mark.asyncio
+async def test_transient_exhaustion_never_feeds_breaker():
+    settings = _make_settings_mock()
+    breaker = _SpyBreaker()
+
+    async def _always_disconnect(**_kwargs):
+        raise aiohttp.ServerDisconnectedError()
+        yield  # pragma: no cover — makes this an async generator
+
+    runner = MagicMock()
+    runner.run_async = _always_disconnect
+
+    processor = BatchProcessor(breaker=breaker)  # type: ignore[arg-type]
+    result = await _run_processor(processor, runner, settings)
+
+    # Row failed (no facts) ...
+    assert result.total_facts == 0
+    assert result.errors
+    # ... but the breaker was NEVER advanced by the transient drops.
+    assert breaker.failure_calls == []
+
+
+@pytest.mark.asyncio
+async def test_server_error_exhaustion_does_feed_breaker():
+    """Control: a genuine ServerError DOES advance the breaker on exhaustion."""
+    settings = _make_settings_mock()
+    breaker = _SpyBreaker()
+
+    async def _always_5xx(**_kwargs):
+        raise ServerError(503, {"error": "upstream down"})
+        yield  # pragma: no cover
+
+    runner = MagicMock()
+    runner.run_async = _always_5xx
+
+    processor = BatchProcessor(breaker=breaker)  # type: ignore[arg-type]
+    await _run_processor(processor, runner, settings)
+
+    # ServerError is resumable; on terminal exhaustion it records exactly one
+    # failure toward the breaker.
+    assert len(breaker.failure_calls) == 1
+    assert isinstance(breaker.failure_calls[0], ServerError)
+
+
+# ===========================================================================
+# (d) Streaming flag wiring — run_async receives run_config with SSE.
+# ===========================================================================
+@pytest.mark.asyncio
+async def test_streaming_flag_passes_sse_run_config():
+    settings = _make_settings_mock()
+    settings.ingest_adk_streaming_sse = True
+    breaker = _SpyBreaker()
+    captured: dict[str, object] = {}
+
+    async def _run_async(**kwargs):
+        captured.update(kwargs)
+        yield _success_event()
+
+    runner = MagicMock()
+    runner.run_async = _run_async
+
+    processor = BatchProcessor(breaker=breaker)  # type: ignore[arg-type]
+    await _run_processor(processor, runner, settings)
+
+    assert "run_config" in captured
+    assert captured["run_config"].streaming_mode == StreamingMode.SSE  # type: ignore[union-attr]
+
+
+@pytest.mark.asyncio
+async def test_streaming_flag_off_omits_run_config():
+    settings = _make_settings_mock()
+    settings.ingest_adk_streaming_sse = False
+    breaker = _SpyBreaker()
+    captured: dict[str, object] = {}
+
+    async def _run_async(**kwargs):
+        captured.update(kwargs)
+        yield _success_event()
+
+    runner = MagicMock()
+    runner.run_async = _run_async
+
+    processor = BatchProcessor(breaker=breaker)  # type: ignore[arg-type]
+    await _run_processor(processor, runner, settings)
+
+    # When the flag is off, ADK keeps its own default RunConfig (non-streaming):
+    # we must NOT pass run_config at all.
+    assert "run_config" not in captured


### PR DESCRIPTION
## Problem (Issue #223)

Fact extraction was producing **zero facts** on channels with longer message batches. Root cause, reproduced live three ways:

| Test | Result |
|------|--------|
| Single + **12 concurrent short** Gemini calls | ✅ all OK → not rate/quota/auth/network |
| 6 **long non-streaming** `gemini-2.5-pro` calls | ❌ **6/6 dropped at ~127-131s** (`aiohttp.ServerDisconnectedError`) |
| 4 **long streaming** calls | ✅ **4/4 OK** (68-79s) |

A long, *non-streaming* `generate_content` sits idle >~120s while the model generates → an edge proxy closes the idle socket. A few of these then trip the LLM **circuit breaker** (threshold 3), which fast-fails every remaining sub-batch → `rows=96 succeeded=0 total_facts=0`.

## Fix — two coordinated layers (minimal, additive)

**Root — stream the extraction runner.** `BatchProcessor.run_async()` now passes `RunConfig(streaming_mode=StreamingMode.SSE)` (the same path QA already uses in prod), gated by `INGEST_ADK_STREAMING_SSE` (**default ON — this is the fix**). Safe with the extractors' structured output: they use only `response_mime_type=application/json` (no `output_schema`/tools), and ADK aggregates the streamed JSON into one assembled `LlmResponse` *before* the recovery callback, so the existing partial-JSON recovery + retry ladder runs unchanged. Streaming keeps the socket warm so the call never idles into the disconnect.

**Robustness — a few transient drops must not wipe a whole batch.** New `_is_transient_net_error()` (aiohttp `ServerDisconnected`/`ClientConnection`/`ClientOSError`, `ConnectionResetError`, timeouts; recurses into `ExceptionGroup`). These now **retry** with the existing backoff and are **never counted toward the breaker** — severing "disconnect storm → breaker open → total wipe". Genuine `ServerError`/5xx still feed the breaker (control test). httpx `RemoteProtocolError`/`ReadError` are deliberately **not** transient — they stay on the truncation reduce→halve ladder (no routing change).

## Verification

**End-to-end on the live stack:** re-extracting a 126-message channel that previously gave `total_facts=0` (96 failed) now produces **`total_facts=105, total_entities=252, errors=0`**, **zero** `ServerDisconnected`, and **99 graph Event nodes**.

- ruff + pyright clean; **49 unit tests** pass (new transient/breaker matrix incl. a control that real `ServerError` still trips the breaker + the existing extraction/breaker suites).
- Empirical probe: a >120s streamed call completes while the same non-streamed call drops at ~130s.

## Notes
- Independent of the durable-media PR (#226).
- **Follow-up:** the wiki-compiler long-call path (litellm) is the same risk class and should get the same streaming treatment in a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)