### PR TITLE
fix(wiki): stream long wiki-compile LLM calls to prevent ServerDisconnected (#223)

### DIFF
--- a/src/beever_atlas/infra/config.py
+++ b/src/beever_atlas/infra/config.py
@@ -461,6 +461,12 @@ class Settings(BaseSettings):
     wiki_token_budget_v2: bool = Field(default=True, alias="BEEVER_WIKI_TOKEN_BUDGET_V2")
     # Phase 4+5: deterministic Key Facts table + delimited response parser. Default OFF.
     wiki_compiler_v2: bool = Field(default=False, alias="BEEVER_WIKI_COMPILER_V2")
+    # Issue #223 — stream the wiki page-compile LLM call (up to 32k output
+    # tokens) so a long generation does not idle past the ~127-131s edge-proxy
+    # disconnect (aiohttp.ServerDisconnectedError → degenerate/fallback wiki
+    # content). The streamed chunks are reassembled into the same response shape,
+    # so parsing is unchanged. Default ON (the fix). Set 0 to revert.
+    wiki_llm_streaming: bool = Field(default=True, alias="WIKI_LLM_STREAMING")
 
     # Credential encryption
     credential_master_key: str = Field(default="")

--- a/src/beever_atlas/services/llm_dispatch.py
+++ b/src/beever_atlas/services/llm_dispatch.py
@@ -295,6 +295,26 @@ def _split_model_for_litellm(provider: str, model: str) -> tuple[str, str]:
     return model, provider
 
 
+async def _acompletion_assembled_stream(litellm: Any, *, messages: Any, **kwargs: Any) -> Any:
+    """Run a STREAMED completion and reassemble it into one ``ModelResponse``.
+
+    Issue #223: a long, non-streaming completion (e.g. a 32k-token wiki page
+    compile) sits idle past the ~130s edge-proxy ceiling and the peer closes the
+    socket → ``aiohttp.ServerDisconnectedError``. Streaming keeps the socket warm
+    with incremental chunks. We collect the chunks and rebuild them via
+    ``litellm.stream_chunk_builder`` so the return value is the SAME response
+    shape (``.choices[0].message.content`` + ``.usage``) that non-streaming
+    callers already consume — every call site stays unchanged.
+    """
+    kwargs.pop("stream", None)  # this helper owns the stream flag
+    stream = await litellm.acompletion(messages=messages, stream=True, **kwargs)
+    chunks = [chunk async for chunk in stream]
+    assembled = litellm.stream_chunk_builder(chunks, messages=messages)
+    if assembled is None:
+        raise RuntimeError("dispatch_completion(stream=True): stream produced no chunks")
+    return assembled
+
+
 async def dispatch_completion(
     *,
     provider: str,
@@ -302,6 +322,7 @@ async def dispatch_completion(
     messages: list[Any],
     endpoint_id: str | None = None,
     timeout: float | None = None,
+    stream: bool = False,
     **kwargs: Any,
 ) -> Any:
     """Throttle-gated wrapper around ``litellm.acompletion``.
@@ -352,12 +373,24 @@ async def dispatch_completion(
     try:
         async with throttle.acquire(provider, est_tokens, endpoint_id=endpoint_id):
             try:
-                response = await litellm.acompletion(
-                    model=litellm_model,
-                    messages=messages,
-                    custom_llm_provider=litellm_provider,
-                    **kwargs,
-                )
+                if stream:
+                    # Issue #223 — stream long completions (e.g. 32k-token wiki
+                    # page compiles) so the socket never idles into the ~130s
+                    # edge-proxy disconnect. Reassembled to the normal shape.
+                    response = await _acompletion_assembled_stream(
+                        litellm,
+                        model=litellm_model,
+                        messages=messages,
+                        custom_llm_provider=litellm_provider,
+                        **kwargs,
+                    )
+                else:
+                    response = await litellm.acompletion(
+                        model=litellm_model,
+                        messages=messages,
+                        custom_llm_provider=litellm_provider,
+                        **kwargs,
+                    )
             except BaseException as exc:
                 record_call(
                     started_at=started_at,

--- a/src/beever_atlas/services/wiki_maintainer.py
+++ b/src/beever_atlas/services/wiki_maintainer.py
@@ -2094,6 +2094,7 @@ class WikiMaintainer:
         ``dispatch_completion`` (which gates on the per-provider throttle).
         Returns the raw JSON text (parsed by the caller).
         """
+        from beever_atlas.infra.config import get_settings
         from beever_atlas.llm.provider import get_llm_provider
         from beever_atlas.services.llm_dispatch import (
             dispatch_completion,
@@ -2111,6 +2112,8 @@ class WikiMaintainer:
             response_format={"type": "json_object"},
             max_tokens=4096,
             temperature=0.2,
+            # Issue #223: stream so a slow generation can't idle-disconnect.
+            stream=get_settings().wiki_llm_streaming,
         )
         return response.choices[0].message.content or "{}"  # type: ignore[index, union-attr]
 

--- a/src/beever_atlas/wiki/compiler.py
+++ b/src/beever_atlas/wiki/compiler.py
@@ -3550,6 +3550,9 @@ class WikiCompiler:
                 messages=[{"role": "user", "content": content}],
                 max_tokens=max_tokens,
                 temperature=temperature,
+                # Issue #223: stream this (up to 32k-token) page compile so a long
+                # generation never idles into the ~130s edge-proxy disconnect.
+                stream=settings.wiki_llm_streaming,
                 **kwargs,
             )
             return response.choices[0].message.content or "{}"  # type: ignore[index, union-attr]

--- a/tests/services/test_llm_dispatch_streaming.py
+++ b/tests/services/test_llm_dispatch_streaming.py
@@ -1,0 +1,87 @@
+"""Issue #223 — streamed-completion reassembly in ``llm_dispatch``.
+
+``_acompletion_assembled_stream`` runs ``litellm.acompletion(stream=True)`` so a
+long generation keeps the socket warm (no ~130s idle disconnect), then rebuilds
+the streamed chunks into the SAME response shape non-streaming callers consume.
+It takes ``litellm`` as its first arg precisely so it can be tested without the
+real SDK.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from beever_atlas.services.llm_dispatch import _acompletion_assembled_stream
+
+
+@pytest.fixture(autouse=True)
+def _fresh_settings():
+    from beever_atlas.infra.config import get_settings
+
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+def _fake_litellm(chunks: list[str], *, build_none: bool = False):
+    captured: dict = {}
+
+    async def _acompletion(*, messages, stream, **kw):
+        captured["stream"] = stream
+        captured["messages"] = messages
+        captured["kwargs"] = kw
+
+        async def _gen():
+            for t in chunks:
+                yield t
+
+        return _gen()
+
+    def _builder(got_chunks, messages):
+        captured["built_from"] = list(got_chunks)
+        if build_none:
+            return None
+        assembled = MagicMock()
+        assembled.choices = [MagicMock()]
+        assembled.choices[0].message.content = "".join(got_chunks)
+        return assembled
+
+    fake = MagicMock()
+    fake.acompletion = _acompletion
+    fake.stream_chunk_builder = _builder
+    return fake, captured
+
+
+@pytest.mark.asyncio
+async def test_streams_and_reassembles_into_one_response():
+    fake, captured = _fake_litellm(["Hello ", "stream", "ed world"])
+
+    resp = await _acompletion_assembled_stream(
+        fake,
+        messages=[{"role": "user", "content": "hi"}],
+        model="gemini/gemini-2.5-pro",
+        custom_llm_provider="gemini",
+        max_tokens=32768,
+    )
+
+    # It requested streaming, collected every chunk, and rebuilt the full text.
+    assert captured["stream"] is True
+    assert captured["built_from"] == ["Hello ", "stream", "ed world"]
+    assert resp.choices[0].message.content == "Hello streamed world"
+    # Non-stream kwargs (model/provider/max_tokens) are forwarded; ``stream`` is
+    # owned by the helper and not duplicated into kwargs.
+    assert captured["kwargs"]["model"] == "gemini/gemini-2.5-pro"
+    assert captured["kwargs"]["custom_llm_provider"] == "gemini"
+    assert captured["kwargs"]["max_tokens"] == 32768
+    assert "stream" not in captured["kwargs"]
+
+
+@pytest.mark.asyncio
+async def test_empty_stream_raises():
+    fake, _ = _fake_litellm([], build_none=True)
+    with pytest.raises(RuntimeError, match="no chunks"):
+        await _acompletion_assembled_stream(
+            fake, messages=[], model="m", custom_llm_provider="gemini"
+        )


### PR DESCRIPTION
Companion to #236 (extraction streaming). Closes the same Issue #223 root cause on the **wiki-compiler** path, which uses LiteLLM (`dispatch_completion`) rather than ADK.

## Problem
The wiki page compiler issues litellm completions with up to **32k output tokens**. A long, *non-streaming* generation idles >~120s and the edge proxy drops the socket at ~127-131s (`aiohttp.ServerDisconnectedError`) → degenerate / deterministic-fallback wiki content. (Reproduced live: 6/6 long non-streaming calls drop at ~130s; 4/4 streaming calls survive.)

## Fix
- `dispatch_completion` gains a `stream: bool` param. When set, **`_acompletion_assembled_stream`** runs `litellm.acompletion(stream=True)`, collects the chunks, and rebuilds them via **`litellm.stream_chunk_builder`** into the *same* `ModelResponse` shape (`.choices[0].message.content` + `.usage`). Every call site and the wiki parsers (`_parse_llm_json` / `_parse_delimited_response`) are **unchanged**.
- The 32k-token page-compile call (`compiler.py`) and the maintainer apply-update call pass `stream=settings.wiki_llm_streaming`, gated by **`WIKI_LLM_STREAMING` (default ON)**. Streaming keeps the socket warm so the call never idles into the disconnect.

## Verification
- **Live:** a full wiki rebuild (`mode=rebuild`) of a real 126-message channel produced **12 pages with 0 `ServerDisconnected`** and **0 streaming-path errors**; content-rich pages rendered `fell_back=False`.
- New unit test asserts the chunk-collect → reassemble → same-shape contract; **230 existing wiki/dispatch tests pass** (no regression); ruff + pyright clean.

## Notes
- Independent of #226 (media) and #236 (extraction streaming); the three are non-overlapping.
- `dispatch_completion(stream=True)` always returns a *complete* reassembled response — callers never see a raw stream iterator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)