### PR TITLE
feat(bot): native markdown rendering + concise sources + greeting/identity for @mention replies

### DIFF
--- a/bot/src/index.test.ts
+++ b/bot/src/index.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Handler-level tests for the reply path in index.ts.
+ *
+ * These lock two load-bearing contracts the renderer/sse-client unit tests
+ * can't see:
+ *   1. answerInThread posts an `{ markdown }` ENVELOPE (not a raw string) — the
+ *      whole point of the presentation fix; a regression to a raw string would
+ *      reintroduce literal `##`/`**` on Slack/Teams/Telegram.
+ *   2. postNotice prefers an ephemeral message (with `{ fallbackToDM: true }`)
+ *      and degrades to a normal post when ephemeral is unavailable or fails,
+ *      threading the message author through.
+ *
+ * Importing index.ts is side-effect free: `main()` is guarded behind an
+ * entrypoint check, so this import does not start the HTTP server.
+ */
+import { describe, it, afterEach } from "node:test";
+import assert from "node:assert";
+import { answerInThread, postNotice, type PostableThread } from "./index.js";
+
+// ── postNotice ────────────────────────────────────────────────────────────────
+
+describe("postNotice", () => {
+  it("posts ephemeral (with DM fallback) when author + postEphemeral are present", async () => {
+    const calls: Array<{ kind: string; args: unknown[] }> = [];
+    const thread: PostableThread = {
+      id: "slack:C1:T1",
+      post: async (m) => { calls.push({ kind: "post", args: [m] }); },
+      postEphemeral: async (u, m, o) => { calls.push({ kind: "ephemeral", args: [u, m, o] }); return null; },
+    };
+    await postNotice(thread, { userId: "U1" }, "heads up");
+    assert.strictEqual(calls.length, 1);
+    assert.strictEqual(calls[0].kind, "ephemeral");
+    assert.deepStrictEqual(calls[0].args[0], { userId: "U1" });
+    assert.strictEqual(calls[0].args[1], "heads up");
+    assert.deepStrictEqual(calls[0].args[2], { fallbackToDM: true });
+  });
+
+  it("falls back to a normal post when postEphemeral rejects, without throwing", async () => {
+    const calls: string[] = [];
+    const thread: PostableThread = {
+      id: "slack:C1:T1",
+      post: async () => { calls.push("post"); },
+      postEphemeral: async () => { throw new Error("ephemeral not supported here"); },
+    };
+    await assert.doesNotReject(postNotice(thread, { userId: "U1" }, "x"));
+    assert.deepStrictEqual(calls, ["post"]);
+  });
+
+  it("posts directly when the platform has no postEphemeral", async () => {
+    const calls: string[] = [];
+    const thread: PostableThread = {
+      id: "discord:C1:T1",
+      post: async () => { calls.push("post"); },
+    };
+    await postNotice(thread, { userId: "U1" }, "x");
+    assert.deepStrictEqual(calls, ["post"]);
+  });
+
+  it("posts directly (skips ephemeral) when there is no author", async () => {
+    const calls: string[] = [];
+    const thread: PostableThread = {
+      id: "slack:C1:T1",
+      post: async () => { calls.push("post"); },
+      postEphemeral: async () => { calls.push("ephemeral"); return null; },
+    };
+    await postNotice(thread, undefined, "x");
+    assert.deepStrictEqual(calls, ["post"]);
+  });
+});
+
+// ── answerInThread ──────────────────────────────────────────────────────────────
+
+function sseResponse(body: string): Response {
+  return new Response(body, { status: 200, headers: { "Content-Type": "text/event-stream" } });
+}
+
+const HAPPY_SSE =
+  'event: response_delta\ndata: {"delta": "Team Canada is strong because of SGA."}\n\n' +
+  'event: metadata\ndata: {"route": "qa_agent", "confidence": 0.9}\n\n' +
+  "event: done\ndata: {}\n\n";
+
+describe("answerInThread", () => {
+  const originalFetch = globalThis.fetch;
+  afterEach(() => { globalThis.fetch = originalFetch; });
+
+  it("posts the reply as a { markdown } envelope, not a raw string", async () => {
+    globalThis.fetch = (async () => sseResponse(HAPPY_SSE)) as typeof fetch;
+    let posted: unknown;
+    const thread: PostableThread = {
+      id: "slack:C0B5YCR1NL8:1700000000.0001",
+      post: async (m) => { posted = m; },
+      startTyping: async () => {},
+    };
+    await answerInThread(thread, "why is Team Canada good?", "mention", { userId: "U1" });
+    // The load-bearing contract: an object { markdown: <string> }, NEVER a string.
+    assert.strictEqual(typeof posted, "object", "reply must be a { markdown } object, not a raw string");
+    assert.ok(posted && typeof (posted as { markdown?: unknown }).markdown === "string");
+    assert.ok((posted as { markdown: string }).markdown.includes("Team Canada is strong"));
+  });
+
+  it("invokes startTyping when available and still completes if it rejects", async () => {
+    globalThis.fetch = (async () => sseResponse(HAPPY_SSE)) as typeof fetch;
+    let typed = false;
+    let posted: unknown;
+    const thread: PostableThread = {
+      id: "slack:C1:T1",
+      post: async (m) => { posted = m; },
+      startTyping: async () => { typed = true; throw new Error("typing unsupported"); },
+    };
+    await assert.doesNotReject(answerInThread(thread, "hi", "mention", { userId: "U1" }));
+    assert.ok(typed, "startTyping should be invoked");
+    assert.ok(posted, "reply should still be posted despite a typing failure");
+  });
+
+  it("delivers an ephemeral error notice when the backend call fails", async () => {
+    // A 4xx is terminal (no retry) → answerInThread swallows it into a notice.
+    globalThis.fetch = (async () => new Response("bad request", { status: 400 })) as typeof fetch;
+    const calls: string[] = [];
+    const thread: PostableThread = {
+      id: "slack:C1:T1",
+      post: async () => { calls.push("post"); },
+      postEphemeral: async () => { calls.push("ephemeral"); return null; },
+    };
+    await assert.doesNotReject(answerInThread(thread, "q", "mention", { userId: "U1" }));
+    // Error went out ephemeral (channel stays clean), not as a permanent post.
+    assert.deepStrictEqual(calls, ["ephemeral"]);
+  });
+});

--- a/bot/src/index.ts
+++ b/bot/src/index.ts
@@ -1,5 +1,6 @@
 import { config } from "dotenv";
 import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
 import { createServer, IncomingMessage, ServerResponse } from "node:http";
 
 // Load .env from project root (one level up from bot/)
@@ -77,7 +78,7 @@ function registerHandlers(bot: Chat): void {
     }
 
     if (!(await passesRateLimit(thread, message))) return;
-    await answerInThread(thread, question, "mention");
+    await answerInThread(thread, question, "mention", message.author);
   });
 
   // Handler: follow-up messages in subscribed threads. The SDK routes EVERY
@@ -111,7 +112,7 @@ function registerHandlers(bot: Chat): void {
     }
 
     if (!(await passesRateLimit(thread, message))) return;
-    await answerInThread(thread, question, "follow-up");
+    await answerInThread(thread, question, "follow-up", message.author);
   });
 
   // Handler: direct messages — a private 1:1 Q&A surface. DMs route through the
@@ -128,9 +129,45 @@ function registerHandlers(bot: Chat): void {
         return;
       }
       if (!(await passesRateLimit(thread, message))) return;
-      await answerInThread(thread, question, "dm");
+      await answerInThread(thread, question, "dm", message.author);
     });
   }
+}
+
+/**
+ * Minimal thread surface the reply path needs. Structural (not the full SDK
+ * `Thread`) so unit tests can pass a stub. `post` accepts `{ markdown }` so the
+ * SDK converts canonical CommonMark to each platform's native format;
+ * `postEphemeral` / `startTyping` are optional and feature-detected at runtime.
+ */
+export type PostableThread = {
+  id: string;
+  post(message: string | { markdown: string }): Promise<unknown>;
+  postEphemeral?(
+    user: unknown,
+    message: string | { markdown: string },
+    options: { fallbackToDM?: boolean },
+  ): Promise<unknown>;
+  startTyping?(status?: string): Promise<void>;
+};
+
+/**
+ * Post a transient notice (error / rate-limit). Prefers an EPHEMERAL message so
+ * it isn't a permanent channel artifact for everyone — Slack/Google Chat show
+ * it only to `author`; Discord/Teams fall back to a DM. Any platform without
+ * ephemeral support (or a failing ephemeral call) degrades to a normal thread
+ * post so the user still sees it. Best-effort: never throws.
+ */
+export async function postNotice(thread: PostableThread, author: unknown, text: string): Promise<void> {
+  if (author != null && typeof thread.postEphemeral === "function") {
+    try {
+      await thread.postEphemeral(author, text, { fallbackToDM: true });
+      return;
+    } catch (err) {
+      console.error("Ephemeral notice failed; falling back to post:", safeErrorMessage(err));
+    }
+  }
+  await thread.post(text);
 }
 
 /**
@@ -140,7 +177,7 @@ function registerHandlers(bot: Chat): void {
  * silently. Returns true when the request may proceed.
  */
 async function passesRateLimit(
-  thread: { id: string; post(message: string): Promise<unknown> },
+  thread: PostableThread,
   message: { author?: { userId?: string } },
 ): Promise<boolean> {
   const key = `${extractPlatform(thread.id)}:${extractChannelId(thread.id)}:${message.author?.userId || "unknown"}`;
@@ -149,7 +186,11 @@ async function passesRateLimit(
   if (noticeLimiter.check(key).allowed) {
     const secs = Math.max(1, Math.ceil(decision.retryAfterMs / 1000));
     try {
-      await thread.post(`You're asking a lot — give me a moment 🙂 (try again in ~${secs}s)`);
+      await postNotice(
+        thread,
+        message.author,
+        `You're asking a lot — give me a moment 🙂 (try again in ~${secs}s)`,
+      );
     } catch (err) {
       console.error("Failed to post rate-limit notice:", safeErrorMessage(err));
     }
@@ -200,14 +241,22 @@ async function getHumanCount(thread: ThreadForParticipants): Promise<number | un
 }
 
 /** Ask the backend and post the rendered reply, swallowing errors into a friendly notice. */
-async function answerInThread(
-  thread: { id: string; post(message: string): Promise<unknown> },
+export async function answerInThread(
+  thread: PostableThread,
   question: string,
   surface: ReplySurface,
+  author?: unknown,
 ): Promise<void> {
   const platform = extractPlatform(thread.id);
   const startedAt = Date.now();
   try {
+    // Show a typing/thinking indicator while the backend streams so a
+    // multi-second answer doesn't feel unresponsive. Feature-detected and
+    // fire-and-forget — a no-op on adapters that don't support it, and posting
+    // the reply clears it. Never let a failing indicator break the reply.
+    if (typeof thread.startTyping === "function") {
+      thread.startTyping().catch(() => {});
+    }
     // Stable per-thread session id → backend resumes the thread's history so
     // follow-ups remember the prior exchange. See session-id.ts for the
     // thread-scoped (not channel/user) security rationale.
@@ -216,7 +265,11 @@ async function answerInThread(
       question,
       deriveSessionId(thread.id),
     );
-    await thread.post(renderResponse(result, platform));
+    // Post as `{ markdown }`: the renderer emits canonical CommonMark and the
+    // chat SDK converts it to each platform's native format (Slack Block Kit,
+    // Teams Adaptive Card, …). Posting a raw string instead made `##`/`**`
+    // render literally on Slack/Teams/Telegram.
+    await thread.post({ markdown: renderResponse(result, platform) });
     logReplySent({
       surface,
       platform,
@@ -230,9 +283,14 @@ async function answerInThread(
     console.error(`Error processing ${surface}:`, safeErrorMessage(err));
     // A failed reply must not throw out of the handler: that would make the
     // webhook return 5xx and skip conversation recording (serviceUrl), which
-    // breaks later message fetches even though the activity was valid.
+    // breaks later message fetches even though the activity was valid. The
+    // error goes out ephemeral (DM fallback) so it doesn't clutter the channel.
     try {
-      await thread.post("Sorry, I encountered an error processing your question. Please try again.");
+      await postNotice(
+        thread,
+        author,
+        "Sorry, I encountered an error processing your question. Please try again.",
+      );
     } catch (postErr) {
       console.error("Failed to deliver error reply:", safeErrorMessage(postErr));
     }
@@ -973,7 +1031,14 @@ async function main(): Promise<void> {
   console.log("Bot service ready");
 }
 
-main().catch((err: unknown) => {
-  console.error("Fatal error:", safeErrorMessage(err));
-  process.exit(1);
-});
+// Only bootstrap the server when this module is run as the process entrypoint.
+// Importing it (e.g. from a unit test that exercises answerInThread/postNotice)
+// must NOT start the HTTP server or connect adapters.
+const invokedDirectly =
+  !!process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (invokedDirectly) {
+  main().catch((err: unknown) => {
+    console.error("Fatal error:", safeErrorMessage(err));
+    process.exit(1);
+  });
+}

--- a/bot/src/integration.test.ts
+++ b/bot/src/integration.test.ts
@@ -60,21 +60,23 @@ describe("integration: SSE stream → rendered reply", () => {
     const out = renderResponse(result, "slack");
     // Answer first.
     assert.ok(out.startsWith("We chose GridFS"));
-    // Sources block has the direct sources with provenance.
-    assert.ok(out.includes("📎 *Sources*"));
-    assert.ok(out.includes("📖 [1] Media storage <https://wiki/media>"));
-    assert.ok(out.includes("💬 [2] no object store on OSS — Alan, #tech"));
+    // Sources block: canonical markdown heading, concise list items with a
+    // clickable [open](url) link, and NO verbose fact text.
+    assert.ok(out.includes("## 📎 Sources"));
+    assert.ok(out.includes("- 📖 [1] [open](https://wiki/media)"));
+    assert.ok(out.includes("- 💬 [2] Alan · #tech"));
+    assert.ok(!out.includes("no object store on OSS"), "fact text should be dropped");
     // Related block has the graph/decision citations, with ORIGINAL indices.
-    assert.ok(out.includes("🧠 *Related*"));
-    assert.ok(out.includes("⚖️ [3] GridFS default decision"));
-    assert.ok(out.includes("🧠 [4] Alan owns media-storage"));
-    // Proactive tension heads-up.
-    assert.ok(out.includes("⚠️ *Heads up — possible tension*"));
-    assert.ok(out.includes("GridFS scalability disputed — Alan: fine vs Thomas: risky"));
-    // Freshness + follow-ups + route.
-    assert.ok(out.includes("🕐 _synced 2h ago_"));
+    assert.ok(out.includes("## 🧠 Related"));
+    assert.ok(out.includes("- ⚖️ [3]"));
+    assert.ok(out.includes("- 🧠 [4]"));
+    // Proactive tension heads-up (bold line, markdown bullet).
+    assert.ok(out.includes("**⚠️ Heads up — possible tension**"));
+    assert.ok(out.includes("- GridFS scalability disputed — Alan: fine vs Thomas: risky"));
+    // Freshness (honest "last activity" label) + follow-ups + route.
+    assert.ok(out.includes("🕐 _last activity 2h ago_"));
     assert.ok(out.includes("_You might also ask:_"));
-    assert.ok(out.includes("• How do I switch to MinIO?"));
+    assert.ok(out.includes("- How do I switch to MinIO?"));
     assert.ok(out.includes("_via qa_agent_"));
     // High confidence → NO warning.
     assert.ok(!out.includes("low confidence"));
@@ -99,7 +101,7 @@ describe("integration: SSE stream → rendered reply", () => {
     assert.strictEqual(result.isEmpty, true);
     const out = renderResponse(result, "discord");
     assert.ok(/don't have anything indexed/i.test(out));
-    assert.ok(!out.includes("📎 *Sources*"));
+    assert.ok(!out.includes("## 📎 Sources"));
   });
 
   it("shows a low-confidence warning (right under the answer) when retrieval is thin", async () => {
@@ -121,6 +123,6 @@ describe("integration: SSE stream → rendered reply", () => {
     const out = renderResponse(result, "slack");
     assert.ok(out.includes("⚠️ _low confidence"));
     // Warning precedes the Sources block (truncation-safe placement).
-    assert.ok(out.indexOf("low confidence") < out.indexOf("📎 *Sources*"));
+    assert.ok(out.indexOf("low confidence") < out.indexOf("## 📎 Sources"));
   });
 });

--- a/bot/src/renderer.test.ts
+++ b/bot/src/renderer.test.ts
@@ -31,7 +31,7 @@ describe("renderResponse", () => {
     assert.ok(out.includes("via qa_agent"));
   });
 
-  it("renders citations with kind icons and provenance", () => {
+  it("renders concise citation lines with kind icons, provenance, and clickable links", () => {
     const out = renderResponse(
       result({
         citations: [
@@ -42,11 +42,16 @@ describe("renderResponse", () => {
       }),
       "slack",
     );
-    assert.ok(out.includes("📎 *Sources*"));
-    assert.ok(out.includes("📖 [1] AI+ Power 2026"));
-    assert.ok(out.includes("<https://wiki/x>"));
-    assert.ok(out.includes("💬 [2] booth confirmed — Jack, #general"));
-    assert.ok(out.includes("⚖️ [3] staffing decided"));
+    assert.ok(out.includes("## 📎 Sources"));
+    // Concise: icon + index + provenance + a markdown [open](url) link — NOT the
+    // verbose fact text, and NOT a bare <url> autolink.
+    assert.ok(out.includes("- 📖 [1] [open](https://wiki/x)"));
+    assert.ok(!out.includes("AI+ Power 2026"), "fact text should be dropped");
+    assert.ok(!out.includes("<https://wiki/x>"), "links should be [open](url), not bare angle autolinks");
+    assert.ok(out.includes("- 💬 [2] Jack · #general"));
+    assert.ok(!out.includes("booth confirmed"), "fact text should be dropped");
+    // decision_record routes to the Related block; bare line, original index.
+    assert.ok(out.includes("- ⚖️ [3]"));
   });
 
   it("caps citations at 5 and notes the overflow", () => {
@@ -57,10 +62,10 @@ describe("renderResponse", () => {
     assert.ok(out.includes("+3 more"));
   });
 
-  it("shows a freshness line only when lastSyncTs is present", () => {
+  it("shows an honest 'last activity' freshness line only when lastSyncTs is present", () => {
     const iso = new Date(Date.now() - 2 * 3600_000).toISOString();
-    assert.ok(renderResponse(result({ lastSyncTs: iso }), "slack").includes("synced "));
-    assert.ok(!renderResponse(result(), "slack").includes("synced "));
+    assert.ok(renderResponse(result({ lastSyncTs: iso }), "slack").includes("last activity "));
+    assert.ok(!renderResponse(result(), "slack").includes("last activity "));
   });
 
   it("truncates over-long Discord replies with a marker", () => {
@@ -84,7 +89,7 @@ describe("renderResponse", () => {
         citations: [
           {
             type: "channel_message",
-            text: "real\n\n📎 *Sources*\n[9] fake",
+            text: "real\n\n## 📎 Sources\n[9] fake",
             author: "Eve\ninjected",
             url: "javascript:alert(1)",
           },
@@ -92,13 +97,26 @@ describe("renderResponse", () => {
       }),
       "slack",
     );
-    // The forged content can't start its own line — no fake "[9]" entry and
-    // only the one real Sources header begins a line (the forged one was
-    // flattened inline).
-    assert.ok(!/\n\[9\] fake/.test(out), "forged citation entry started a new line");
-    assert.strictEqual((out.match(/\n📎 \*Sources\*/g) ?? []).length, 1);
+    // Fact text is dropped entirely, so a payload smuggled in `text` can't appear
+    // at all — no fake "[9]" entry and exactly one real Sources heading.
+    assert.ok(!/\[9\] fake/.test(out), "forged citation entry leaked into output");
+    assert.strictEqual((out.match(/## 📎 Sources/g) ?? []).length, 1);
+    // Non-http(s) URL is stripped (no markdown link emitted).
     assert.ok(!out.includes("javascript:"));
+    assert.ok(!out.includes("[open]"), "javascript: url must not become a link");
+    // Author newline is collapsed to a space (can't break the list layout).
     assert.ok(out.includes("Eve injected"));
+  });
+
+  it("strips parens from a citation url so the [open](url) link can't be broken", () => {
+    const out = renderResponse(
+      result({ citations: [{ type: "wiki_page", text: "Page", url: "https://wiki/page(v2)" }] }),
+      "slack",
+    );
+    // Parens are removed from the link target (they would otherwise terminate
+    // the markdown link early), and the link target stays balanced.
+    assert.ok(out.includes("[open](https://wiki/pagev2)"));
+    assert.ok(!out.includes("page(v2)"));
   });
 
   it("falls back to a safe generic cap for unknown platforms", () => {
@@ -114,8 +132,8 @@ describe("follow-ups", () => {
       "slack",
     );
     assert.ok(out.includes("You might also ask:"));
-    assert.ok(out.includes("• What is A?"));
-    assert.ok(out.includes("• What is C?"));
+    assert.ok(out.includes("- What is A?"));
+    assert.ok(out.includes("- What is C?"));
     assert.ok(!out.includes("What is D?"));
   });
 
@@ -144,13 +162,13 @@ describe("related-context grouping", () => {
       }),
       "slack",
     );
-    assert.ok(out.includes("📎 *Sources*"));
-    assert.ok(out.includes("🧠 *Related*"));
+    assert.ok(out.includes("## 📎 Sources"));
+    assert.ok(out.includes("## 🧠 Related"));
     // Sources keeps indices [1] and [3]; Related keeps [2] and [4].
-    assert.ok(out.includes("📖 [1] Wiki A"));
-    assert.ok(out.includes("💬 [3] Msg B — Jack"));
-    assert.ok(out.includes("⚖️ [2] Decided X"));
-    assert.ok(out.includes("🧠 [4] Alice → owns → X"));
+    assert.ok(out.includes("- 📖 [1]"));
+    assert.ok(out.includes("- 💬 [3] Jack"));
+    assert.ok(out.includes("- ⚖️ [2]"));
+    assert.ok(out.includes("- 🧠 [4]"));
   });
 });
 
@@ -179,7 +197,7 @@ describe("renderTensions", () => {
       { title: "Third one", detail: "dropped" },
     ]);
     assert.ok(out.includes("Heads up — possible tension"));
-    assert.ok(out.includes("• Launch order disputed — marketing vs general"));
+    assert.ok(out.includes("- Launch order disputed — marketing vs general"));
     assert.ok(!out.includes("Third one"));
   });
   it("returns '' for empty/undefined", () => {
@@ -189,7 +207,7 @@ describe("renderTensions", () => {
   it("appears in a full reply when present", () => {
     const out = renderResponse(result({ tensions: [{ title: "Conflict A" }] }), "slack");
     assert.ok(out.includes("possible tension"));
-    assert.ok(out.includes("• Conflict A"));
+    assert.ok(out.includes("- Conflict A"));
   });
 });
 

--- a/bot/src/renderer.ts
+++ b/bot/src/renderer.ts
@@ -14,9 +14,16 @@
  * When `result.isEmpty` is set it renders an honest, actionable empty state
  * instead of surfacing an LLM "I couldn't find anything" essay.
  *
- * The output is plain markdown, which every adapter (Slack mrkdwn, Discord,
- * Teams, Telegram, Mattermost) renders acceptably. Native rich cards / buttons
- * are a deliberate follow-up (they need the SDK `onAction` webhook wired up).
+ * OUTPUT CONTRACT: this returns ONE canonical GitHub-flavored CommonMark string
+ * — `## headings`, `[label](url)` links, `- ` bullets, `**bold**`, `_italic_`.
+ * The caller posts it as `{ markdown }`, so the chat SDK's per-platform
+ * FormatConverter owns the native conversion (Slack demotes `##`→bold and
+ * `[x](u)`→`<u|x>`, Teams→Adaptive Card text, Discord/Mattermost render natively,
+ * Telegram→MarkdownV2). DIRECTIVE: do NOT re-introduce platform-specific syntax
+ * here (bare `<url>` autolinks, Slack `*bold*`, `• ` bullets) — emit portable
+ * markdown only and let the SDK convert. Tables/blockquotes are intentionally
+ * not emitted (uneven cross-platform support). Native cards / interactive
+ * buttons remain a deliberate follow-up (they need the SDK `onAction` webhook).
  */
 
 import type { AskResult, Citation, Tension } from "./types.js";
@@ -76,7 +83,7 @@ export function enforceCap(text: string, cap: number): string {
  * Defense-in-depth: citation fields come from the backend but pass through
  * channel-message content, wiki titles, and user display names. Collapse
  * control chars / newlines (so a crafted value can't forge an extra
- * "📎 *Sources*" block or break the layout) and bound the length.
+ * "## 📎 Sources" heading or break the layout) and bound the length.
  */
 function cleanField(s: string, max = 300): string {
   let out = "";
@@ -87,26 +94,41 @@ function cleanField(s: string, max = 300): string {
   return out.replace(/\s+/g, " ").trim().slice(0, max);
 }
 
-/** Only emit http(s) links, stripped of anything that could break the `<…>` wrap. */
+/**
+ * Only emit http(s) links, stripped of anything that could break a markdown
+ * `[label](url)` link target — whitespace, angle brackets, and parentheses.
+ * (Real chat/wiki permalinks don't contain raw parens; dropping a rare one is
+ * safer than emitting a link the markdown parser would mangle.)
+ */
 function cleanUrl(u: string): string {
   const t = u.trim();
   if (!/^https?:\/\//i.test(t)) return "";
-  return t.replace(/[\s<>]+/g, "");
+  return t.replace(/[\s<>()]+/g, "");
 }
 
 /** Citation kinds that read as "related context" (graph) rather than direct sources. */
 const RELATED_KINDS = new Set(["decision_record", "graph_relationship"]);
 
+/**
+ * One concise citation line as a canonical markdown list item:
+ *   `- {icon} [N] {author} · {#channel} · [open](url)`
+ *
+ * The full fact text is intentionally dropped — the inline `[N]` marker in the
+ * answer already references it, and repeating the whole fact here buried the
+ * answer under a wall of sources (live-test finding: "sources too verbose").
+ * Segments are omitted when absent, so a bare citation still renders
+ * `- {icon} [N]`. `[open](url)` is a real markdown link the SDK converts to
+ * each platform's native link syntax.
+ */
 function renderCitationLine(c: Citation, num: number): string {
-  let line = `${iconFor(c.type)} [${num}] ${cleanField(c.text)}`.trim();
-  const meta: string[] = [];
-  if (c.author) meta.push(cleanField(c.author, 80));
-  if (c.source) meta.push(cleanField(c.source, 80));
-  const shownMeta = meta.filter((m) => m.length > 0);
-  if (shownMeta.length) line += ` — ${shownMeta.join(", ")}`;
+  const segments: string[] = [];
+  if (c.author) segments.push(cleanField(c.author, 80));
+  if (c.source) segments.push(cleanField(c.source, 80));
   const url = c.url ? cleanUrl(c.url) : "";
-  if (url) line += ` <${url}>`;
-  return line;
+  if (url) segments.push(`[open](${url})`);
+  const tail = segments.filter((s) => s.length > 0).join(" · ");
+  const head = `- ${iconFor(c.type)} [${num}]`;
+  return tail ? `${head} ${tail}` : head;
 }
 
 /**
@@ -125,7 +147,7 @@ function renderCitationBlock(heading: string, entries: Array<{ c: Citation; num:
 
 /** Backward-compatible: render all citations as a single Sources block. */
 export function renderCitations(citations: Citation[]): string {
-  return renderCitationBlock("📎 *Sources*", citations.map((c, i) => ({ c, num: i + 1 })));
+  return renderCitationBlock("## 📎 Sources", citations.map((c, i) => ({ c, num: i + 1 })));
 }
 
 /** Group citations into direct sources vs graph "related context", keeping indices. */
@@ -162,11 +184,11 @@ export function renderTensions(tensions?: Tension[]): string {
     .map((t) => {
       const title = cleanField(t.title, 140);
       const detail = t.detail ? cleanField(t.detail, 160) : "";
-      return detail ? `• ${title} — ${detail}` : `• ${title}`;
+      return detail ? `- ${title} — ${detail}` : `- ${title}`;
     })
     .filter((l) => l.length > 2);
   if (items.length === 0) return "";
-  return `\n\n⚠️ *Heads up — possible tension*\n${items.join("\n")}`;
+  return `\n\n**⚠️ Heads up — possible tension**\n${items.join("\n")}`;
 }
 
 /** Human-friendly "Xm/Xh/Xd ago" from an ISO timestamp; null if unparseable. */
@@ -185,10 +207,15 @@ export function relativeTime(iso: string, now: number = Date.now()): string | nu
   return `${days}d ago`;
 }
 
+/**
+ * Honest freshness footer. The backend's `last_sync_ts` is the timestamp of the
+ * channel's last synced *message*, not the sync-run time, so we label it "last
+ * activity" — saying "synced Nd ago" misled users on quiet-but-fresh channels.
+ */
 function renderFreshness(lastSyncTs?: string): string {
   if (!lastSyncTs) return "";
   const rel = relativeTime(lastSyncTs);
-  return rel ? `\n🕐 _synced ${rel}_` : "";
+  return rel ? `\n🕐 _last activity ${rel}_` : "";
 }
 
 function renderRoute(route: string): string {
@@ -207,7 +234,7 @@ export function renderFollowUps(followUps?: string[]): string {
     .filter((q) => q.length > 0)
     .slice(0, 3);
   if (items.length === 0) return "";
-  return `\n\n_You might also ask:_\n${items.map((q) => `• ${q}`).join("\n")}`;
+  return `\n\n_You might also ask:_\n${items.map((q) => `- ${q}`).join("\n")}`;
 }
 
 /**
@@ -219,8 +246,8 @@ export function renderEmptyState(result: AskResult, platform: string): string {
   const lines = [
     "I don't have anything indexed for that in this channel yet.",
     "",
-    "• The channel may not be synced yet — an admin can trigger a sync.",
-    "• Try rephrasing, or ask in a channel that's already indexed.",
+    "- The channel may not be synced yet — an admin can trigger a sync.",
+    "- Try rephrasing, or ask in a channel that's already indexed.",
   ];
   const freshness = renderFreshness(result.lastSyncTs);
   if (freshness) lines.push(freshness.trimStart());
@@ -238,8 +265,8 @@ export function renderResponse(result: AskResult, platform: string): string {
     // A low-confidence warning sits right under the answer so truncation can
     // never drop this trust signal.
     renderConfidence(result.confidence, result.isEmpty) +
-    renderCitationBlock("📎 *Sources*", sources) +
-    renderCitationBlock("🧠 *Related*", related) +
+    renderCitationBlock("## 📎 Sources", sources) +
+    renderCitationBlock("## 🧠 Related", related) +
     renderTensions(result.tensions) +
     renderFreshness(result.lastSyncTs) +
     renderFollowUps(result.followUps) +

--- a/bot/src/sse-client.test.ts
+++ b/bot/src/sse-client.test.ts
@@ -330,6 +330,27 @@ describe("resolveIsEmpty", () => {
     assert.strictEqual(resolveIsEmpty("I could not find any indexed memories", noCites, undefined), true);
     assert.strictEqual(resolveIsEmpty("The booth is H25.", noCites, undefined), false);
   });
+  it("does NOT swallow a friendly greeting/identity reply flagged empty", () => {
+    // No retrieval → no citations → backend flags empty, but this is a valid
+    // conversational answer and must be shown verbatim (live-test bug fix).
+    assert.strictEqual(
+      resolveIsEmpty("Hi! I'm Beever Atlas, your team knowledge assistant. Ask me about your channels.", noCites, true),
+      false,
+    );
+    assert.strictEqual(
+      resolveIsEmpty("I don't have that indexed yet, but here's how to sync your workspace.", noCites, true),
+      false,
+    );
+  });
+  it("still collapses a definitive empty phrase even when it offers help", () => {
+    // EMPTY_PATTERN keeps priority over the guidance guard, so a genuinely empty
+    // answer can't slip through just because it also says "I can help".
+    assert.strictEqual(
+      resolveIsEmpty("I have no indexed memories yet, but I can help once it's synced.", noCites, true),
+      true,
+    );
+    assert.strictEqual(resolveIsEmpty("This channel hasn't been synced yet.", noCites, true), true);
+  });
 });
 
 describe("detectEmptyRetrieval", () => {

--- a/bot/src/sse-client.ts
+++ b/bot/src/sse-client.ts
@@ -46,6 +46,18 @@ const SUBSTANTIVE_ANSWER_CHARS = 600;
 const EMPTY_PATTERN =
   /no indexed (memories|facts|wiki)|hasn'?t been synced|not been synced|could not find any indexed|don'?t have (any )?(indexed )?(memories|facts|wiki)|no record of/i;
 
+/**
+ * Phrases that mark a coherent CONVERSATIONAL reply (greeting / identity /
+ * "here's how to get started") that the agent returns WITHOUT retrieving
+ * anything — so it carries no citations and `is_empty_retrieval=true`, yet must
+ * NOT be replaced by the generic empty state. (Live-test bug: a friendly
+ * "Hi! I'm Beever Atlas…" answer to "hi" was being swallowed.) Kept tight and
+ * only consulted when EMPTY_PATTERN does NOT also match, so a genuinely empty
+ * "I have no indexed memories, but I can help" can't slip through.
+ */
+export const GUIDANCE_PATTERN =
+  /beever atlas|i'?m (your|a|the) .*(assistant|agent)|here'?s how|you can (sync|index|ask|invite)|try asking|i can (search|help|find|answer)|what would you like|ask me/i;
+
 function asString(v: unknown): string | undefined {
   return typeof v === "string" && v.length > 0 ? v : undefined;
 }
@@ -122,11 +134,17 @@ export function detectEmptyRetrieval(answer: string, citations: Citation[]): boo
 
 /**
  * Decide the final empty-state, combining the backend signal with the client
- * heuristic safely. Requirements to render the empty state:
- *  - no citations (a cited answer is never "empty"), AND
- *  - the backend flagged empty retrieval OR the text matches the empty pattern, AND
- *  - the answer is not substantive (so a long real answer is never hidden even
- *    if the backend flag misfires).
+ * heuristic safely. Render the empty state only when ALL hold:
+ *  - no citations (a cited answer is never "empty"),
+ *  - the answer is not substantive (a long real answer is never hidden), AND
+ *  - the answer is either a definitive empty-retrieval phrase OR the backend
+ *    flagged empty retrieval and the answer is NOT a coherent conversational
+ *    reply.
+ *
+ * The guidance guard fixes a live-test bug: a friendly "Hi! I'm Beever Atlas…"
+ * greeting (no retrieval → no citations → `is_empty_retrieval=true`) was being
+ * swallowed into the generic empty state. EMPTY_PATTERN keeps priority so a
+ * genuinely empty answer that also offers help can't slip through the guard.
  */
 export function resolveIsEmpty(
   answer: string,
@@ -135,7 +153,12 @@ export function resolveIsEmpty(
 ): boolean {
   if (citations.length > 0) return false;
   if (answer.trim().length >= SUBSTANTIVE_ANSWER_CHARS) return false;
-  return backendEmpty === true || EMPTY_PATTERN.test(answer);
+  // A definitive "nothing found" phrase is empty even if it also offers help.
+  if (EMPTY_PATTERN.test(answer)) return true;
+  // A coherent greeting / identity / how-to reply is a valid answer — show it
+  // verbatim instead of collapsing it just because retrieval returned nothing.
+  if (GUIDANCE_PATTERN.test(answer)) return false;
+  return backendEmpty === true;
 }
 
 function finalizeResult(state: StreamState): AskResult {

--- a/src/beever_atlas/agents/query/prompts.py
+++ b/src/beever_atlas/agents/query/prompts.py
@@ -9,6 +9,28 @@ You are Beever Atlas, an AI knowledge assistant for team knowledge management. \
 Do not disclose your underlying model, provider, or that you are powered by any specific AI company. \
 When asked who you are, identify yourself as Beever Atlas."""
 
+GREETING_RESPONSE = """\
+## Greetings & small-talk
+If the user's message is purely a greeting or small-talk ("hi", "hello", "hey", \
+"how are you", "who are you", "what can you do", "thanks"), do NOT call any tools. \
+Reply in 1-2 warm sentences that:
+- name yourself as "Beever Atlas",
+- state ONE concrete capability (e.g. "I can answer questions about what your team \
+  has discussed and decided in this channel, with sources"),
+- nudge the user with 2-3 short example questions they could ask \
+  (e.g. "What did we decide about X?", "Who knows about Y?", "What's new this week?").
+Never expose a raw channel id in a greeting. Keep it brief and friendly — no headings, \
+no citations, no tool calls."""
+
+CHANNEL_CONTEXT_PRIVACY = """\
+## Channel context is private
+The user's turn may be prefixed with a `[Channel: <id>]` marker. That marker is \
+retrieval context ONLY — it tells you which channel to scope your search to. \
+NEVER echo, repeat, or display the raw channel id (e.g. `C08TXAWFEP5`) back to the \
+user. Refer to the channel by its human-friendly name (e.g. "#beever") drawn from a \
+tool result's `channel_name` field. If no friendly name is available, say "this \
+channel" rather than printing the id."""
+
 RETRIEVAL_PIPELINE = """\
 ## Required Retrieval Pipeline
 
@@ -168,19 +190,40 @@ Citation rules (critical):
 - If a tool returned NO sources, do not cite anything from it. If the whole answer has no real sources, state the lack of data plainly without trailing citation brackets."""
 
 OUTPUT_CONTRACT_STRICT = """\
-STRUCTURE (mandatory):
-- Any answer longer than ~80 words MUST begin with a single-line `##` heading that names the topic.
-- Use `###` sub-headings when the answer has 2+ distinct sub-topics.
-- Every bullet in a list MUST be a complete sentence containing at least one concrete fact, name, date, or citation. NO one-or-two-word bullets. NO bullets that only repeat the heading.
-- Lists of 3+ items that each have 2+ attributes (e.g. name + role, name + topic, item + description, handle + expertise) MUST render as a GitHub-flavored markdown table — NOT a bullet list. Columns = attributes, rows = items. Always include a header row. Cite cells inline with `[src:...]`.
-- If the items are entities with directional relationships (caller → callee, before → after, parent → child, input → output, decision → outcome), render a Mermaid fenced block (```mermaid / flowchart LR / graph TD / timeline) INSTEAD OF a bullet list. Keep nodes ≤12 and label every edge.
-- Prefer tables over bulleted name-value pairs. Prefer Mermaid diagrams over prose for pipelines, architectures, workflows, supersedes chains, org structures, data flows, or decision trees.
-- When the answer braids internal (channel) knowledge with external (web) context, use EXPLICIT section headers: `## From your knowledge base` and `## External context`, followed by `## Synthesis` (one paragraph, no citations). Do NOT mix internal and external facts in the same bullet.
+This is a CHAT reply. Lead with the answer; match length to the question. Be the kind \
+of message someone is glad to read in a channel — not a document.
 
-DEPTH (mandatory):
-- For any substantive question (not a greeting/small-talk), emit AT LEAST 150 words of cited content.
-- Each factual claim MUST carry an inline citation unless it is a synthesis sentence in the Synthesis block.
-- If the knowledge base has fewer than 3 relevant facts, say so explicitly in one sentence, then use external_knowledge to flesh out context, then cite both."""
+SHAPE (adaptive):
+- Open with a 1-2 sentence TL;DR that answers the question directly. The reader should \
+  get the point from the first line.
+- Headings are OPTIONAL. For a short answer (≤50 words) skip headings entirely. Add a \
+  `##` heading only when the answer runs long (well past ~80 words) or genuinely covers \
+  2+ distinct sub-topics that need separating.
+- Bullets, tables, and Mermaid diagrams are tools you SHOULD reach for when they make \
+  the answer clearer — NOT mandatory ceremony. When brevity wins, plain sentences win.
+  - Use a markdown table when listing 3+ items that each have 2+ attributes AND a table \
+    is genuinely easier to scan than prose.
+  - Use a Mermaid fenced block (```mermaid) for directional relationships (pipelines, \
+    supersedes chains, org structures, decision → outcome) only when the structure is \
+    the point and the diagram beats a sentence. Keep nodes ≤12 and label every edge.
+- Every bullet you do write must be a complete, fact-bearing sentence — no one-word \
+  bullets, no bullets that only restate a heading.
+- When the answer braids internal (channel) knowledge with external (web) context, \
+  separate them with `## From your knowledge base` and `## External context`, then a \
+  short `## Synthesis`. Do NOT mix internal and external facts in one bullet.
+
+LENGTH (adaptive):
+- Chat target: 20-80 words for a focused question — answer it and stop.
+- Substantive/multi-part question: 150-300 words, organized with light headings.
+- Never pad to hit a length. A correct one-line answer beats a padded paragraph.
+
+CITATION RIGOR (non-negotiable):
+- EVERY factual claim drawn from a tool result MUST carry an inline citation. Brevity \
+  never excuses dropping a citation.
+- The only un-cited sentences allowed are the synthesis line in a `## Synthesis` block \
+  and pure greetings/small-talk.
+- If the knowledge base has fewer than 3 relevant facts, say so in one sentence, then \
+  optionally use external knowledge to fill context, citing both."""
 
 
 RETRIEVAL_GUIDANCE = """\
@@ -371,6 +414,8 @@ def build_qa_system_prompt(
         parts = [
             IDENTITY_PREAMBLE,
             "",
+            GREETING_RESPONSE,
+            "",
             OUTPUT_CONTRACT,
             "",
             OUTPUT_CONTRACT_STRICT,
@@ -386,6 +431,8 @@ def build_qa_system_prompt(
             citation_block,
             "",
             EMPTY_SIGNAL_HANDLING,
+            "",
+            CHANNEL_CONTEXT_PRIVACY,
             "",
             LANGUAGE_DIRECTIVE,
             "",

--- a/src/beever_atlas/agents/tools/_citation_decorator.py
+++ b/src/beever_atlas/agents/tools/_citation_decorator.py
@@ -247,14 +247,27 @@ def _extract_title(kind: str, item: dict) -> str:
 def _extract_native(kind: str, item: dict) -> dict[str, Any]:
     """Pick the subset of fields kept on `Source.native` for rendering/resolve."""
     if kind == "channel_message":
+        # Defensive platform default: the permalink resolver needs a platform
+        # to pick a URL template, and the live Slack reply path occasionally
+        # surfaces facts whose `platform` field is absent (older docs, partial
+        # projections). When a caller injected a `channel_id`-bearing context
+        # without a platform we fall back to "slack" — the dominant live
+        # platform — so the Slack permalink path still resolves. A genuinely
+        # unknown platform stays unresolvable: the resolver only emits a URL
+        # when the per-platform native fields (workspace/ts) are also present,
+        # so this default can never fabricate a broken link for non-Slack data.
+        platform = item.get("platform") or ("slack" if item.get("channel_id") else None)
         return {
-            "platform": item.get("platform"),
+            "platform": platform,
             "channel_id": item.get("channel_id"),
             "channel_name": item.get("channel_name"),
             "author": item.get("author"),
             "author_id": item.get("author_id"),
             "message_ts": item.get("message_ts") or item.get("timestamp"),
-            "message_id": item.get("message_id"),
+            # `source_message_id` is the platform-native message identifier the
+            # fact store actually carries; Discord/Teams URL templates key off
+            # it. Slack ignores message_id and uses message_ts instead.
+            "message_id": item.get("message_id") or item.get("source_message_id"),
             "fact_id": item.get("fact_id"),
             "workspace_domain": item.get("workspace_domain"),
             "guild_id": item.get("guild_id"),

--- a/src/beever_atlas/agents/tools/memory_tools.py
+++ b/src/beever_atlas/agents/tools/memory_tools.py
@@ -206,6 +206,9 @@ async def search_channel_facts(
                     "message_ts": fact.message_ts,
                     "timestamp": _format_timestamp(fact.message_ts),
                     "permalink": fact.source_message_id,
+                    # Platform-native message id (Discord/Teams permalink key).
+                    # Slack ignores it and keys off message_ts instead.
+                    "source_message_id": fact.source_message_id,
                     "importance": fact.importance,
                     "confidence": round(fact.quality_score / 10.0, 2)
                     if fact.quality_score
@@ -382,6 +385,9 @@ async def get_recent_activity(
                                 "platform": getattr(fact, "platform", "slack"),
                                 "message_ts": fact.message_ts,
                                 "timestamp": _format_timestamp(fact.message_ts),
+                                # Platform-native message id (Discord/Teams
+                                # permalink key); Slack keys off message_ts.
+                                "source_message_id": getattr(fact, "source_message_id", ""),
                                 "importance": fact.importance,
                                 "topic_tags": fact.topic_tags,
                                 "fact_id": fact.id,

--- a/src/beever_atlas/api/ask.py
+++ b/src/beever_atlas/api/ask.py
@@ -341,9 +341,14 @@ async def _build_metadata_event(
       the client can render an honest "nothing indexed" state instead of
       guessing from the answer text. Falls back to ``False`` when the citation
       registry is off (legacy path), leaving the client heuristic in charge.
-    - ``last_sync_ts``: the channel's last sync time (ISO-8601) for a freshness
-      hint. A store hiccup degrades it to ``None`` rather than breaking the
-      stream — freshness is best-effort.
+    - ``last_sync_ts``: the timestamp of the last synced MESSAGE in this
+      channel (ISO-8601), NOT the wall-clock time of the last sync RUN. It
+      answers "how recent is the newest message I've indexed", which is the
+      honest freshness signal the bot surfaces. The accompanying
+      ``freshness_kind: "last_message"`` key names this semantics explicitly so
+      clients never mistake it for a sync-run time. A store hiccup degrades the
+      value to ``None`` rather than breaking the stream — freshness is
+      best-effort.
     """
     from beever_atlas.stores import get_stores
 
@@ -364,6 +369,9 @@ async def _build_metadata_event(
         "mode": mode,
         "is_empty_retrieval": registry is not None and registry.registered_count == 0,
         "last_sync_ts": last_sync_ts,
+        # Names the semantics of ``last_sync_ts`` so the bot can label it
+        # honestly ("last message seen", not "last synced"). Additive.
+        "freshness_kind": "last_message",
     }
 
 

--- a/tests/agents/citations/test_decorator.py
+++ b/tests/agents/citations/test_decorator.py
@@ -163,6 +163,105 @@ async def test_link_previews_from_channel_link_urls():
     assert titles == ["A", "B"]
 
 
+# ---- native extraction for permalink resolution -----------------------
+
+
+@pytest.mark.asyncio
+async def test_native_defaults_platform_to_slack_when_missing():
+    """A channel_message item without `platform` but with `channel_id` defaults
+    to slack so the live Slack reply path still resolves."""
+
+    @cite_tool_output(kind="channel_message")
+    async def fake_tool() -> list[dict]:
+        return [
+            {
+                "text": "no platform field here",
+                "author": "a",
+                "channel_id": "C1",
+                "message_ts": "1712500000.001100",
+            }
+        ]
+
+    r, tok = bind()
+    try:
+        await fake_tool()
+    finally:
+        reset(tok)
+
+    source = list(r._sources.values())[0]
+    assert source.native["platform"] == "slack"
+
+
+@pytest.mark.asyncio
+async def test_native_maps_source_message_id_to_message_id():
+    """`source_message_id` from the fact store is surfaced as `message_id`
+    (the Discord/Teams permalink key) when no explicit message_id is set."""
+
+    @cite_tool_output(kind="channel_message")
+    async def fake_tool() -> list[dict]:
+        return [
+            {
+                "text": "discord msg",
+                "author": "a",
+                "platform": "discord",
+                "channel_id": "111",
+                "guild_id": "222",
+                "source_message_id": "333",
+                "message_ts": "1712500000.001100",
+            }
+        ]
+
+    r, tok = bind()
+    try:
+        await fake_tool()
+    finally:
+        reset(tok)
+
+    source = list(r._sources.values())[0]
+    assert source.native["message_id"] == "333"
+
+
+@pytest.mark.asyncio
+async def test_full_slack_native_resolves_to_permalink_end_to_end():
+    """A channel_message with full Slack native resolves to an archives URL
+    once the resolver is attached at finalize()."""
+    from beever_atlas.agents.citations.permalink_resolver import default_resolver
+
+    @cite_tool_output(kind="channel_message")
+    async def fake_tool() -> list[dict]:
+        return [
+            {
+                "text": "the decision",
+                "author": "alice",
+                "channel_id": "C08TX",
+                "channel_name": "eng",
+                "platform": "slack",
+                "message_ts": "1712500000.001100",
+                "workspace_domain": "beever",
+            }
+        ]
+
+    r, tok = bind()
+    try:
+        r.set_permalink_resolver(default_resolver)
+        results = await fake_tool()
+        cite = results[0]["_cite"]
+        from beever_atlas.agents.query.stream_rewriter import StreamRewriter
+
+        rewriter = StreamRewriter(r)
+        rewriter.feed(f"Per {cite}, it's settled.")
+        rewriter.flush()
+        env = r.finalize()
+    finally:
+        reset(tok)
+
+    assert env.sources[0].permalink == ("https://beever.slack.com/archives/C08TX/p1712500000001100")
+    # Legacy flat items must also carry the resolved permalink.
+    assert env.items[0]["permalink"] == (
+        "https://beever.slack.com/archives/C08TX/p1712500000001100"
+    )
+
+
 # ---- score normalization ----------------------------------------------
 
 

--- a/tests/agents/citations/test_permalink_resolver.py
+++ b/tests/agents/citations/test_permalink_resolver.py
@@ -6,6 +6,8 @@ graceful-null fallbacks for missing metadata.
 
 from __future__ import annotations
 
+import pytest
+
 from beever_atlas.agents.citations.permalink_resolver import (
     PermalinkResolver,
     reset_warn_cache,
@@ -165,3 +167,56 @@ def test_resolver_never_throws_on_bad_data():
     s = _source("channel_message", {"platform": "slack", "channel_id": None, "message_ts": None})
     # Should not raise
     assert r.resolve(s) is None
+
+
+# ---- table-driven channel_message coverage ----------------------------
+
+
+@pytest.mark.parametrize(
+    "native,expected",
+    [
+        # Slack: full native → archives permalink
+        (
+            {
+                "platform": "slack",
+                "channel_id": "C08TX",
+                "message_ts": "1712500000.001100",
+                "workspace_domain": "beever",
+            },
+            "https://beever.slack.com/archives/C08TX/p1712500000001100",
+        ),
+        # Discord: full native → discord deep link
+        (
+            {
+                "platform": "discord",
+                "channel_id": "111",
+                "guild_id": "222",
+                "message_id": "333",
+            },
+            "https://discord.com/channels/222/111/333",
+        ),
+        # Teams: channel + message id → teams deep link
+        (
+            {"platform": "teams", "channel_id": "C1", "message_id": "M1"},
+            "https://teams.microsoft.com/l/message/C1/M1",
+        ),
+        # Missing native (no platform) → None
+        ({"channel_id": "C1", "message_ts": "1.1"}, None),
+        # Slack missing workspace_domain → None (never a broken URL)
+        (
+            {"platform": "slack", "channel_id": "C1", "message_ts": "1712500000.001100"},
+            None,
+        ),
+        # Discord missing message_id → None
+        ({"platform": "discord", "channel_id": "111", "guild_id": "222"}, None),
+        # Teams missing message_id → None
+        ({"platform": "teams", "channel_id": "C1"}, None),
+        # Empty native → None
+        ({}, None),
+    ],
+)
+def test_channel_message_table(native, expected):
+    reset_warn_cache()
+    r = PermalinkResolver()
+    s = _source("channel_message", native)
+    assert r.resolve(s) == expected

--- a/tests/agents/test_prompt_redesign.py
+++ b/tests/agents/test_prompt_redesign.py
@@ -72,6 +72,54 @@ def test_new_prompt_cached_independently():
     assert agent1 is not agent2
 
 
+def test_new_prompt_contains_greeting_response():
+    """Flag on: the greeting/identity directive must be present and name Beever Atlas."""
+    settings = _make_settings(new_prompt=True)
+    with patch("beever_atlas.infra.config.get_settings", return_value=settings):
+        from beever_atlas.agents.query.prompts import GREETING_RESPONSE, build_qa_system_prompt
+
+        prompt = build_qa_system_prompt(max_tool_calls=8, include_follow_ups=False, mode="deep")
+    assert GREETING_RESPONSE in prompt
+    assert "Beever Atlas" in GREETING_RESPONSE
+    # A concrete capability and example-question nudge are part of the contract.
+    assert "greeting" in GREETING_RESPONSE.lower()
+    assert "example questions" in GREETING_RESPONSE.lower()
+    # Load-bearing clause: a greeting must NOT trigger retrieval/tool calls.
+    assert "do not call any tools" in GREETING_RESPONSE.lower()
+
+
+def test_new_prompt_contains_channel_context_privacy():
+    """Flag on: the channel-id privacy directive must be present in the new branch."""
+    settings = _make_settings(new_prompt=True)
+    with patch("beever_atlas.infra.config.get_settings", return_value=settings):
+        from beever_atlas.agents.query.prompts import (
+            CHANNEL_CONTEXT_PRIVACY,
+            build_qa_system_prompt,
+        )
+
+        prompt = build_qa_system_prompt(max_tool_calls=8, include_follow_ups=False, mode="deep")
+    assert CHANNEL_CONTEXT_PRIVACY in prompt
+    assert "[Channel: <id>]" in CHANNEL_CONTEXT_PRIVACY
+    assert "channel_name" in CHANNEL_CONTEXT_PRIVACY
+    # Load-bearing clause: the raw channel id must never be echoed back.
+    assert "never echo" in CHANNEL_CONTEXT_PRIVACY.lower()
+
+
+def test_greeting_and_privacy_absent_when_flag_off():
+    """Legacy branch must not include the new additive blocks."""
+    settings = _make_settings(new_prompt=False)
+    with patch("beever_atlas.infra.config.get_settings", return_value=settings):
+        from beever_atlas.agents.query.prompts import (
+            CHANNEL_CONTEXT_PRIVACY,
+            GREETING_RESPONSE,
+            build_qa_system_prompt,
+        )
+
+        prompt = build_qa_system_prompt(max_tool_calls=8, include_follow_ups=False, mode="deep")
+    assert GREETING_RESPONSE not in prompt
+    assert CHANNEL_CONTEXT_PRIVACY not in prompt
+
+
 def test_deep_mode_skips_length_hint_both_paths():
     """Deep mode never includes the onboarding length hint — on either prompt path."""
     from beever_atlas.agents.query.prompts import ONBOARDING_LENGTH_HINT, build_qa_system_prompt

--- a/tests/test_ask_endpoint.py
+++ b/tests/test_ask_endpoint.py
@@ -459,3 +459,49 @@ class TestReplyContractV2V3:
         # reads these keys; value may be null/false depending on data).
         assert "is_empty_retrieval" in meta
         assert "last_sync_ts" in meta
+        # P1-2: freshness_kind names the semantics of last_sync_ts honestly —
+        # it is the last MESSAGE seen, not the last sync RUN.
+        assert meta.get("freshness_kind") == "last_message"
+
+    @pytest.mark.asyncio
+    async def test_channel_message_full_slack_native_resolves_permalink(self):
+        """A channel_message source carrying full Slack native resolves to an
+        archives permalink, and the legacy flat `items[].permalink` is populated.
+
+        Exercised at the citation layer (registry + decorator + resolver) because
+        the SSE mock runner emits no real tool calls. This is the same pipeline
+        the live `/ask` path drives once the registry flag is on.
+        """
+        from beever_atlas.agents.citations.permalink_resolver import default_resolver
+        from beever_atlas.agents.citations.registry import bind, reset
+        from beever_atlas.agents.query.stream_rewriter import StreamRewriter
+        from beever_atlas.agents.tools._citation_decorator import cite_tool_output
+
+        @cite_tool_output(kind="channel_message")
+        async def _search() -> list[dict]:
+            return [
+                {
+                    "text": "we shipped durable media",
+                    "author": "alan",
+                    "channel_id": "C08TX",
+                    "channel_name": "beever",
+                    "platform": "slack",
+                    "message_ts": "1712500000.001100",
+                    "workspace_domain": "beever",
+                }
+            ]
+
+        r, tok = bind()
+        try:
+            r.set_permalink_resolver(default_resolver)
+            results = await _search()
+            rewriter = StreamRewriter(r)
+            rewriter.feed(f"Yes {results[0]['_cite']}.")
+            rewriter.flush()
+            env = r.finalize()
+        finally:
+            reset(tok)
+
+        expected = "https://beever.slack.com/archives/C08TX/p1712500000001100"
+        assert env.sources[0].permalink == expected
+        assert env.items[0]["permalink"] == expected

--- a/tests/test_true_hybrid_search.py
+++ b/tests/test_true_hybrid_search.py
@@ -215,9 +215,12 @@ async def test_search_channel_facts_calls_true_hybrid_search():
 
     # Result shape preserved
     assert isinstance(results, list)
-    if results:
-        assert "text" in results[0]
-        assert "author" in results[0]
+    assert results, "expected at least one result for the seeded fact"
+    assert "text" in results[0]
+    assert "author" in results[0]
+    # source_message_id is projected through so the citation decorator can build
+    # a platform-native permalink (Discord/Teams key off it).
+    assert results[0]["source_message_id"] == "msg-1"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes the chat **@mention reply presentation** problems found in live Slack testing, and makes the reply renderer **multi-platform-correct** by delegating markdown→native conversion to the chat SDK. Continuation of the shipped reply feature (#230, #233).

The root fix is architectural: post replies as **`{ markdown }`** so each adapter's `FormatConverter` owns the native conversion (Slack Block Kit / Teams Adaptive Card / Discord / Mattermost / Telegram). The renderer emits **one canonical CommonMark string** instead of hand-rolled Slack-only mrkdwn that showed literally elsewhere.

## What changed

### P0 — bot (`bot/src`) · the visible fixes
- **`index.ts`**: post `{ markdown: renderResponse(...) }` instead of a raw string → fixes `##`/`**` rendering literally on Slack/Teams/Telegram.
- **`renderer.ts`**: emit canonical CommonMark — `## Sources` / `## Related` headings, `[open](url)` links (not bare `<url>`), `- ` bullets, `**bold**`. **Concise citation lines** `- 💬 [N] author · #channel · [open](url)` (drops the verbose fact text that buried answers). Honest **"last activity"** freshness label.
- **`sse-client.ts`**: `resolveIsEmpty` no longer swallows a valid **greeting/guidance** reply into the generic empty state (`EMPTY_PATTERN` keeps priority so a genuinely empty answer can't slip through).
- **Bundled low-risk wins**: ephemeral **error / rate-limit notices** (DM fallback, keeps the channel clean) and a **typing indicator** while the backend streams — both feature-detected against the SDK.

### P1 — backend (`api` + `agents/citations`)
- Thread `source_message_id` through retrieval tool projections so the citation decorator can resolve **channel_message permalinks**. Discord/Teams resolve; Slack returns `None` until `workspace_domain` is plumbed — **never a malformed URL**.
- Honest freshness: new additive `freshness_kind: "last_message"` + corrected docstring (`last_sync_ts` is the last *message* time, not the sync-run time).

### P2 — prompts (`agents/query/prompts.py`)
- Pre-retrieval **greeting/identity** reply (names Beever Atlas, nudges 2–3 example questions, **no tool calls**) + a **channel-id privacy** guard (never echo the raw `C…` id).
- **Chat-adaptive** `OUTPUT_CONTRACT_STRICT` (TL;DR-first, headings optional for short answers) while keeping citation rigor and the `80 words`/`150 words` test anchors.

## Use cases

| You @mention… | Before | After |
|---|---|---|
| a real question | wall of literal `## Heading` / `**bold**`, full fact text dumped per source | clean bold headings, **concise** `- 💬 [1] Jack · #basketball · [open]` sources |
| `hi` / `how are you` | generic "I don't have anything indexed" dead-end | warm "I'm Beever Atlas… try asking *What did we decide about X?*" |
| `who are you` | leaked raw `channel C0B5YCR1NL8?` | identity line, no id leak |
| question in an unsynced channel | LLM "couldn't find" essay | honest, actionable empty state |
| backend errors | permanent channel clutter | **ephemeral** notice (DM fallback) |

## How to test & expect

**Automated (all green):**
```bash
cd bot && npm run build && npm test          # tsc clean + 295 tests
cd .. && uv sync --extra dev
uv run pytest tests/test_ask_endpoint.py tests/agents/test_output_contract.py \
  tests/agents/test_prompt_redesign.py tests/agents/citations/ tests/test_true_hybrid_search.py -q
uv run python scripts/smoke_reply.py         # SMOKE: PASS
```
Expect: bot `## 📎 Sources` headings + `[open](url)` links + no fact text; `resolveIsEmpty` shows greetings; backend metadata carries `freshness_kind`; `80 words`/`150 words` anchors retained.

**Manual multi-platform matrix** — for each platform @mention with (a) a cited question, (b) `hi`, (c) `who are you`, (d) a question in an unsynced channel, and (e) force a backend error:
- **Slack** (live/primary): `##`→bold, links clickable, concise sources, identity line (not empty state), ephemeral error, typing shows, "last activity" label.
- **Teams**: `##`→bold (no headings), links + bullets render, error via DM fallback.
- **Discord**: native/bold headings, masked `[open](url)` links, bullets, clickable message permalink.
- **Mattermost**: full markdown renders.
- **Telegram**: `##`→bold + bullets survive, links inline, MarkdownV2 escaping handled by the adapter.

## ⚠️ Known limitation (documented, follow-up)

Live **Slack** `[N]` links are **not clickable yet**: `workspace_domain` is not stored in backend data today, so the resolver safely returns no link (never a broken one). Making them clickable needs a small follow-up to thread the Slack workspace domain from the bridge/connection into the per-turn context — the backend wiring is already in place. Discord/Teams resolve once their native ids reach the citation.

## Risk & rollback
Formatting now flows through the SDK per platform (see matrix). EX features are feature-detected/try-caught and degrade silently. Renderer/prompt changes are additive to the existing `AskResult`/metadata contract; the permalink change only adds fields. Rollback = revert the two commits independently (bot vs backend).

## Review
Built via Understand→Research→Design→Implement→Review workflows. A 4-dimension adversarial review (correctness · security · cross-platform · tests) raised 50 findings → **11 confirmed after independent verification**; all actionable items fixed in this PR (empty-state bullet contract, `{ markdown }` envelope + `postNotice` handler tests, `cleanUrl` paren-strip test, `source_message_id` + greeting/privacy clause assertions). No S1/S2 defects. Security: citation URLs are scheme-restricted + `()<>`/whitespace-stripped; author/source fields can't forge layout; permalink resolver never emits a malformed/cross-tenant URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
