### PR TITLE
fix(bot): attach Slack workspace_domain on the per-connection channel route (completes #239)

### DIFF
--- a/bot/src/bridge.ts
+++ b/bot/src/bridge.ts
@@ -2715,6 +2715,28 @@ async function handleListChannels(
   }
 }
 
+/**
+ * Attach the Slack workspace domain (cached from auth.test at registration) to a
+ * channel so the backend can build clickable citation permalinks. Slack-only,
+ * best-effort — a missing domain just leaves citations unlinked, never errors.
+ *
+ * Called by EVERY single-channel route (platform-level AND per-connection) so no
+ * route can silently drop the domain — the backend's BridgeAdapter uses the
+ * per-connection path, so patching only the platform route left permalinks dead.
+ * Prefers the exact per-connection domain when the connectionId is known.
+ */
+export function attachSlackWorkspaceDomain(
+  channel: NormalizedChannel,
+  chatManager: ChatManager,
+  connectionId?: string,
+): void {
+  if (channel.workspace_domain || channel.platform !== "slack") return;
+  const domain =
+    (connectionId ? chatManager.getWorkspaceDomain(connectionId) : null) ??
+    chatManager.getWorkspaceDomainForPlatform("slack");
+  if (domain) channel.workspace_domain = domain;
+}
+
 async function handleGetChannel(
   _req: IncomingMessage,
   res: ServerResponse,
@@ -2739,14 +2761,9 @@ async function handleGetChannel(
     }
 
     const channel = await bridge.getChannel(channelId);
-    // Attach the Slack workspace domain (per-connection, cached from auth.test)
-    // so the backend can build clickable citation permalinks. The per-platform
-    // bridges don't know it; chatManager does. Slack-only and best-effort — a
-    // missing domain just leaves citations unlinked.
-    if (!channel.workspace_domain && (channel.platform === "slack" || resolvedPlatform === "slack")) {
-      const domain = chatManager.getWorkspaceDomainForPlatform("slack");
-      if (domain) channel.workspace_domain = domain;
-    }
+    // This route resolves the bridge by platform (no specific connectionId), so
+    // the helper falls back to the platform-level domain lookup.
+    attachSlackWorkspaceDomain(channel, chatManager);
     jsonResponse(res, 200, channel);
   } catch (err) {
     console.error("Bridge: getChannel error:", safeErrorMessage(err));
@@ -3360,6 +3377,9 @@ export function registerBridgeRoutes(
     if (req.method === "GET" && connChannelMatch) {
       await handleConnectionRoute(req, res, chatManager, connChannelMatch[1], async (bridge) => {
         const channel = await bridge.getChannel(decodeChannelSegment(connChannelMatch[2]));
+        // The backend's BridgeAdapter resolves channels via THIS per-connection
+        // route, so the domain must be attached here too (exact, by connectionId).
+        attachSlackWorkspaceDomain(channel, chatManager, connChannelMatch[1]);
         jsonResponse(res, 200, channel);
       });
       return true;

--- a/bot/src/bridge.workspace-domain.test.ts
+++ b/bot/src/bridge.workspace-domain.test.ts
@@ -1,0 +1,73 @@
+/**
+ * attachSlackWorkspaceDomain — the helper every single-channel bridge route uses
+ * to stamp the Slack workspace domain onto a channel so the backend can build
+ * clickable citation permalinks.
+ *
+ * Regression guard for the bug live-testing caught: the backend resolves
+ * channels via the PER-CONNECTION route, so patching only the platform-level
+ * route left permalinks dead. The helper centralizes the logic; these tests pin
+ * the exact-by-connection vs platform-fallback behavior.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { attachSlackWorkspaceDomain } from "./bridge.js";
+import type { NormalizedChannel } from "./bridge.js";
+
+function slackChannel(over: Partial<NormalizedChannel> = {}): NormalizedChannel {
+  return {
+    channel_id: "C1",
+    name: "general",
+    platform: "slack",
+    is_member: true,
+    member_count: null,
+    topic: null,
+    purpose: null,
+    ...over,
+  };
+}
+
+/** Minimal ChatManager stub exposing only the two domain getters the helper calls. */
+function stubManager(byConn: Record<string, string>, byPlatform: string | null) {
+  return {
+    getWorkspaceDomain: (id: string) => byConn[id] ?? null,
+    getWorkspaceDomainForPlatform: (_p: string) => byPlatform,
+  } as unknown as Parameters<typeof attachSlackWorkspaceDomain>[1];
+}
+
+describe("attachSlackWorkspaceDomain", () => {
+  it("uses the EXACT per-connection domain when a connectionId is given", () => {
+    const ch = slackChannel();
+    attachSlackWorkspaceDomain(ch, stubManager({ "conn-1": "beeveratlas" }, "other"), "conn-1");
+    assert.strictEqual(ch.workspace_domain, "beeveratlas");
+  });
+
+  it("falls back to the platform domain when the connection has none", () => {
+    const ch = slackChannel();
+    attachSlackWorkspaceDomain(ch, stubManager({}, "beeveratlas"), "conn-unknown");
+    assert.strictEqual(ch.workspace_domain, "beeveratlas");
+  });
+
+  it("uses the platform domain when no connectionId is given", () => {
+    const ch = slackChannel();
+    attachSlackWorkspaceDomain(ch, stubManager({}, "beeveratlas"));
+    assert.strictEqual(ch.workspace_domain, "beeveratlas");
+  });
+
+  it("is a no-op for non-Slack channels", () => {
+    const ch = slackChannel({ platform: "discord" });
+    attachSlackWorkspaceDomain(ch, stubManager({ "conn-1": "beeveratlas" }, "beeveratlas"), "conn-1");
+    assert.strictEqual(ch.workspace_domain, undefined);
+  });
+
+  it("never overwrites a domain the channel already carries", () => {
+    const ch = slackChannel({ workspace_domain: "preset" });
+    attachSlackWorkspaceDomain(ch, stubManager({ "conn-1": "beeveratlas" }, "beeveratlas"), "conn-1");
+    assert.strictEqual(ch.workspace_domain, "preset");
+  });
+
+  it("leaves the domain unset when none is known anywhere", () => {
+    const ch = slackChannel();
+    attachSlackWorkspaceDomain(ch, stubManager({}, null), "conn-1");
+    assert.strictEqual(ch.workspace_domain, undefined);
+  });
+});


### PR DESCRIPTION
## Summary
Completes the clickable-Slack-permalink feature from #239. Live testing found `[N]` citations still resolved to **no link** even though the bot correctly cached `workspace_domain=beeveratlas`.

## Root cause
#239 patched only the platform-level `handleGetChannel` route. The backend's `BridgeAdapter` resolves channels via the **per-connection** route `/bridge/connections/:connId/channels/:id`, whose inline handler returned the channel *without* the domain. Verified live:
```
/bridge/channels/{id}                    → workspace_domain: beeveratlas  ✅
/bridge/connections/{conn}/channels/{id} → workspace_domain: None         ❌ (the one the backend uses)
```

## Fix
Extract a shared `attachSlackWorkspaceDomain(channel, chatManager, connectionId?)` helper and call it from **both** single-channel routes, so no route can silently drop the domain. The per-connection route passes its `connectionId` for an **exact** lookup; the platform route falls back to the platform domain. Slack-gated, best-effort, never overwrites.

## Test & verify
- `cd bot && npm test` → 312 pass (+6 new in `bridge.workspace-domain.test.ts`); tsc clean; 0 lint errors.
- Reviewed (code-reviewer): APPROVE, 0 issues — confirmed no other single-channel route misses the injection; no regression from dropping the redundant `resolvedPlatform` check (`SlackBridge.getChannel` hardcodes `platform: "slack"`); no new security surface.
- **Live (post-merge):** rebuild Docker, @mention a question in `#basketball`, confirm `[1]` resolves a `https://beeveratlas.slack.com/archives/...` permalink.

## Directive
Every new single-channel bridge route must call `attachSlackWorkspaceDomain` — do not inline domain logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
