### PR TITLE
fix(ingestion): preserve Slack-native message ts → clickable citation permalinks (completes the feature)

### DIFF
--- a/src/beever_atlas/agents/citations/permalink_resolver.py
+++ b/src/beever_atlas/agents/citations/permalink_resolver.py
@@ -72,7 +72,13 @@ class PermalinkResolver:
 
         if platform == "slack":
             workspace = native.get("workspace_domain") or native.get("workspace")
-            ts_path = _slack_ts_path(str(message_ts or ""))
+            # ``message_ts`` is stored as an ISO datetime for display; the numeric
+            # Slack ts needed for the archive URL is carried on the native message
+            # id (source_message_id → message_id). Try message_ts first (legacy
+            # numeric data), then fall back to the native message id.
+            ts_path = _slack_ts_path(str(message_ts or "")) or _slack_ts_path(
+                str(native.get("message_id") or "")
+            )
             if not workspace or not ts_path:
                 _warn_once(source.id, "slack missing workspace or ts")
                 return None

--- a/src/beever_atlas/agents/ingestion/persister.py
+++ b/src/beever_atlas/agents/ingestion/persister.py
@@ -46,6 +46,18 @@ def weaviate_failed(persist_errors: list[str]) -> bool:
     return any(err.startswith(WEAVIATE_ERROR_PREFIX) for err in persist_errors)
 
 
+def native_message_id(source_msg: dict[str, Any]) -> str:
+    """The platform-native message id of a preprocessed source message.
+
+    This is the value (e.g. the numeric Slack ts ``1779390885.369099``) needed to
+    build a real message permalink — as opposed to the synthetic ``msg-N``
+    reference the LLM emits. Prefers the explicit ``native_message_id`` the
+    preprocessor stamps, falling back to the raw ``message_id``. Returns ``""``
+    when neither is present (citation simply stays unlinked).
+    """
+    return source_msg.get("native_message_id") or source_msg.get("message_id") or ""
+
+
 def match_media_by_word_overlap(
     fact: dict[str, Any],
     preprocessed_messages: list[dict[str, Any]],
@@ -249,6 +261,13 @@ class PersisterAgent(BaseAgent):
                     heuristic_match = True
 
             if source_msg:
+                # Preserve the platform-native message id (e.g. the numeric Slack
+                # ts) for permalink construction. The LLM only emits the synthetic
+                # ``msg-N`` reference, which can't build a real message URL — so
+                # override source_message_id with the matched message's native id.
+                native_id = native_message_id(source_msg)
+                if native_id:
+                    fact_data["source_message_id"] = native_id
                 media_urls = source_msg.get("source_media_urls") or []
                 if media_urls:
                     logger.info(

--- a/src/beever_atlas/agents/ingestion/preprocessor.py
+++ b/src/beever_atlas/agents/ingestion/preprocessor.py
@@ -373,6 +373,13 @@ class PreprocessorAgent(BaseAgent):
             enriched["thread_context"] = _build_thread_context(msg, messages_by_ts)
             enriched["preprocessed"] = True
             enriched["msg_id"] = f"msg-{msg_seq}"
+            # Preserve the platform-native message id (e.g. the numeric Slack ts
+            # "1779390885.369099") so the persister can stamp it onto facts for
+            # permalink construction. The LLM only ever sees the synthetic
+            # ``msg_id`` above; the native id is what builds a real message URL.
+            enriched["native_message_id"] = (
+                msg.get("message_id") or msg.get("source_message_id") or ""
+            )
             msg_seq += 1
             preprocessed.append(enriched)
 

--- a/tests/agents/citations/test_permalink_resolver.py
+++ b/tests/agents/citations/test_permalink_resolver.py
@@ -45,6 +45,40 @@ def test_slack_permalink():
     assert r.resolve(s) == expected
 
 
+def test_slack_permalink_from_native_message_id_when_ts_is_iso():
+    """Real Slack facts store message_ts as an ISO datetime (display format); the
+    numeric ts lives on the native message id. The resolver must fall back to it."""
+    r = PermalinkResolver()
+    s = _source(
+        "channel_message",
+        {
+            "platform": "slack",
+            "channel_id": "C0B5YCR1NL8",
+            "message_ts": "2026-05-21T19:14:45.369000+00:00",  # ISO — not usable directly
+            "message_id": "1779390885.369099",  # the real numeric Slack ts
+            "workspace_domain": "beeveratlas",
+        },
+    )
+    expected = "https://beeveratlas.slack.com/archives/C0B5YCR1NL8/p1779390885369099"
+    assert r.resolve(s) == expected
+
+
+def test_slack_iso_ts_and_no_native_id_returns_null():
+    """An ISO ts with no numeric native id can't build a permalink — returns None,
+    never a broken URL."""
+    r = PermalinkResolver()
+    s = _source(
+        "channel_message",
+        {
+            "platform": "slack",
+            "channel_id": "C1",
+            "message_ts": "2026-05-21T19:14:45+00:00",
+            "workspace_domain": "w",
+        },
+    )
+    assert r.resolve(s) is None
+
+
 def test_slack_missing_workspace_returns_null():
     r = PermalinkResolver()
     s = _source(

--- a/tests/test_persister_heuristic.py
+++ b/tests/test_persister_heuristic.py
@@ -9,11 +9,26 @@ The raised threshold must:
 
 from __future__ import annotations
 
-from beever_atlas.agents.ingestion.persister import match_media_by_word_overlap
+from beever_atlas.agents.ingestion.persister import (
+    match_media_by_word_overlap,
+    native_message_id,
+)
 
 
 def _msg(author: str, text: str, **extra) -> dict:
     return {"author_id": author, "text": text, **extra}
+
+
+def test_native_message_id_prefers_explicit_then_message_id():
+    # Explicit native_message_id wins.
+    assert native_message_id({"native_message_id": "1779390885.369099", "message_id": "x"}) == (
+        "1779390885.369099"
+    )
+    # Falls back to raw message_id (the numeric Slack ts from the bridge).
+    assert native_message_id({"message_id": "1712500000.001100"}) == "1712500000.001100"
+    # Neither present → empty (citation stays unlinked, never a broken id).
+    assert native_message_id({"msg_id": "msg-2"}) == ""
+    assert native_message_id({}) == ""
 
 
 def test_single_common_word_does_not_attribute_media():


### PR DESCRIPTION
## Summary
The **final blocker** for clickable Slack citation permalinks (started in #239/#240). Even with `workspace_domain` flowing correctly, `[N]` resolved to no link because the **numeric Slack ts** needed for an archive URL was dropped during ingestion.

## ✅ Verified working live
```
message_id (native): 1779390798.972589
workspace_domain    : beeveratlas
PERMALINK           : https://beeveratlas.slack.com/archives/C0B5YCR1NL8/p1779390798972589
```
A real, clickable Slack archive URL — proven end-to-end on a fresh `#basketball` re-extraction.

## Root cause
A Slack archive URL needs the numeric ts (`1779390798.972589` → `p1779390798972589`). The pipeline dropped it:
- the bridge converts ts → ISO for the `timestamp` field (keeps the numeric ts only in `message_id`);
- the preprocessor replaces the native id with a synthetic `msg-N` reference for the LLM.

Result: facts had `message_ts` = ISO and `source_message_id` = `"msg-N"` — neither usable by the resolver (`_slack_ts_path` requires `^\d+(\.\d+)?$`). The real ts survives on `ChannelMessage.message_id`.

## Fix
- **preprocessor**: stamp `native_message_id` (the numeric Slack ts) on each enriched message, alongside the synthetic `msg_id` the LLM references.
- **persister**: override `fact.source_message_id` with the matched source message's native id (via a new pure `native_message_id()` helper) — covers all three source-match paths.
- **resolver**: for Slack, fall back from the ISO `message_ts` to the numeric native message id when building the `p<ts>` path.

`source_message_id` now holds the platform-native id (Slack ts), which is strictly better than the batch-scoped `msg-N` — it also fixes the MCP `read_provenance` raw-message lookup and provenance grouping, both previously broken by `msg-N`.

## Operational note (re-extraction)
`batch_upsert_facts` uses Weaviate `add_object` (insert semantics), so **re-extracting *existing* facts does not update them** — their UUIDs already exist. New syncs get the ts automatically; to backfill an already-synced channel, clear derived data (`DELETE /api/channels/{id}/data`) then re-sync. (A true batch-replace upsert is a reasonable separate follow-up.)

## Test & verify
- `uv run pytest tests/agents/citations/ tests/test_persister_heuristic.py -q` → green (+ new: resolver ISO-ts→native-id, ISO-ts→None-no-broken-url, `native_message_id()` preference chain).
- Reviewed (code-reviewer): APPROVE, 0 critical/high; 1 cosmetic/self-healing MEDIUM. Confirmed `deterministic_id` doesn't use `source_message_id` (no dedup collision) and all consumers benefit.
- Live: clear + re-sync `#basketball` → citation resolves the archives URL above.

## Constraints / decisions
- A missing/non-numeric ts still yields `None` (no broken URL).
- Rejected storing the numeric ts in `message_ts` (breaks ISO display/freshness) and converting ISO→ts in the resolver (lossy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
