### PR TITLE
feat: make @mention bot replies perfect — fix 10 live-review defects + market-learned polish

### DIFF
--- a/bot/src/integration.test.ts
+++ b/bot/src/integration.test.ts
@@ -79,7 +79,8 @@ describe("integration: SSE stream → rendered reply", () => {
     assert.ok(out.includes("🕐 _last activity 2h ago_"));
     assert.ok(out.includes("_You might also ask:_"));
     assert.ok(out.includes("- How do I switch to MinIO?"));
-    assert.ok(out.includes("_via qa_agent_"));
+    // Internal route footer is suppressed (no "via qa_agent" leaked to users).
+    assert.ok(!out.includes("via qa_agent"));
     // High confidence → NO warning.
     assert.ok(!out.includes("low confidence"));
   });

--- a/bot/src/renderer.test.ts
+++ b/bot/src/renderer.test.ts
@@ -25,13 +25,14 @@ function result(overrides: Partial<AskResult> = {}): AskResult {
 }
 
 describe("renderResponse", () => {
-  it("renders the answer and a route footer", () => {
+  it("renders the answer; the internal route footer is suppressed", () => {
     const out = renderResponse(result(), "slack");
     assert.ok(out.includes("The booth is H25."));
-    assert.ok(out.includes("via qa_agent"));
+    // "via qa_agent" is internal dev chrome — never shown to users.
+    assert.ok(!out.includes("via qa_agent"));
   });
 
-  it("renders concise citation lines with kind icons, provenance, and clickable links", () => {
+  it("renders NAMED citation cards: titles for wiki/decision, author·#channel for messages", () => {
     const out = renderResponse(
       result({
         citations: [
@@ -43,17 +44,43 @@ describe("renderResponse", () => {
       "slack",
     );
     assert.ok(out.includes("## 📎 Sources"));
-    // Concise: the numbered marker itself is the clickable link — `[N](url)` —
-    // NOT the verbose fact text, and NOT a bare <url> autolink or [open] segment.
-    assert.ok(out.includes("- 📖 [1](https://wiki/x)"));
+    // wiki_page: the marker links, and the PAGE TITLE is the human label.
+    assert.ok(out.includes("- 📖 [1](https://wiki/x) AI+ Power 2026"));
     assert.ok(!out.includes("[open]"), "marker is the link; no separate [open] segment");
-    assert.ok(!out.includes("AI+ Power 2026"), "fact text should be dropped");
     assert.ok(!out.includes("<https://wiki/x>"), "links should be [N](url), not bare angle autolinks");
-    // No url → plain marker.
+    // channel_message: author · #channel, but NOT the message text (the inline [N] refs it).
     assert.ok(out.includes("- 💬 [2] Jack · #general"));
-    assert.ok(!out.includes("booth confirmed"), "fact text should be dropped");
-    // decision_record routes to the Related block; bare line, original index.
-    assert.ok(out.includes("- ⚖️ [3]"));
+    assert.ok(!out.includes("booth confirmed"), "message text is dropped; the inline marker references it");
+    // decision_record (Related block): short title shown as the label.
+    assert.ok(out.includes("- ⚖️ [3] staffing decided"));
+  });
+
+  it("omits a raw platform user-id as the author, shows a real name", () => {
+    const idAuthor = renderResponse(
+      result({ citations: [{ type: "channel_message", text: "x", author: "U0B55TPHLHF", source: "basketball" }] }),
+      "slack",
+    );
+    assert.ok(!idAuthor.includes("U0B55TPHLHF"), "raw user id must not be shown");
+    assert.ok(idAuthor.includes("#basketball"), "channel name still shown, with leading #");
+    const named = renderResponse(
+      result({ citations: [{ type: "channel_message", text: "x", author: "Carmen Lee", source: "#basketball" }] }),
+      "slack",
+    );
+    assert.ok(named.includes("Carmen Lee · #basketball"));
+    // An all-caps handle WITHOUT a digit is a real name, not an id — keep it.
+    const caps = renderResponse(
+      result({ citations: [{ type: "channel_message", text: "x", author: "TEAMWORK", source: "#g" }] }),
+      "slack",
+    );
+    assert.ok(caps.includes("TEAMWORK · #g"), "all-caps name without a digit is not a raw id");
+  });
+
+  it("labels a web source by its domain", () => {
+    const out = renderResponse(
+      result({ citations: [{ type: "web_result", text: "Some Long Article Title", url: "https://www.espn.com/nba/x" }] }),
+      "slack",
+    );
+    assert.ok(out.includes("- 🌐 [1](https://www.espn.com/nba/x) espn.com"), "domain (no www) is the label");
   });
 
   it("caps citations at 5 and notes the overflow", () => {
@@ -64,10 +91,35 @@ describe("renderResponse", () => {
     assert.ok(out.includes("+3 more"));
   });
 
-  it("shows an honest 'last activity' freshness line only when lastSyncTs is present", () => {
+  it("shows 'last activity' freshness only for channel-sourced answers", () => {
     const iso = new Date(Date.now() - 2 * 3600_000).toISOString();
-    assert.ok(renderResponse(result({ lastSyncTs: iso }), "slack").includes("last activity "));
-    assert.ok(!renderResponse(result(), "slack").includes("last activity "));
+    const channelCite = [{ type: "channel_message", text: "x", source: "#g" }];
+    // Channel-sourced + lastSyncTs → freshness shown.
+    assert.ok(
+      renderResponse(result({ lastSyncTs: iso, citations: channelCite }), "slack").includes("last activity "),
+    );
+    // Web/wiki-only answer → no channel-freshness line (provenance mismatch fix).
+    assert.ok(
+      !renderResponse(
+        result({ lastSyncTs: iso, citations: [{ type: "web_result", text: "t", url: "https://x.com" }] }),
+        "slack",
+      ).includes("last activity "),
+    );
+    // No lastSyncTs → nothing regardless.
+    assert.ok(!renderResponse(result({ citations: channelCite }), "slack").includes("last activity "));
+    // Mixed channel + web → freshness still shown (a channel source is present).
+    assert.ok(
+      renderResponse(
+        result({
+          lastSyncTs: iso,
+          citations: [
+            { type: "channel_message", text: "x", source: "#g" },
+            { type: "web_result", text: "t", url: "https://x.com" },
+          ],
+        }),
+        "slack",
+      ).includes("last activity "),
+    );
   });
 
   it("truncates over-long Discord replies with a marker", () => {
@@ -206,6 +258,49 @@ describe("related-context grouping", () => {
   });
 });
 
+describe("no-sources chrome gating (greeting / general-knowledge)", () => {
+  it("a zero-citation reply renders ONLY the answer + follow-ups — no trust chrome", () => {
+    const out = renderResponse(
+      result({
+        answer: "Hi! I'm Beever Atlas. Ask me what your team has discussed.",
+        citations: [],
+        confidence: 0.4, // low-ish, but there are NO sources to verify
+        lastSyncTs: new Date(Date.now() - 3 * 3600_000).toISOString(),
+        followUps: ["What did we decide about the roadmap?"],
+      }),
+      "slack",
+    );
+    assert.ok(out.includes("Hi! I'm Beever Atlas"));
+    assert.ok(out.includes("You might also ask:"));
+    // None of the citation/trust chrome leaks onto a sourceless reply.
+    assert.ok(!out.includes("verify against the sources"));
+    assert.ok(!out.includes("limited sources"));
+    assert.ok(!out.includes("## 📎 Sources"));
+    assert.ok(!out.includes("## 🧠 Related"));
+    assert.ok(!out.includes("last activity"));
+    assert.ok(!out.includes("via "));
+  });
+});
+
+describe("source count heading", () => {
+  it("appends '· N' to the Sources heading only when the list overflows", () => {
+    const many = Array.from({ length: 8 }, (_, i) => ({ type: "channel_message", text: `c${i}`, source: "#g" }));
+    const over = renderResponse(result({ citations: many }), "teams");
+    assert.ok(over.includes("## 📎 Sources · 8"));
+    const few = renderResponse(
+      result({ citations: [{ type: "channel_message", text: "c", source: "#g" }] }),
+      "slack",
+    );
+    assert.ok(few.includes("## 📎 Sources\n"));
+    assert.ok(!few.includes("Sources · "));
+    // Boundary: exactly MAX_CITATIONS (5) → no overflow, plain heading.
+    const five = Array.from({ length: 5 }, (_, i) => ({ type: "channel_message", text: `c${i}`, source: "#g" }));
+    const atCap = renderResponse(result({ citations: five }), "slack");
+    assert.ok(atCap.includes("## 📎 Sources\n"));
+    assert.ok(!atCap.includes("Sources · "), "exactly 5 must not append '· 5'");
+  });
+});
+
 describe("renderConfidence", () => {
   it("warns on a low score and softly nudges on a medium score", () => {
     assert.ok(renderConfidence(0.2, false).includes("low confidence"));
@@ -222,9 +317,14 @@ describe("renderConfidence", () => {
     assert.strictEqual(renderConfidence(0, false), "");
     assert.strictEqual(renderConfidence(0.1, true), "");
   });
-  it("appears in a full reply only when low", () => {
-    assert.ok(renderResponse(result({ confidence: 0.2 }), "slack").includes("low confidence"));
-    assert.ok(!renderResponse(result({ confidence: 0.9 }), "slack").includes("low confidence"));
+  it("appears in a full reply only when low AND there are sources", () => {
+    const cite = [{ type: "channel_message", text: "x", source: "#g" }];
+    assert.ok(renderResponse(result({ confidence: 0.2, citations: cite }), "slack").includes("low confidence"));
+    // Mid band with sources → the softer "limited sources" nudge appears end-to-end.
+    assert.ok(renderResponse(result({ confidence: 0.5, citations: cite }), "slack").includes("limited sources"));
+    assert.ok(!renderResponse(result({ confidence: 0.9, citations: cite }), "slack").includes("low confidence"));
+    // No sources → no confidence caveat at all (a greeting must not say "verify against the sources").
+    assert.ok(!renderResponse(result({ confidence: 0.2, citations: [] }), "slack").includes("low confidence"));
   });
 });
 

--- a/bot/src/renderer.ts
+++ b/bot/src/renderer.ts
@@ -108,29 +108,69 @@ function cleanUrl(u: string): string {
 
 /** Citation kinds that read as "related context" (graph) rather than direct sources. */
 const RELATED_KINDS = new Set(["decision_record", "graph_relationship"]);
+/** Kinds whose "source" is a person+channel rather than a titled document. */
+const MESSAGE_KINDS = new Set(["channel_message", "qa_history"]);
 
 /**
- * One concise citation line as a canonical markdown list item:
- *   `- {icon} [N](url) {author} · {#channel} · {age}`
- *
- * The numbered marker `[N]` is itself the clickable link to the source when a
- * permalink is present (`[N](url)`) — matching the inline `[N]` markers in the
- * answer — so there's no separate "open" segment. When there's no url it renders
- * as plain `[N]`. The full fact text is intentionally dropped (the inline marker
- * already references it; repeating it buried the answer). A relative age is
- * appended when the source carries a timestamp, as a recency/trust signal.
- * Segments are omitted when absent, so a bare citation still renders `- {icon} [N]`.
+ * A bare platform-native id (e.g. Slack "U0B55TPHLHF") that leaked through when a
+ * display name couldn't be resolved. It carries no trust to a reader, so we omit
+ * it rather than print it. Requires a U/W/C/D/G/T prefix, 8+ chars, AND at least
+ * one digit — real platform ids always contain digits, so an all-caps display
+ * name/handle like "TEAMWORK" or "CATHERINE" is never mistaken for an id.
+ */
+const RAW_ID_RE = /^[UWCDGT][A-Z0-9]*[0-9][A-Z0-9]{6,}$/;
+function isRawPlatformId(s: string): boolean {
+  return RAW_ID_RE.test(s.trim());
+}
+
+/** Registrable domain (no leading www.) of an http(s) url, or "" if unparseable. */
+function domainOf(url: string): string {
+  try {
+    return new URL(url).hostname.replace(/^www\./i, "");
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * One concise, NAMED citation line as a canonical markdown list item. The numbered
+ * marker `[N]` is itself the clickable link when a permalink is present
+ * (`[N](url)`) — matching the inline `[N]` markers in the answer. After the marker
+ * comes a human-readable label tuned per kind so a source reads at a glance
+ * (Perplexity/Glean style) instead of a bare `[N]`:
+ *   - channel_message → `{author} · {#channel} · {age}`
+ *   - web_result      → `{domain} · {age}`
+ *   - wiki_page       → `{page title} · {age}`
+ *   - decision/graph  → `{short title} · {author?} · {age}`
+ * A raw platform user-id is never shown as an author; segments are omitted when
+ * absent, so a bare citation still renders `- {icon} [N]`.
  */
 function renderCitationLine(c: Citation, num: number): string {
   const url = c.url ? cleanUrl(c.url) : "";
   const marker = url ? `[${num}](${url})` : `[${num}]`;
+  const author = c.author && !isRawPlatformId(c.author) ? cleanField(c.author, 80) : "";
+  const title = c.text ? cleanField(c.text, 80) : "";
+  const age = c.timestamp ? (relativeTime(c.timestamp) ?? "") : "";
+
   const segments: string[] = [];
-  if (c.author) segments.push(cleanField(c.author, 80));
-  if (c.source) segments.push(cleanField(c.source, 80));
-  if (c.timestamp) {
-    const age = relativeTime(c.timestamp);
-    if (age) segments.push(age);
+  if (MESSAGE_KINDS.has(c.type)) {
+    // Who said it, where — the message text itself is referenced by the inline [N].
+    if (author) segments.push(author);
+    if (c.source) {
+      const src = cleanField(c.source, 80);
+      segments.push(src.startsWith("#") ? src : `#${src}`); // idempotent hash
+    }
+  } else if (c.type === "web_result") {
+    segments.push(domainOf(url) || title); // domain preferred, fall back to title
+  } else if (c.type === "wiki_page") {
+    if (title) segments.push(title);
+  } else {
+    // decision_record / graph_relationship / media / uploaded_file
+    if (title) segments.push(title);
+    if (author) segments.push(author);
   }
+  if (age) segments.push(age);
+
   const tail = segments.filter((s) => s.length > 0).join(" · ");
   const head = `- ${iconFor(c.type)} ${marker}`;
   return tail ? `${head} ${tail}` : head;
@@ -147,7 +187,10 @@ function renderCitationBlock(heading: string, entries: Array<{ c: Citation; num:
   const lines = shown.map(({ c, num }) => renderCitationLine(c, num)).join("\n");
   const overflow = entries.length - shown.length;
   const more = overflow > 0 ? `\n_+${overflow} more_` : "";
-  return `\n\n${heading}\n${lines}${more}`;
+  // Surface the total count in the heading when the list overflows, so the reader
+  // knows how many sources back the answer (e.g. "## 📎 Sources · 9").
+  const head = entries.length > MAX_CITATIONS ? `${heading} · ${entries.length}` : heading;
+  return `\n\n${head}\n${lines}${more}`;
 }
 
 /** Backward-compatible: render all citations as a single Sources block. */
@@ -229,7 +272,14 @@ function renderFreshness(lastSyncTs?: string): string {
   return rel ? `\n🕐 _last activity ${rel}_` : "";
 }
 
+/**
+ * Internal agent/route names that must never be shown to end users — "via
+ * qa_agent" is developer chrome, not information. The footer only renders for a
+ * genuinely user-facing route name (none today), so it effectively disappears.
+ */
+const INTERNAL_ROUTES = new Set(["qa_agent", "deep", "quick", "summarize", "memory_agent", "router", "echo"]);
 function renderRoute(route: string): string {
+  if (!route || INTERNAL_ROUTES.has(route)) return "";
   return `\n_via ${cleanField(route, 40)}_`;
 }
 
@@ -270,18 +320,28 @@ export function renderResponse(result: AskResult, platform: string): string {
   const plat = (platform || "unknown").toLowerCase();
   if (result.isEmpty) return renderEmptyState(result, plat);
 
-  const { sources, related } = partitionCitations(result.citations || []);
+  const citations = result.citations || [];
+  const { sources, related } = partitionCitations(citations);
+  // "No sources → no citation UI" (Glean rule): a greeting or general-knowledge
+  // reply with zero citations must NOT show a confidence caveat ("verify against
+  // the sources" with no sources), a Related block, or the route footer. It
+  // renders as just the answer + follow-ups.
+  const hasSources = sources.length + related.length > 0;
+  // Channel freshness ("last activity Nd ago") only makes sense when the answer
+  // actually rests on channel messages — not for web/wiki-only answers.
+  const hasChannelSource = citations.some((c) => MESSAGE_KINDS.has(c.type));
+
   const body =
     (result.answer || "").trimEnd() +
     // A low-confidence warning sits right under the answer so truncation can
-    // never drop this trust signal.
-    renderConfidence(result.confidence, result.isEmpty) +
+    // never drop this trust signal — but only when there ARE sources to verify.
+    (hasSources ? renderConfidence(result.confidence, result.isEmpty) : "") +
     renderCitationBlock("## 📎 Sources", sources) +
     renderCitationBlock("## 🧠 Related", related) +
     renderTensions(result.tensions) +
-    renderFreshness(result.lastSyncTs) +
+    (hasChannelSource ? renderFreshness(result.lastSyncTs) : "") +
     renderFollowUps(result.followUps) +
-    renderRoute(result.route || "qa_agent");
+    (hasSources ? renderRoute(result.route || "") : "");
 
   return enforceCap(body, capFor(plat));
 }

--- a/bot/src/sse-client.test.ts
+++ b/bot/src/sse-client.test.ts
@@ -8,7 +8,43 @@ import {
   detectEmptyRetrieval,
   resolveIsEmpty,
   normalizeTensions,
+  dedupDoubledAnswer,
 } from "./sse-client.js";
+
+describe("dedupDoubledAnswer", () => {
+  const A =
+    "In the #basketball channel, SGA refers to Shai Gilgeous-Alexander, a top-3 player known for durability";
+  it("collapses an exactly-doubled answer (same citation markers)", () => {
+    const a = A + " [1]. He strengthens Team Canada [2].";
+    assert.strictEqual(dedupDoubledAnswer(a + a), a);
+  });
+  it("collapses a citation-RENUMBERED doubled answer ([1][2] → [3][4])", () => {
+    const c1 = A + " [1]. He strengthens Team Canada [2].";
+    const c2 = A + " [3]. He strengthens Team Canada [4].";
+    assert.strictEqual(dedupDoubledAnswer(c1 + c2), c1);
+  });
+  it("leaves a single (non-doubled) answer untouched", () => {
+    assert.strictEqual(dedupDoubledAnswer(A), A);
+  });
+  it("leaves a short answer untouched", () => {
+    assert.strictEqual(dedupDoubledAnswer("hi there"), "hi there");
+  });
+  it("leaves a legitimately repetitive-phrase answer untouched", () => {
+    const legit = "The Celtics beat the Mavericks 4-1 [1]. The Celtics are champions [1]. More context here.";
+    assert.strictEqual(dedupDoubledAnswer(legit), legit);
+  });
+  it("dedups the answer end-to-end through consumeSSEStream", async () => {
+    const a = A + " [1]. He strengthens Team Canada [2].";
+    // The backend streamed the full answer twice (the session-replay bug).
+    const body =
+      `event: response_delta\ndata: ${JSON.stringify({ delta: a })}\n\n` +
+      `event: response_delta\ndata: ${JSON.stringify({ delta: a })}\n\n` +
+      `event: metadata\ndata: {"route":"qa_agent","confidence":0.9}\n\n` +
+      "event: done\ndata: {}\n\n";
+    const result = await consumeSSEStream(mockResponse(body));
+    assert.strictEqual(result.answer, a, "the rendered answer must not be doubled");
+  });
+});
 
 function mockResponse(body: string): Response {
   return new Response(body, {

--- a/bot/src/sse-client.ts
+++ b/bot/src/sse-client.ts
@@ -163,14 +163,57 @@ export function resolveIsEmpty(
   return backendEmpty === true;
 }
 
+/** Inline citation markers, normalized before comparing two copies of an answer. */
+const CITE_MARKER_RE = /\[\d+\]|\[src:[^\]]+\]/y;
+
+/**
+ * Collapse an answer the backend streamed TWICE. A session-history replay makes
+ * the model echo the prior identical assistant turn before the new one, so the
+ * accumulated `response_delta` text is the full answer doubled (the backend's
+ * own finalization net fixes only its persisted copy, not the streamed events).
+ * Citation markers are normalized before comparison because the rewriter can
+ * renumber the second copy ([1][2] → [3][4]). Conservative: only collapses a
+ * clean ≥80-char doubling, so a legitimate answer is never corrupted.
+ */
+export function dedupDoubledAnswer(text: string): string {
+  const n = text.length;
+  if (n < 80) return text;
+  // Fast path: exact byte doubling.
+  if (n % 2 === 0 && text.slice(0, n / 2) === text.slice(n / 2)) return text.slice(0, n / 2);
+  // Renumbering-aware: compare with citation markers collapsed.
+  const norm = text.replace(/\[\d+\]|\[src:[^\]]+\]/g, "[#]");
+  const m = norm.length;
+  if (m >= 80 && m % 2 === 0 && norm.slice(0, m / 2) === norm.slice(m / 2)) {
+    // Walk the ORIGINAL, tracking normalized length, to find where the first
+    // copy ends (normalized index m/2), and keep that prefix.
+    const target = m / 2;
+    let normLen = 0;
+    let i = 0;
+    while (i < n && normLen < target) {
+      CITE_MARKER_RE.lastIndex = i;
+      const mt = CITE_MARKER_RE.exec(text);
+      if (mt && mt.index === i) {
+        normLen += 3; // len("[#]")
+        i = CITE_MARKER_RE.lastIndex;
+      } else {
+        normLen += 1;
+        i += 1;
+      }
+    }
+    return text.slice(0, i);
+  }
+  return text;
+}
+
 function finalizeResult(state: StreamState): AskResult {
+  const answer = dedupDoubledAnswer(state.answer);
   return {
-    answer: state.answer,
+    answer,
     citations: state.citations,
     route: state.route,
     confidence: state.confidence,
     costUsd: state.costUsd,
-    isEmpty: resolveIsEmpty(state.answer, state.citations, state.backendEmpty),
+    isEmpty: resolveIsEmpty(answer, state.citations, state.backendEmpty),
     lastSyncTs: state.lastSyncTs,
     followUps: state.followUps,
     tensions: state.tensions,

--- a/src/beever_atlas/agents/query/follow_ups_tool.py
+++ b/src/beever_atlas/agents/query/follow_ups_tool.py
@@ -79,6 +79,17 @@ _BULLET_PREFIX_RE = re.compile(r"^[-*\d.\s]+")
 # circular import with the citation registry module; kept in lock-step.
 _SRC_LITERAL_RE = re.compile(r"\[\s*(?:src:[^\[\]]*?|External:[^\[\]]*?)\]", re.IGNORECASE)
 
+# Drop templated/placeholder suggestions the LLM may emit when it ignores the
+# "use concrete examples" prompt instruction. The reliable, low-false-positive
+# signal is a bare uppercase X/Y/Z that ENDS the question (optionally before
+# ?/./!) — the unmistakable "What did we decide about X?" / "Who knows about Y?"
+# template shape. Anchoring to the trailing position deliberately KEEPS
+# legitimate named concepts where a capital X/Y/Z sits mid-sentence ("Y
+# Combinator", "Series X launch", "the Z-score model"). This filter is a safety
+# net; the prompt reword is the primary defense, so under-matching a rare
+# "...Series X?" is preferable to dropping real suggestions.
+_PLACEHOLDER_RE = re.compile(r"(?<![A-Za-z-])[XYZ](?=[?.!]?\s*$)")
+
 
 def _clean(questions: list[str]) -> list[str]:
     if not isinstance(questions, list):
@@ -94,6 +105,12 @@ def _clean(questions: list[str]) -> list[str]:
         # Collapse runs of whitespace left behind by the scrub.
         stripped = re.sub(r"\s{2,}", " ", stripped)
         if len(stripped) < _MIN_QUESTION_LEN:
+            continue
+        # Drop templated placeholder chips (e.g. "...about X?", "...about Y?")
+        # so a non-grounded suggestion never reaches the renderer even when the
+        # model ignores the "use concrete examples" prompt instruction.
+        if _PLACEHOLDER_RE.search(stripped):
+            logger.warning("follow_ups: dropped placeholder suggestion %r", stripped)
             continue
         out.append(stripped)
         if len(out) >= _MAX_QUESTIONS:

--- a/src/beever_atlas/agents/query/prompts.py
+++ b/src/beever_atlas/agents/query/prompts.py
@@ -4,21 +4,30 @@ All prompt strings are centralized here to separate prompt engineering
 from ADK agent wiring logic. Agent files import from this module.
 """
 
+from datetime import datetime, timezone
+
 IDENTITY_PREAMBLE = """\
 You are Beever Atlas, an AI knowledge assistant for team knowledge management. \
-Do not disclose your underlying model, provider, or that you are powered by any specific AI company. \
-When asked who you are, identify yourself as Beever Atlas."""
+Hard constraints: always identify yourself as Beever Atlas, and NEVER disclose your \
+underlying model, provider, or that you are powered by any specific AI company. \
+Within those constraints, speak naturally — when asked who you are or what you do, \
+describe what you can do for THIS channel in your own words, varying your phrasing. \
+Do not recite a fixed marketing sentence."""
 
 GREETING_RESPONSE = """\
 ## Greetings & small-talk
 If the user's message is purely a greeting or small-talk ("hi", "hello", "hey", \
 "how are you", "who are you", "what can you do", "thanks"), do NOT call any tools. \
-Reply in 1-2 warm sentences that:
-- name yourself as "Beever Atlas",
-- state ONE concrete capability (e.g. "I can answer questions about what your team \
-  has discussed and decided in this channel, with sources"),
-- nudge the user with 2-3 short example questions they could ask \
-  (e.g. "What did we decide about X?", "Who knows about Y?", "What's new this week?").
+Reply in 1-2 warm, natural sentences (vary your wording — do not reuse a canned line) that:
+- identify you as "Beever Atlas",
+- state ONE concrete capability in your own words (e.g. that you can answer questions \
+  about what the team has discussed and decided in this channel, with sources),
+- nudge the user with 2-3 CONCRETE example questions grounded in what this channel is \
+  likely about (infer plausible topics from the channel name or any context you have). \
+  The examples must be real, askable questions — NEVER emit literal placeholders such \
+  as "about X", "topic Y", or a bare X/Y/Z token. If you genuinely have no channel \
+  context, give generic-but-concrete examples like "What did we decide most recently?", \
+  "Who has been most active here?", or "What's new this week?".
 Never expose a raw channel id in a greeting. Keep it brief and friendly — no headings, \
 no citations, no tool calls."""
 
@@ -410,9 +419,18 @@ def build_qa_system_prompt(
 
     citation_block = CITATION_FORMAT_REGISTRY if registry_on else CITATION_FORMAT
 
+    # Dated line computed at call time (NOT module import) so a long-lived
+    # process always anchors relative terms to the real current date.
+    date_line = (
+        f"Today's date is {datetime.now(timezone.utc):%A, %Y-%m-%d}. "
+        "Interpret 'today', 'this week', 'recently', and 'latest' relative to this date."
+    )
+
     if new_prompt:
         parts = [
             IDENTITY_PREAMBLE,
+            "",
+            date_line,
             "",
             GREETING_RESPONSE,
             "",
@@ -458,9 +476,12 @@ def build_qa_system_prompt(
                 parts.extend(["", EMPTY_RETRIEVAL_FOLLOW_UP_CHIPS])
         return "\n".join(parts)
 
-    # Legacy path — flag off: byte-identical to pre-redesign output
+    # Legacy path — flag off. Date line is the only addition (placed right
+    # after the identity preamble) so relative-time terms stay anchored.
     parts = [
         IDENTITY_PREAMBLE,
+        "",
+        date_line,
         "",
         RETRIEVAL_PIPELINE,
         "",

--- a/src/beever_atlas/api/ask.py
+++ b/src/beever_atlas/api/ask.py
@@ -118,6 +118,64 @@ def _sse_event(event_type: str, data: dict) -> str:
     return f"event: {event_type}\ndata: {json.dumps(data)}\n\n"
 
 
+# Inline citation markers, normalized away before comparing two copies of an
+# answer — the stateful citation rewriter renumbers the second copy ([1][2] →
+# [3][4]) and rewrites [src:xxx] tags, so a byte-identity check would miss a
+# real doubling.
+_CITE_MARKER_RE = re.compile(r"\[\d+\]|\[src:[^\]]+\]")
+
+
+def _dedup_exact_double(text: str, session_id: str) -> str:
+    """Conservative finalization safety net for verbatim-doubled answers.
+
+    Some streaming paths deliver the full answer twice (a final aggregate that
+    repeats the partial stream, or two ADK events). Collapse only when the text
+    is a clean doubling — first half equal to second. Citation markers are
+    normalized before comparison so a second copy whose ``[N]``/``[src:xxx]``
+    tags were renumbered still matches. Requires ≥80 chars; legitimate answers
+    are never self-repeats at this length, so this net cannot corrupt a real
+    answer.
+    """
+    n = len(text)
+    if n < 80:
+        return text
+    # Fast path: exact byte doubling (no markers, or identical ones).
+    if n % 2 == 0 and text[: n // 2] == text[n // 2 :]:
+        logger.warning(
+            "dedup: halved exact-duplicate answer (len=%d, session=%s)",
+            n,
+            session_id,
+        )
+        return text[: n // 2]
+    # Renumbering-aware path: compare with citation markers collapsed so a copy
+    # whose [N] tags were renumbered still matches.
+    norm = _CITE_MARKER_RE.sub("[#]", text)
+    m = len(norm)
+    if m >= 80 and m % 2 == 0 and norm[: m // 2] == norm[m // 2 :]:
+        # The normalized halves match → the original is firstCopy + renumbered
+        # secondCopy. Walk the ORIGINAL, tracking normalized length, to find
+        # where the first copy ends (normalized index m // 2), and keep that
+        # prefix (with its original — correctly numbered — markers).
+        target = m // 2
+        norm_len = 0
+        i = 0
+        while i < n and norm_len < target:
+            mt = _CITE_MARKER_RE.match(text, i)
+            if mt:
+                norm_len += 3  # len("[#]")
+                i = mt.end()
+            else:
+                norm_len += 1
+                i += 1
+        logger.warning(
+            "dedup: halved citation-renumbered duplicate answer (len=%d, session=%s)",
+            n,
+            session_id,
+        )
+        return text[:i]
+    return text
+
+
 class _HeartbeatSentinel:
     """Yielded by ``_stream_with_heartbeats`` whenever the underlying
     agent stream has been silent for the heartbeat interval. The QA
@@ -789,6 +847,14 @@ async def _run_agent_stream(
             _skip_text_emit = sse_streaming and not _event_is_partial
 
             if event.content and event.content.parts:
+                # Event-scoped dedup guard: a single NON-partial (aggregate)
+                # event must not emit two verbatim-equivalent text parts. The
+                # cross-event _last_emitted_chunk guard misses this because the
+                # stateful StreamRewriter renumbers citations, so the 2nd copy
+                # is no longer byte-identical to the 1st. This flag is reset per
+                # event and never throttles the legitimate multi-chunk partial
+                # streaming path (partial events are exempt below).
+                _emitted_text_this_event = False
                 for part in event.content.parts:
                     part_is_thought = getattr(part, "thought", False)
                     if part_is_thought:
@@ -801,6 +867,20 @@ async def _run_agent_stream(
                             if not _skip_text_emit:
                                 yield _sse_event("thinking", {"text": part.text})
                     elif part.text:
+                        # Event-scoped dedup: on a NON-partial aggregate event,
+                        # only the first text part is the answer; any further
+                        # text part in the SAME event is a verbatim repeat
+                        # (citation-renumbered, so byte-compare guards miss it).
+                        # Partial events are exempt — multiple token chunks per
+                        # turn are legitimate there.
+                        if not _event_is_partial and _emitted_text_this_event:
+                            logger.warning(
+                                "dedup: suppressed extra text part in same event "
+                                "(len=%d, session=%s)",
+                                len(part.text),
+                                session_id,
+                            )
+                            continue
                         # Belt-and-suspenders: if thought flag somehow leaks here, drop it.
                         if getattr(part, "thought", False):
                             logger.warning(
@@ -849,6 +929,7 @@ async def _run_agent_stream(
                                     yield _sse_event("response_delta", {"delta": rewritten})
                                     accumulated_text += rewritten
                                     _last_emitted_chunk = rewritten
+                                    _emitted_text_this_event = True
                         else:
                             if part.text == _last_emitted_chunk or (
                                 len(part.text) >= 40 and accumulated_text.endswith(part.text)
@@ -862,6 +943,7 @@ async def _run_agent_stream(
                                 yield _sse_event("response_delta", {"delta": part.text})
                                 accumulated_text += part.text
                                 _last_emitted_chunk = part.text
+                                _emitted_text_this_event = True
 
             # Turn complete
             if event.turn_complete:
@@ -871,6 +953,11 @@ async def _run_agent_stream(
                     if tail:
                         yield _sse_event("response_delta", {"delta": tail})
                         accumulated_text += tail
+
+                # Finalization safety net: collapse a verbatim-doubled answer
+                # before citations/persistence. Conservative (exact halves
+                # ≥80 chars only). Runs on the answer body before gallery append.
+                accumulated_text = _dedup_exact_double(accumulated_text, session_id)
 
                 # Safety net: if retrieval found media but the LLM skipped the
                 # `## Media` section, build and append one from the registry.
@@ -1042,6 +1129,9 @@ async def _run_agent_stream(
                 if _tail:
                     yield _sse_event("response_delta", {"delta": _tail})
                     accumulated_text += _tail
+                # Finalization safety net (mirror of the turn_complete path):
+                # collapse a verbatim-doubled answer before gallery/citations.
+                accumulated_text = _dedup_exact_double(accumulated_text, session_id)
                 from beever_atlas.agents.query.gallery_fallback import (
                     maybe_build_gallery,
                 )
@@ -1051,6 +1141,10 @@ async def _run_agent_stream(
                     yield _sse_event("response_delta", {"delta": _gallery2})
                     accumulated_text += _gallery2
             if accumulated_text.strip():
+                # Finalization safety net for the registry-off sub-path (the
+                # registry-on body was already deduped above; re-running on a
+                # single copy is a no-op).
+                accumulated_text = _dedup_exact_double(accumulated_text, session_id)
                 # Flush rewriter + emit envelope when registry is active.
                 if _rewriter is not None and _registry is not None:
                     tail = _rewriter.flush()

--- a/tests/agents/test_follow_ups.py
+++ b/tests/agents/test_follow_ups.py
@@ -2,6 +2,7 @@
 
 from beever_atlas.agents.query.follow_ups_tool import (
     FollowUpsCollector,
+    _clean,
     _current_collector,
     suggest_follow_ups,
 )
@@ -30,13 +31,25 @@ def test_bullets_stripped():
 def test_returns_three_strings():
     results = []
 
+    # Use concrete questions (no X/Y/Z placeholders) so they survive the
+    # placeholder filter — this test asserts plain-string passthrough.
     def run(collector):
-        suggest_follow_ups(["What is X?", "Who owns Y?", "When did Z happen?"])
+        suggest_follow_ups(
+            [
+                "What did the team decide about authentication?",
+                "Who owns the Slack integration?",
+                "When did the migration ship?",
+            ]
+        )
         results.extend(collector.questions)
 
     _with_collector(run)
     assert len(results) == 3
-    assert results == ["What is X?", "Who owns Y?", "When did Z happen?"]
+    assert results == [
+        "What did the team decide about authentication?",
+        "Who owns the Slack integration?",
+        "When did the migration ship?",
+    ]
 
 
 def test_empty_after_strip_dropped():
@@ -48,3 +61,15 @@ def test_empty_after_strip_dropped():
 
     _with_collector(run)
     assert results == ["valid?"]
+
+
+def test_placeholder_suggestions_dropped():
+    # Templated chips with X/Y placeholders must never reach the renderer.
+    assert _clean(["What did we decide about X?", "Who knows about Y?"]) == []
+
+
+def test_real_question_kept_alongside_placeholder():
+    # A concrete question survives while the placeholder chip is dropped.
+    assert _clean(["What did we decide about X?", "Who owns the deployment pipeline?"]) == [
+        "Who owns the deployment pipeline?"
+    ]

--- a/tests/agents/test_onboarding_length.py
+++ b/tests/agents/test_onboarding_length.py
@@ -89,7 +89,9 @@ async def test_over_cap_logs_warning():
     fake_session.user_id = "u1"
 
     fake_runner = MagicMock()
-    long_text = "A" * 1600
+    # Asymmetric so the duplicate-answer dedup net (exact-equal halves) does not
+    # collapse this synthetic over-cap fixture before the length check runs.
+    long_text = "A" * 1599 + "B"
     event = _make_turn_complete_event(long_text)
     fake_runner.run_async = MagicMock(return_value=_async_events(event))
 

--- a/tests/agents/test_prompt_redesign.py
+++ b/tests/agents/test_prompt_redesign.py
@@ -132,3 +132,45 @@ def test_deep_mode_skips_length_hint_both_paths():
         assert hint_text not in prompt, (
             f"Length hint found in deep-mode prompt (new_prompt={new_prompt})"
         )
+
+
+def test_prompt_contains_todays_date_both_paths():
+    """A dated line (computed at call time) must be injected on both prompt paths."""
+    from datetime import datetime, timezone
+
+    fixed = datetime(2026, 6, 6, 12, 0, 0, tzinfo=timezone.utc)
+
+    class _FixedDatetime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return fixed if tz is None else fixed.astimezone(tz)
+
+    expected = f"{fixed:%A, %Y-%m-%d}"
+    for new_prompt in (False, True):
+        settings = _make_settings(new_prompt=new_prompt)
+        with patch("beever_atlas.infra.config.get_settings", return_value=settings):
+            with patch("beever_atlas.agents.query.prompts.datetime", _FixedDatetime):
+                from beever_atlas.agents.query.prompts import build_qa_system_prompt
+
+                prompt = build_qa_system_prompt(
+                    max_tool_calls=8, include_follow_ups=False, mode="deep"
+                )
+        assert f"Today's date is {expected}" in prompt, (
+            f"Date line missing (new_prompt={new_prompt})"
+        )
+        # Relative-time anchoring clause must accompany the date.
+        assert "relative to this date" in prompt
+
+
+def test_prompt_identifies_as_beever_atlas_no_model_leak_both_paths():
+    """Invariants: identifies as Beever Atlas; never leaks model/provider identity."""
+    for new_prompt in (False, True):
+        settings = _make_settings(new_prompt=new_prompt)
+        with patch("beever_atlas.infra.config.get_settings", return_value=settings):
+            from beever_atlas.agents.query.prompts import build_qa_system_prompt
+
+            prompt = build_qa_system_prompt(max_tool_calls=8, include_follow_ups=False, mode="deep")
+        assert "Beever Atlas" in prompt
+        lowered = prompt.lower()
+        for leak in ("gemini", "google", "openai", "anthropic", "claude"):
+            assert leak not in lowered, f"model/provider leak '{leak}' (new_prompt={new_prompt})"

--- a/tests/test_ask_dedup.py
+++ b/tests/test_ask_dedup.py
@@ -1,0 +1,197 @@
+"""Tests for the bot-reply answer-duplication guards in ``ask.py``.
+
+Covers the two additive dedup layers added in the bot-reply polish work:
+
+1. Event-scoped guard — a single NON-partial (aggregate) ADK event that
+   carries the same answer text in two parts must emit exactly ONE
+   ``response_delta`` and accumulate the text only once.
+2. Finalization safety net (`_dedup_exact_double`) — an answer that is an
+   EXACT byte doubling (>= 80 chars) is halved before persistence, while a
+   non-exact near-double is left untouched.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from beever_atlas.api.ask import _dedup_exact_double
+from beever_atlas.server.app import app
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+def _install_mock_stores(mock_stores):
+    yield mock_stores
+
+
+@pytest.fixture
+async def client():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+def _make_part(text: str):
+    part = MagicMock()
+    part.text = text
+    part.thought = False
+    return part
+
+
+def _make_event(parts, *, partial: bool = False, turn_complete: bool = False):
+    content = MagicMock()
+    content.parts = parts
+    event = MagicMock()
+    event.content = content
+    event.partial = partial
+    event.turn_complete = turn_complete
+    event.error_code = None
+    event.error_message = None
+    event.get_function_calls.return_value = []
+    event.get_function_responses.return_value = []
+    return event
+
+
+async def _noop_decomposed_prompt(question: str, channel_id: str):
+    return f"[Channel: {channel_id}]\n\n{question}", None
+
+
+async def _noop_chat_history(session_id: str):
+    return []
+
+
+def _duplicate_part_runner():
+    """Runner that emits one NON-partial event whose two parts repeat the
+    same answer text, then a turn_complete event."""
+    answer = "The team chose dark mode after a long discussion in the design sync."
+
+    async def run_async(**kwargs):
+        yield _make_event([_make_part(answer), _make_part(answer)])
+        yield _make_event([_make_part("")], turn_complete=True)
+
+    return run_async, answer
+
+
+@pytest.fixture
+def _mock_session_and_prompt():
+    mock_session = MagicMock()
+    mock_session.user_id = "test_user"
+    mock_session.id = "test_session_id"
+    with (
+        patch(
+            "beever_atlas.agents.query.qa_agent.get_agent_for_mode",
+            return_value=MagicMock(),
+        ),
+        patch("beever_atlas.api.ask.create_runner") as mock_cr,
+        patch("beever_atlas.api.ask.create_session", new_callable=AsyncMock) as mock_cs,
+        patch(
+            "beever_atlas.api.ask._build_decomposed_prompt",
+            side_effect=_noop_decomposed_prompt,
+        ),
+        patch(
+            "beever_atlas.api.ask._load_chat_history_parts",
+            side_effect=_noop_chat_history,
+        ),
+    ):
+        mock_cs.return_value = mock_session
+        yield mock_cr
+
+
+def _parse_response_deltas(body: str) -> list[str]:
+    import json
+
+    deltas = []
+    current_event = None
+    for line in body.split("\n"):
+        if line.startswith("event: "):
+            current_event = line[7:]
+        elif line.startswith("data: ") and current_event == "response_delta":
+            deltas.append(json.loads(line[6:]).get("delta", ""))
+            current_event = None
+    return deltas
+
+
+class TestEventScopedGuard:
+    @pytest.mark.asyncio
+    async def test_duplicate_parts_in_one_event_emit_once(
+        self, client: AsyncClient, _mock_session_and_prompt
+    ):
+        run_async, answer = _duplicate_part_runner()
+        runner_instance = MagicMock()
+        runner_instance.run_async = run_async
+        _mock_session_and_prompt.return_value = runner_instance
+
+        captured = {}
+        real_persist = "beever_atlas.api.ask._persist_qa_history"
+
+        async def _capture(**kwargs):
+            captured["answer"] = kwargs.get("answer")
+
+        with patch(real_persist, side_effect=_capture):
+            response = await client.post(
+                "/api/channels/C123/ask",
+                json={"question": "what did we decide?"},
+            )
+
+        deltas = _parse_response_deltas(response.text)
+        # Exactly ONE response_delta carried the answer (the duplicate part
+        # in the same aggregate event was suppressed).
+        answer_deltas = [d for d in deltas if answer in d]
+        assert len(answer_deltas) == 1
+        # The accumulated/persisted answer is A, not A+A.
+        assert captured.get("answer") == answer
+
+
+class TestFinalizationNet:
+    def test_exact_double_is_halved(self):
+        a = "x" * 100
+        doubled = a + a  # 200 chars, exact byte doubling
+        assert _dedup_exact_double(doubled, "sess") == a
+
+    def test_non_exact_double_is_not_halved(self):
+        # "A" + "A " differs in the second half (trailing space) → NOT halved.
+        a = "y" * 60
+        near = a + a + " "  # second half != first half
+        assert _dedup_exact_double(near, "sess") == near
+
+    def test_short_exact_double_below_threshold_untouched(self):
+        # Below 80 chars: conservative net does not touch it.
+        a = "hello "  # 6 chars; doubled = 12 < 80
+        assert _dedup_exact_double(a + a, "sess") == a + a
+
+    def test_single_answer_untouched(self):
+        single = (
+            "This is a single, non-repeating answer that exceeds eighty characters in total length."
+        )
+        assert _dedup_exact_double(single, "sess") == single
+
+    def test_citation_renumbered_double_is_halved(self):
+        # The real production case: the stateful citation rewriter renumbers the
+        # SECOND copy's markers ([1][2] → [3][4]), so a byte-identity check would
+        # miss it. The renumbering-aware path must still collapse it and KEEP the
+        # first copy's correct numbering.
+        c1 = (
+            "Team Canada is legitimately good due to the presence of "
+            "Shai Gilgeous-Alexander [1]. He strengthens the roster [2]."
+        )
+        c2 = (
+            "Team Canada is legitimately good due to the presence of "
+            "Shai Gilgeous-Alexander [3]. He strengthens the roster [4]."
+        )
+        assert _dedup_exact_double(c1 + c2, "sess") == c1
+
+    def test_legit_repeated_phrase_not_halved(self):
+        # An answer that merely repeats a phrase (not the WHOLE answer) is left
+        # intact — the halves are not equal even after marker normalization.
+        legit = (
+            "The 2024 NBA Finals featured the Boston Celtics defeating the Dallas "
+            "Mavericks 4-1 [1]. The Boston Celtics are the most recent champions [1]."
+        )
+        assert _dedup_exact_double(legit, "sess") == legit

--- a/tests/test_qa_chat_overhaul.py
+++ b/tests/test_qa_chat_overhaul.py
@@ -305,7 +305,8 @@ class TestAgentModeConfig:
 
         prompt = build_qa_system_prompt()
         assert "Beever Atlas" in prompt
-        assert "Do not disclose" in prompt
+        # Non-disclosure invariant (phrasing loosened to a behavioral instruction).
+        assert "NEVER disclose" in prompt
 
     def test_retrieval_pipeline_in_prompt(self, monkeypatch):
         from beever_atlas.infra import config


### PR DESCRIPTION
## What & why
Makes the Beever Atlas chat reply feel polished and trustworthy in the **real Slack render**. Fixes 10 defects found in a live screenshot review and adds low-risk, market-learned polish (named source cards, no-sources gating). Found via an Understand→Research→Design→Implement→Review workflow (studied Glean / Slack AI / Perplexity / Notion AI / Dust / Guru). Interactive buttons / slash commands / streaming / feedback reactions are **deliberately deferred** (each needs a new webhook handler — own PR).

## The 10 fixes
| # | Defect | Fix | Where |
|---|--------|-----|-------|
| 1 | **Answer streamed TWICE** | `dedupDoubledAnswer` (citation-marker-normalized, conservative ≥80-char halves) on both the client stream and the persisted copy | `sse-client.ts`, `ask.py` |
| 2 | Greeting shows confidence/freshness/Related/route with 0 sources | Gate trust-chrome on `sources.length > 0` | `renderer.ts` |
| 3 | Author = raw user id (`U0B55TPHLHF`) | Omit ids (regex requires a digit, spares `TEAMWORK`) | `renderer.ts` |
| 4 | Bare source labels | **Named cards**: wiki title / web domain / author·#channel | `renderer.ts` |
| 5 | `via qa_agent` leaked | Suppress internal routes | `renderer.ts` |
| 6 | Follow-ups show literal `X`/`Y` | Prompt reword + trailing-`X/Y/Z` filter (keeps "Y Combinator") | `prompts.py`, `follow_ups_tool.py` |
| 7 | Channel without `#` | Prepend `#` (idempotent) | `renderer.ts` |
| 8 | Channel freshness on web/wiki answers | Gate `🕐` on a channel source present | `renderer.ts` |
| 9 | No date awareness | Inject today's date into the system prompt | `prompts.py` |
| 10 | Templated identity | Behavioral, varying greeting instruction | `prompts.py` |

## The duplication — root-caused empirically
Reproduced via curl: the doubling happens **only on a repeated question within a session** — conversation-history replay makes the model echo the prior identical answer + the new one. A *different* question is clean (no stale contamination). The first patch (a backend finalization net) fixed only the *persisted* copy — **the client renders from the streamed `response_delta` deltas**, so the dedup also lives in the bot's `finalizeResult`. Verified live: the doubled stream is reproduced (`dedup: halved` fires in backend logs) and the bot now collapses it.

## New polish (this PR)
Named source cards (title/domain/author·#channel) · honest "no sources → no citation UI" gating · `Sources · N` count + `+N more` · graceful empty-state.

## Deferred (follow-up "interactivity" PR)
👍/👎 feedback reactions, "show all sources" / "ask follow-up" buttons (onAction), `/ask` slash command, live token streaming, per-source verified/stale badges, deep-linked passage citations.

## Before / after
- **Greeting** — before: warm line **+ `⚠️ low confidence — verify against the sources` + `🕐 last activity` + `via qa_agent`** and the **answer printed twice**. After: one warm line + concrete example questions, nothing else.
- **Channel fact** — before: answer doubled, `💬 [2] U0B55TPHLHF · basketball`. After: single answer, `💬 [2] Carmen Lee · #basketball · 2d ago`.

## Test plan (unit + LIVE — curl can't see the rendered reply)
- `cd bot && npm run build && npm test` → **322 pass** (incl. `dedupDoubledAnswer` unit + a doubled-stream `consumeSSEStream` integration); 0 lint errors.
- `uv run pytest tests/test_ask_dedup.py tests/agents/test_follow_ups.py tests/agents/test_prompt_redesign.py tests/test_ask_endpoint.py tests/agents/test_output_contract.py -q` → green; smoke PASS; ruff/format clean.
- **Live Slack** (local Docker, `#basketball` C0B5YCR1NL8): ask the same question twice in a thread → single answer (not doubled); greeting → clean; channel fact → named cards, no raw id; web answer → domain labels, no channel-freshness.

## Review
Adversarial 3-dimension review (correctness · security · cross-platform/tests): **33 findings → 10 confirmed**. All actionable ones fixed: the **S2 duplication-fix gap** (made it renumbering-aware + moved it client-side after empirically confirming the mechanism), the **S3 raw-id false-positive** (require a digit), the placeholder over-filter (trailing-only), plus the confirmed test gaps. No S1/S2 remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
