### PR TITLE
fix(channel-resolver): cache only successful name resolutions (harden cross-channel guard)

### DIFF
--- a/src/beever_atlas/agents/tools/channel_resolver.py
+++ b/src/beever_atlas/agents/tools/channel_resolver.py
@@ -13,8 +13,14 @@ _channel_name_cache: dict[str, str] = {}
 async def resolve_channel_name(channel_id: str) -> str:
     """Resolve a channel ID to its display name.
 
-    Uses an in-memory cache to avoid repeated MongoDB lookups.
-    Falls back to the raw channel_id if resolution fails.
+    Uses an in-memory cache to avoid repeated MongoDB lookups. Falls back to the
+    raw channel_id when resolution fails — but ONLY caches SUCCESSFUL
+    resolutions. A transient store error or a not-yet-synced channel must not
+    poison the cache with the raw id: that would permanently disable name
+    resolution for the channel until process restart, which silently breaks the
+    cross-channel guard (it can't tell "this channel" from another when the name
+    is a raw id) and channel-name rendering. Leaving misses uncached lets a
+    later call resolve correctly once the store is ready / the channel syncs.
     """
     if channel_id in _channel_name_cache:
         return _channel_name_cache[channel_id]
@@ -26,10 +32,14 @@ async def resolve_channel_name(channel_id: str) -> str:
         # Use the existing get_channel_display_name method which queries
         # activity_events for details.channel_name (the canonical source).
         name = await store.get_channel_display_name(channel_id)
-        resolved = name if name else channel_id
-        _channel_name_cache[channel_id] = resolved
-        return resolved
+        if name:
+            _channel_name_cache[channel_id] = name  # cache real resolutions only
+            return name
+        # Not found yet (e.g. channel not synced) — return raw id but do NOT
+        # cache, so a later call retries once the name exists.
+        return channel_id
     except Exception:
-        logger.debug("Could not resolve channel name for %s", channel_id)
-        _channel_name_cache[channel_id] = channel_id
+        # Transient store error (e.g. Mongo blip under load) — return raw id but
+        # do NOT poison the cache; retry on the next call.
+        logger.debug("Could not resolve channel name for %s (will retry)", channel_id)
         return channel_id

--- a/tests/agents/tools/test_channel_resolver.py
+++ b/tests/agents/tools/test_channel_resolver.py
@@ -1,0 +1,66 @@
+"""resolve_channel_name caching: only SUCCESSFUL resolutions are cached, so a
+transient store error / not-yet-synced channel can't poison the cache and
+permanently disable name resolution (which would break the cross-channel guard
+and channel-name rendering)."""
+
+from __future__ import annotations
+
+import pytest
+
+from beever_atlas.agents.tools import channel_resolver
+from beever_atlas.agents.tools.channel_resolver import resolve_channel_name
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    channel_resolver._channel_name_cache.clear()
+    yield
+    channel_resolver._channel_name_cache.clear()
+
+
+class _Store:
+    def __init__(self, behaviors):
+        # behaviors: list of either a string (return) or Exception (raise)
+        self._behaviors = list(behaviors)
+        self.calls = 0
+
+    async def get_channel_display_name(self, channel_id):
+        self.calls += 1
+        b = self._behaviors.pop(0) if self._behaviors else None
+        if isinstance(b, Exception):
+            raise b
+        return b
+
+
+def _patch_store(monkeypatch, store):
+    class _Stores:
+        mongodb = store
+
+    monkeypatch.setattr("beever_atlas.stores.get_stores", lambda: _Stores(), raising=False)
+
+
+async def test_transient_error_is_not_cached_and_retries(monkeypatch):
+    store = _Store([RuntimeError("mongo blip"), "basketball"])
+    _patch_store(monkeypatch, store)
+    # First call: store errors → raw id, NOT cached.
+    assert await resolve_channel_name("C1") == "C1"
+    assert "C1" not in channel_resolver._channel_name_cache
+    # Second call: store recovers → resolves correctly (no poisoning).
+    assert await resolve_channel_name("C1") == "basketball"
+    assert channel_resolver._channel_name_cache["C1"] == "basketball"
+
+
+async def test_missing_name_is_not_cached_and_retries(monkeypatch):
+    store = _Store([None, "basketball"])
+    _patch_store(monkeypatch, store)
+    assert await resolve_channel_name("C1") == "C1"  # not synced yet → raw id
+    assert "C1" not in channel_resolver._channel_name_cache
+    assert await resolve_channel_name("C1") == "basketball"  # resolves once synced
+
+
+async def test_successful_resolution_is_cached(monkeypatch):
+    store = _Store(["basketball"])
+    _patch_store(monkeypatch, store)
+    assert await resolve_channel_name("C1") == "basketball"
+    assert await resolve_channel_name("C1") == "basketball"
+    assert store.calls == 1  # second call served from cache, no store hit


### PR DESCRIPTION
## Summary
Hardens `resolve_channel_name` so a transient store error or a not-yet-synced channel can't **permanently** disable channel-name resolution — which would silently break the #244 cross-channel refusal guard and citation channel labels.

## The bug
`resolve_channel_name` cached its **raw-id fallback** on any miss/error:
```python
resolved = name if name else channel_id
_channel_name_cache[channel_id] = resolved   # caches the failure too
```
So one Mongo blip (common under load) or a channel that hasn't synced yet poisons the in-memory cache with the raw id and returns it **forever** (until restart). Downstream, the #244 cross-channel guard compares the named channel against the current channel's name; when that name is a raw id, the guard's "can't tell same-vs-different, don't guess" path fires and it **stops refusing** cross-channel questions.

## The fix
Cache **only confirmed display names**. A miss/error returns the raw id **without caching**, so a later call resolves correctly once the store is ready / the channel syncs.

## How it was found
Live verification (driving real `/api/channels/{id}/ask` requests after deploying #244). The cross-channel refusal **does** fire on the deployed code (the name resolves from `activity_events`) — but a standalone probe surfaced that a failed lookup poisons the cache, which would disable the guard after any transient blip. The #244 unit tests had mocked the resolver, hiding this.

## Verification
- New `tests/agents/tools/test_channel_resolver.py` (3 tests, **no resolver mocking-away**): transient error → not cached → retries; missing name → not cached → retries; success → cached (single store hit).
- 99 resolver-touching tests pass (qa-overhaul, channel-isolation, bot-polish); ruff clean.

## Note
This does not change the happy path (a resolvable channel still resolves and caches). The cross-channel refusal already works on deployed #244; this prevents the cache-poisoning failure mode from disabling it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)