### PR TITLE
feat(connectivity): Slack Socket Mode + surfaced PUBLIC_BOT_URL to close the inbound-webhook gap

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -109,6 +109,19 @@ BOT_PORT=3001
 BACKEND_URL=http://localhost:8000
 BRIDGE_URL=http://localhost:3001
 
+# PUBLIC_BOT_URL: where the bot's inbound webhooks are reachable from the public
+# internet. Inbound-webhook platforms (Slack Events API, Microsoft Teams) need
+# this; outbound ones (Discord, Mattermost, and Slack Socket Mode) do not.
+#   • Local dev: run a tunnel (`ngrok http 3001`) and put its https URL here.
+#     Reserve a free static ngrok domain so it survives restarts (see
+#     docs/guides/slack-setup.md). Then re-pointing Slack/Teams is a one-time step.
+#   • Production: your real public domain, e.g. https://beever-atlas.example.com
+# The Settings → connection wizard reads this to show the exact Slack Request
+# URL ({PUBLIC_BOT_URL}/api/slack) and Teams messaging endpoint
+# ({PUBLIC_BOT_URL}/api/teams) to paste. Leave blank if you only use outbound
+# platforms / Slack Socket Mode.
+PUBLIC_BOT_URL=
+
 # ── Reply-feature tuning (all optional; safe defaults shown) ─────────────────
 # BOT_SESSION_SECRET: HMAC key for per-thread conversation-memory session ids.
 #   SET THIS IN PRODUCTION — when unset, session ids are derived from a known

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install test lint dev stop docker-up docker-down clean demo demo-regenerate-fixtures reembed-all reembed-resume reembed-dry-run
+.PHONY: install test lint dev stop docker-up docker-down clean demo demo-regenerate-fixtures reembed-all reembed-resume reembed-dry-run tunnel
 
 install:
 	uv sync --extra dev
@@ -41,6 +41,25 @@ docker-up:
 
 docker-down:
 	docker compose down
+
+# Expose the bot's inbound webhooks (port 3001) over a public HTTPS tunnel so
+# Slack (Events API) and Microsoft Teams can deliver events in local dev.
+# Discord, Mattermost, and Slack Socket Mode do NOT need this.
+#
+# Set NGROK_DOMAIN to a reserved static domain (free tier includes one — see
+# https://dashboard.ngrok.com/domains) so the URL survives reboots and you only
+# configure Slack/Teams once. Then put the same https URL in PUBLIC_BOT_URL.
+#   make tunnel NGROK_DOMAIN=your-name.ngrok-free.app
+# Without a domain it falls back to an ephemeral URL (changes every restart).
+tunnel:
+	@command -v ngrok >/dev/null 2>&1 || { echo "ngrok not installed: brew install ngrok"; exit 1; }
+	@if [ -n "$(NGROK_DOMAIN)" ]; then \
+		echo "Starting ngrok on static domain https://$(NGROK_DOMAIN) → :3001"; \
+		ngrok http 3001 --url=https://$(NGROK_DOMAIN); \
+	else \
+		echo "Starting ngrok on an EPHEMERAL url → :3001 (set NGROK_DOMAIN for a stable one)"; \
+		ngrok http 3001; \
+	fi
 
 demo:
 	docker compose -f docker-compose.yml -f demo/docker-compose.demo.yml up --build

--- a/bot/src/chat-manager.test.ts
+++ b/bot/src/chat-manager.test.ts
@@ -1,6 +1,51 @@
 import { describe, it } from "node:test";
 import assert from "node:assert";
-import { ChatManager, parseSlackWorkspaceDomain } from "./chat-manager.js";
+import { ChatManager, parseSlackWorkspaceDomain, planSlackAdapter } from "./chat-manager.js";
+
+describe("planSlackAdapter", () => {
+  it("chooses socket mode when an appToken is present", () => {
+    assert.deepStrictEqual(
+      planSlackAdapter({ botToken: "xoxb-1", appToken: "xapp-1" }),
+      { ok: true, mode: "socket" },
+    );
+  });
+  it("chooses webhook mode when only a signingSecret is present", () => {
+    assert.deepStrictEqual(
+      planSlackAdapter({ botToken: "xoxb-1", signingSecret: "s1" }),
+      { ok: true, mode: "webhook" },
+    );
+  });
+  it("prefers socket mode when both appToken and signingSecret are present", () => {
+    assert.deepStrictEqual(
+      planSlackAdapter({ botToken: "xoxb-1", appToken: "xapp-1", signingSecret: "s1" }),
+      { ok: true, mode: "socket" },
+    );
+  });
+  it("reports missing botToken", () => {
+    assert.deepStrictEqual(
+      planSlackAdapter({ signingSecret: "s1" }),
+      { ok: false, missing: ["botToken"] },
+    );
+  });
+  it("reports missing transport when neither appToken nor signingSecret is set", () => {
+    assert.deepStrictEqual(
+      planSlackAdapter({ botToken: "xoxb-1" }),
+      { ok: false, missing: ["signingSecret|appToken"] },
+    );
+  });
+  it("reports both missing when given an empty config", () => {
+    assert.deepStrictEqual(
+      planSlackAdapter({}),
+      { ok: false, missing: ["botToken", "signingSecret|appToken"] },
+    );
+  });
+  it("treats empty-string credentials as absent", () => {
+    assert.deepStrictEqual(
+      planSlackAdapter({ botToken: "", appToken: "" }),
+      { ok: false, missing: ["botToken", "signingSecret|appToken"] },
+    );
+  });
+});
 
 describe("parseSlackWorkspaceDomain", () => {
   it("extracts the subdomain from a Slack auth.test url", () => {

--- a/bot/src/chat-manager.ts
+++ b/bot/src/chat-manager.ts
@@ -173,7 +173,8 @@ export class ChatManager {
       // Required credential keys per platform — entries missing any of these are
       // skipped so a single broken connection cannot take down the entire bot.
       const REQUIRED_CREDENTIALS: Record<string, string[]> = {
-        slack: ["botToken", "signingSecret"],
+        // Slack has two valid credential shapes (webhook vs socket mode), so it
+        // is validated separately below rather than via this simple AND-list.
         discord: ["botToken", "publicKey", "applicationId"],
         teams: ["appId", "appPassword"],
         telegram: ["botToken"],
@@ -183,6 +184,19 @@ export class ChatManager {
       const adapterInstances: Record<string, unknown> = {};
 
       for (const [key, entry] of this.adapters.entries()) {
+        // Slack: botToken is always required, plus EITHER a signingSecret
+        // (Events API / webhook mode — needs a public inbound URL) OR an
+        // appToken (Socket Mode — outbound WebSocket, no public URL needed).
+        let slackMode: "socket" | "webhook" | null = null;
+        if (entry.platform === "slack") {
+          const plan = planSlackAdapter(entry.config);
+          if (!plan.ok) {
+            console.warn(`ChatManager: skipping "${key}" — missing required credentials: ${plan.missing.join(", ")}`);
+            continue;
+          }
+          slackMode = plan.mode;
+        }
+
         const required = REQUIRED_CREDENTIALS[entry.platform];
         if (required) {
           const missing = required.filter((k) => !entry.config[k]);
@@ -194,10 +208,26 @@ export class ChatManager {
 
         try {
           if (entry.platform === "slack") {
-            const slackAdapter = createSlackAdapter({
-              botToken: entry.config.botToken,
-              signingSecret: entry.config.signingSecret,
-            });
+            // Socket Mode (appToken present) connects an OUTBOUND WebSocket to
+            // Slack — like Discord/Mattermost — so it needs no public inbound
+            // URL and survives host restarts without re-pointing a tunnel.
+            // Falls back to webhook/Events-API mode (signingSecret) otherwise.
+            // The socket is started automatically by the adapter's
+            // initialize(chat), which runs during newBot.initialize() below.
+            const useSocketMode = slackMode === "socket";
+            const slackAdapter = useSocketMode
+              ? createSlackAdapter({
+                  botToken: entry.config.botToken,
+                  appToken: entry.config.appToken,
+                  mode: "socket",
+                })
+              : createSlackAdapter({
+                  botToken: entry.config.botToken,
+                  signingSecret: entry.config.signingSecret,
+                });
+            console.log(
+              `ChatManager: Slack adapter "${key}" using ${useSocketMode ? "socket" : "webhook"} mode`,
+            );
             adapterInstances[key] = slackAdapter;
             // Cache team_id → connectionId for URL-based file routing
             try {
@@ -511,6 +541,31 @@ export class ChatManager {
     }
     return null;
   }
+}
+
+/**
+ * Decide how a Slack adapter should be built from its credentials.
+ *
+ * Slack supports two inbound transports:
+ *  - "socket": Socket Mode — needs `botToken` + `appToken` (xapp-...). The
+ *    adapter opens an OUTBOUND WebSocket to Slack (like Discord/Mattermost), so
+ *    no public inbound URL/tunnel is required and it survives host restarts.
+ *  - "webhook": Events API — needs `botToken` + `signingSecret`. Slack POSTs
+ *    events to a public inbound URL, so it requires a tunnel in local dev.
+ *
+ * When both `appToken` and `signingSecret` are present, socket mode wins (it is
+ * strictly easier to operate locally). Returns `ok:false` with the missing keys
+ * when neither transport can be satisfied.
+ */
+export function planSlackAdapter(config: Record<string, unknown>):
+  | { ok: true; mode: "socket" | "webhook" }
+  | { ok: false; missing: string[] } {
+  const has = (k: string) => Boolean(config[k]);
+  const missing: string[] = [];
+  if (!has("botToken")) missing.push("botToken");
+  if (!has("signingSecret") && !has("appToken")) missing.push("signingSecret|appToken");
+  if (missing.length > 0) return { ok: false, missing };
+  return { ok: true, mode: has("appToken") ? "socket" : "webhook" };
 }
 
 /**

--- a/bot/src/index.ts
+++ b/bot/src/index.ts
@@ -530,11 +530,18 @@ async function registerTeamsFromEnvIfPresent(
 async function fallbackToEnvCredentials(chatManager: ChatManager): Promise<void> {
   let registered = 0;
 
-  // Slack
+  // Slack — Socket Mode (SLACK_APP_TOKEN, xapp-...) is preferred for local/
+  // single-workspace dev: it uses an outbound WebSocket and needs no public
+  // inbound URL. Falls back to Events API (signing secret) when no app token.
   const slackToken = process.env.SLACK_BOT_TOKEN;
+  const slackAppToken = process.env.SLACK_APP_TOKEN;
   const slackSecret = process.env.SLACK_SIGNING_SECRET;
-  if (slackToken && slackSecret) {
-    console.log("Env fallback: registering Slack adapter from .env credentials");
+  if (slackToken && slackAppToken) {
+    console.log("Env fallback: registering Slack adapter (socket mode) from .env credentials");
+    await chatManager.register("slack", { botToken: slackToken, appToken: slackAppToken });
+    registered++;
+  } else if (slackToken && slackSecret) {
+    console.log("Env fallback: registering Slack adapter (webhook mode) from .env credentials");
     await chatManager.register("slack", { botToken: slackToken, signingSecret: slackSecret });
     registered++;
   }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,12 @@ services:
       REDIS_URL: redis://redis:6379
       BRIDGE_URL: http://bot:3001
       BRIDGE_API_KEY: ${BRIDGE_API_KEY:-}
+      # Public URL where the bot's inbound webhooks are reachable from the
+      # internet (tunnel in local dev, real domain in prod). Surfaced read-only
+      # in the Settings → connection wizard so users know the exact Slack
+      # Request URL / Teams messaging endpoint to paste. Optional: Discord,
+      # Mattermost, and Slack Socket Mode do not need it.
+      PUBLIC_BOT_URL: ${PUBLIC_BOT_URL:-}
     healthcheck:
       test: ["CMD", "python", "-c", "import httpx; httpx.get('http://localhost:8000/api/health')"]
       interval: 30s

--- a/docs/guides/slack-setup.md
+++ b/docs/guides/slack-setup.md
@@ -43,35 +43,48 @@ Go to **OAuth & Permissions** → **Scopes** → **Bot Token Scopes** and add:
 | `mpim:history` | Multi-party DM history |
 | `mpim:read` | List multi-party DMs |
 
-## 3. Enable Event Subscriptions
+## 3. Choose a delivery mode: Socket Mode **or** Events API
 
-Go to **Event Subscriptions** → Toggle **Enable Events** ON.
+Slack can deliver events two ways. **Pick one.**
 
-### Request URL
+| | **Socket Mode** (recommended for local / self-hosted) | **Events API** (webhook) |
+|---|---|---|
+| Transport | Outbound WebSocket from the bot | Slack POSTs to a public URL |
+| Needs a public URL / tunnel? | **No** | **Yes** |
+| Survives host restarts? | **Yes**, reconnects automatically | Only if the public URL is stable |
+| Credential | App-Level Token (`xapp-…`) | Signing Secret |
+| Multi-workspace OAuth? | No (single workspace) | Yes |
 
-The Request URL is where Slack sends webhook events. During development, you need to expose your local bot service:
+Socket Mode behaves like the Discord and Mattermost adapters — no tunnel, no re-pointing after a reboot. Prefer it unless you need multi-workspace OAuth (typical only for the hosted/EE multi-tenant build, which runs behind a real public domain).
 
-**Option A: ngrok (recommended for dev)**
+### Option A — Socket Mode (no public URL needed)
+
+1. **Settings → Socket Mode** → toggle **Enable Socket Mode** ON.
+2. **Basic Information → App-Level Tokens** → **Generate Token and Scopes** → add the `connections:write` scope → copy the token (starts with `xapp-`).
+3. Still configure **Event Subscriptions → Subscribe to bot events** (below) — the event list applies to both modes — but you do **not** set a Request URL.
+4. In the connection wizard (or `SLACK_APP_TOKEN`), provide the `xapp-` token. No signing secret is required.
+
+### Option B — Events API (public Request URL)
+
+Go to **Event Subscriptions** → toggle **Enable Events** ON, then set the **Request URL** to where the bot is reachable from the internet.
+
+Expose the local bot service (port 3001):
+
 ```bash
-# Install ngrok
-brew install ngrok
-
-# Expose bot service (default port 3001)
+# ngrok — reserve a free STATIC domain so the URL survives restarts:
+#   https://dashboard.ngrok.com/domains
+ngrok http 3001 --url=https://<your-static>.ngrok-free.app
+# …or an ephemeral URL (changes every restart):
 ngrok http 3001
+# Shortcut: make tunnel NGROK_DOMAIN=<your-static>.ngrok-free.app
 
-# Use the HTTPS URL ngrok gives you, e.g.:
-# https://abc123.ngrok-free.app/api/slack
-```
-
-**Option B: Cloudflare Tunnel**
-```bash
-brew install cloudflared
+# or Cloudflare Tunnel:
 cloudflared tunnel --url http://localhost:3001
 ```
 
-Set the Request URL to: `https://<your-tunnel>/api/slack`
+Set **Request URL** to `https://<your-public-url>/api/slack` and provide the **Signing Secret** in the wizard. Slack sends a verification challenge — the Chat SDK handles it automatically.
 
-Slack will send a verification challenge — the Chat SDK handles this automatically.
+> **Tip:** Set `PUBLIC_BOT_URL` to this same `https://…` base. The Settings → connection wizard then shows the exact Request URL to paste (and the Teams messaging endpoint), so you never have to assemble it by hand. With a **static** ngrok domain you configure Slack/Teams once and reboots no longer break inbound delivery.
 
 ### Subscribe to Bot Events
 

--- a/scripts/set_slack_socket_mode.py
+++ b/scripts/set_slack_socket_mode.py
@@ -1,0 +1,115 @@
+"""Migrate an existing Slack connection to Socket Mode IN PLACE — no delete.
+
+The web UI has no edit-credentials flow, and deleting a connection cascades a
+hard-purge of its sole-owned channels (messages/facts/wiki). This script adds an
+app-level token (``xapp-...``) to the stored credentials of an existing Slack
+connection so the bot switches to Socket Mode (outbound WebSocket, no public
+URL / tunnel) on its next rebuild — preserving all synced data and channel
+selections.
+
+Usage (inside the backend container, which holds CREDENTIAL_MASTER_KEY + DB):
+
+    docker compose exec beever-atlas \
+        python -m scripts.set_slack_socket_mode --app-token xapp-XXXX
+
+The token is read from --app-token or the SLACK_APP_TOKEN env var, so it can stay
+on your machine and never has to be pasted into a chat. Pass --connection-id to
+target a specific connection; otherwise the single Slack connection is used.
+
+After it runs, restart the bot so it re-registers the adapter in socket mode:
+
+    docker compose restart bot
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import sys
+
+from beever_atlas.infra.config import get_settings
+from beever_atlas.stores import StoreClients, init_stores
+
+
+def _redact(token: str) -> str:
+    if len(token) <= 8:
+        return "****"
+    return f"{token[:7]}…{token[-4:]}"
+
+
+async def _run(connection_id: str | None, app_token: str) -> int:
+    settings = get_settings()
+    stores = StoreClients.from_settings(settings)
+    await stores.startup()
+    init_stores(stores)
+
+    conns = await stores.platform.list_connections()
+    slack = [c for c in conns if c.platform == "slack"]
+    if connection_id:
+        slack = [c for c in slack if c.id == connection_id]
+
+    if not slack:
+        print("ERROR: no matching Slack connection found.", file=sys.stderr)
+        return 1
+    if len(slack) > 1:
+        ids = ", ".join(c.id for c in slack)
+        print(
+            f"ERROR: multiple Slack connections ({ids}); pass --connection-id.",
+            file=sys.stderr,
+        )
+        return 1
+
+    conn = slack[0]
+    creds = stores.platform.decrypt_connection_credentials(conn)
+    before = sorted(creds.keys())
+
+    # Merge — keep existing bot_token/signing_secret. The bot's bridge camelizes
+    # stored snake_case keys (app_token -> appToken) before building the adapter,
+    # and planSlackAdapter() prefers socket mode whenever appToken is present, so
+    # signing_secret can safely stay (useful if you ever revert to Events API).
+    # Match the stored convention: snake_case if that's what's already there.
+    token_key = "app_token" if "bot_token" in creds else "appToken"
+    creds[token_key] = app_token
+
+    updated = await stores.platform.update_connection(conn.id, credentials=creds)
+    if updated is None:
+        print(f"ERROR: update failed for connection {conn.id}.", file=sys.stderr)
+        return 1
+
+    print(f"OK: connection {conn.id} ({conn.display_name})")
+    print(f"  credentials before: {before}")
+    print(f"  credentials after:  {sorted(creds.keys())}")
+    print(f"  appToken set to:    {_redact(app_token)}")
+    print("Next: `docker compose restart bot`, then expect the bot log line")
+    print('  ChatManager: Slack adapter "..." using socket mode')
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--app-token",
+        default=os.environ.get("SLACK_APP_TOKEN", ""),
+        help="Slack app-level token (xapp-...). Defaults to $SLACK_APP_TOKEN.",
+    )
+    parser.add_argument(
+        "--connection-id",
+        default=None,
+        help="Target a specific Slack connection id (optional).",
+    )
+    args = parser.parse_args()
+
+    if not args.app_token or not args.app_token.startswith("xapp-"):
+        print(
+            "ERROR: provide a valid app-level token via --app-token or "
+            "SLACK_APP_TOKEN (must start with 'xapp-').",
+            file=sys.stderr,
+        )
+        return 1
+
+    return asyncio.run(_run(args.connection_id, args.app_token))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/beever_atlas/api/config.py
+++ b/src/beever_atlas/api/config.py
@@ -17,3 +17,25 @@ async def get_languages() -> dict:
         "supported_languages": settings.supported_languages_list,
         "default_target_language": settings.default_target_language,
     }
+
+
+@router.get("/connectivity")
+async def get_connectivity() -> dict:
+    """Return the public bot URL and the exact inbound-webhook URLs to paste
+    into Slack (Events API Request URL) and Teams (messaging endpoint).
+
+    `public_bot_url` is empty when unset — the UI then shows guidance to
+    configure a tunnel (local dev) or a public domain (production). Outbound
+    transports (Discord, Mattermost, Slack Socket Mode) do not need this.
+    """
+    base = get_settings().public_bot_base
+    return {
+        "public_bot_url": base,
+        "configured": bool(base),
+        "webhooks": {
+            # Legacy per-platform routes; the bot also accepts the
+            # per-connection route /api/webhooks/{connectionId}.
+            "slack": f"{base}/api/slack" if base else "",
+            "teams": f"{base}/api/teams" if base else "",
+        },
+    }

--- a/src/beever_atlas/infra/config.py
+++ b/src/beever_atlas/infra/config.py
@@ -344,6 +344,18 @@ class Settings(BaseSettings):
     # Bridge (bot service)
     bridge_url: str = Field(default="http://localhost:3001")
     bridge_api_key: str = Field(default="")
+    # Public URL at which the bot's inbound webhooks are reachable from the
+    # internet (e.g. an ngrok/cloudflared tunnel in local dev, or the real
+    # domain in production). Surfaced read-only to the web Settings UI so users
+    # know exactly what to paste into Slack's Request URL and Teams' messaging
+    # endpoint. Inbound-webhook platforms (Slack Events API, Teams) need this;
+    # outbound ones (Discord, Mattermost, Slack Socket Mode) do not.
+    public_bot_url: str = Field(default="", alias="PUBLIC_BOT_URL")
+
+    @property
+    def public_bot_base(self) -> str:
+        """Public bot base URL with any trailing slash removed (empty if unset)."""
+        return (self.public_bot_url or "").rstrip("/")
     # When True, accept both constant-time and legacy `==` bridge auth paths
     # for one release cycle. Every legacy accept logs a warning.
     bridge_hmac_dual: bool = Field(default=False, alias="BEEVER_BRIDGE_HMAC_DUAL")

--- a/src/beever_atlas/infra/config.py
+++ b/src/beever_atlas/infra/config.py
@@ -356,6 +356,7 @@ class Settings(BaseSettings):
     def public_bot_base(self) -> str:
         """Public bot base URL with any trailing slash removed (empty if unset)."""
         return (self.public_bot_url or "").rstrip("/")
+
     # When True, accept both constant-time and legacy `==` bridge auth paths
     # for one release cycle. Every legacy accept logs a warning.
     bridge_hmac_dual: bool = Field(default=False, alias="BEEVER_BRIDGE_HMAC_DUAL")

--- a/src/beever_atlas/server/app.py
+++ b/src/beever_atlas/server/app.py
@@ -106,8 +106,14 @@ async def _migrate_env_connection(stores: StoreClients, settings) -> None:
         )
         return
 
+    # An app-level token (xapp-...) enables Socket Mode: the bot reaches Slack
+    # over an outbound WebSocket, so no public inbound URL/tunnel is required.
+    # Prefer it when present; otherwise fall back to Events API (signing secret).
+    slack_app_token = os.environ.get("SLACK_APP_TOKEN", "")
     slack_signing_secret = os.environ.get("SLACK_SIGNING_SECRET", "")
     credentials: dict = {"botToken": slack_token}
+    if slack_app_token:
+        credentials["appToken"] = slack_app_token
     if slack_signing_secret:
         credentials["signingSecret"] = slack_signing_secret
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -35,9 +35,13 @@ class TestSettings:
         assert hasattr(settings, "jina_api_key")
         assert hasattr(settings, "tavily_api_key")
 
-    def test_public_bot_base_empty_by_default(self):
+    def test_public_bot_base_empty_when_unset(self, monkeypatch):
         from beever_atlas.infra.config import Settings
 
+        # Force-empty via the env source (which outranks the dotenv source) so a
+        # developer's local .env PUBLIC_BOT_URL=<live tunnel> can't leak in. This
+        # exercises the empty/unconfigured branch of public_bot_base.
+        monkeypatch.setenv("PUBLIC_BOT_URL", "")
         assert Settings().public_bot_base == ""
 
     def test_public_bot_base_strips_trailing_slash(self, monkeypatch):
@@ -73,7 +77,9 @@ class TestConnectivityEndpoint:
         import beever_atlas.api.config as cfg
         from beever_atlas.infra.config import Settings
 
-        monkeypatch.delenv("PUBLIC_BOT_URL", raising=False)
+        # Force-empty via the env source (outranks dotenv) so a developer's local
+        # .env PUBLIC_BOT_URL can't leak in and falsely mark this configured.
+        monkeypatch.setenv("PUBLIC_BOT_URL", "")
         monkeypatch.setattr(cfg, "get_settings", Settings)
         result = await cfg.get_connectivity()
         assert result["configured"] is False

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -35,6 +35,51 @@ class TestSettings:
         assert hasattr(settings, "jina_api_key")
         assert hasattr(settings, "tavily_api_key")
 
+    def test_public_bot_base_empty_by_default(self):
+        from beever_atlas.infra.config import Settings
+
+        assert Settings().public_bot_base == ""
+
+    def test_public_bot_base_strips_trailing_slash(self, monkeypatch):
+        from beever_atlas.infra.config import Settings
+
+        monkeypatch.setenv("PUBLIC_BOT_URL", "https://abc.ngrok-free.app/")
+        assert Settings().public_bot_base == "https://abc.ngrok-free.app"
+
+    def test_public_bot_url_reads_alias_env(self, monkeypatch):
+        from beever_atlas.infra.config import Settings
+
+        monkeypatch.setenv("PUBLIC_BOT_URL", "https://host.example.com")
+        assert Settings().public_bot_base == "https://host.example.com"
+
+
+class TestConnectivityEndpoint:
+    """`/api/config/connectivity` surfaces the exact inbound-webhook URLs to the
+    Settings UI so users know what to paste into Slack / Teams."""
+
+    async def test_returns_computed_webhook_urls_when_configured(self, monkeypatch):
+        import beever_atlas.api.config as cfg
+        from beever_atlas.infra.config import Settings
+
+        monkeypatch.setenv("PUBLIC_BOT_URL", "https://abc.ngrok-free.app/")
+        monkeypatch.setattr(cfg, "get_settings", Settings)
+        result = await cfg.get_connectivity()
+        assert result["configured"] is True
+        assert result["public_bot_url"] == "https://abc.ngrok-free.app"
+        assert result["webhooks"]["slack"] == "https://abc.ngrok-free.app/api/slack"
+        assert result["webhooks"]["teams"] == "https://abc.ngrok-free.app/api/teams"
+
+    async def test_empty_when_unconfigured(self, monkeypatch):
+        import beever_atlas.api.config as cfg
+        from beever_atlas.infra.config import Settings
+
+        monkeypatch.delenv("PUBLIC_BOT_URL", raising=False)
+        monkeypatch.setattr(cfg, "get_settings", Settings)
+        result = await cfg.get_connectivity()
+        assert result["configured"] is False
+        assert result["public_bot_url"] == ""
+        assert result["webhooks"] == {"slack": "", "teams": ""}
+
 
 class TestEmbeddingSettings:
     """PR-B: ``EmbeddingSettings`` defaults preserve legacy Jina behavior and

--- a/web/src/components/settings/ConnectionWizard.tsx
+++ b/web/src/components/settings/ConnectionWizard.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react";
-import { X, ArrowLeft, ArrowRight, CheckCircle2, Loader2, AlertCircle, ExternalLink, Zap } from "lucide-react";
+import { X, ArrowLeft, ArrowRight, CheckCircle2, Loader2, AlertCircle, ExternalLink, Zap, Copy, Check } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { api } from "@/lib/api";
 import { ChannelSelector } from "./ChannelSelector";
 import { useCreateConnection } from "@/hooks/useConnections";
 import { useConnectionChannels, useUpdateChannels } from "@/hooks/useConnections";
@@ -32,7 +33,21 @@ const SLACK_INSTRUCTIONS = [
   },
   { text: "Click Install to Workspace and authorize" },
   { text: "Copy the Bot User OAuth Token (starts with xoxb-)" },
-  { text: "Under Basic Information, copy the Signing Secret" },
+  {
+    text: "Choose how Slack delivers events — pick ONE:",
+    details: [
+      "A) Socket Mode (recommended, no public URL): Settings → Socket Mode → enable it, then Basic Information → App-Level Tokens → generate a token with the connections:write scope. Copy it (starts with xapp-).",
+      "B) Events API (needs a public URL): Basic Information → copy the Signing Secret instead. You will also set a Request URL in the next step.",
+    ],
+  },
+  {
+    text: "Under Event Subscriptions → Subscribe to bot events, add the events the bot listens for (both modes):",
+    details: ["app_mention", "message.channels", "message.groups"],
+  },
+  {
+    text: "Events API only — set Event Subscriptions → Request URL to your public bot URL + /api/slack and wait for the green Verified ✓ (skip this entirely if you chose Socket Mode):",
+    details: ["https://<your-public-url>/api/slack"],
+  },
 ];
 
 const DISCORD_INSTRUCTIONS = [
@@ -123,7 +138,22 @@ function validateAadGuid(label: string) {
 const CREDENTIAL_FIELDS: Record<Platform, CredentialField[]> = {
   slack: [
     { key: "bot_token", label: "Bot Token", placeholder: "xoxb-...", type: "password" },
-    { key: "signing_secret", label: "Signing Secret", placeholder: "Your app's signing secret", type: "password" },
+    {
+      key: "app_token",
+      label: "App-Level Token (Socket Mode — recommended)",
+      placeholder: "xapp-...",
+      type: "password",
+      optional: true,
+      hint: "Recommended for local/self-hosted: Socket Mode uses an outbound connection, so no public URL or tunnel is needed and it keeps working after restarts. Generate under Basic Information → App-Level Tokens with the connections:write scope.",
+    },
+    {
+      key: "signing_secret",
+      label: "Signing Secret (Events API)",
+      placeholder: "Your app's signing secret",
+      type: "password",
+      optional: true,
+      hint: "Only needed if you are NOT using Socket Mode. Events API requires a public Request URL (a tunnel in local dev).",
+    },
   ],
   discord: [
     { key: "bot_token", label: "Bot Token", placeholder: "Your bot token", type: "password" },
@@ -226,7 +256,14 @@ export function ConnectionWizard({ platform, onClose, onComplete }: ConnectionWi
     }
   }
 
-  const credentialsFilled = fields.every((f) => f.optional || (credentials[f.key] ?? "").trim().length > 0);
+  const credentialsFilled =
+    fields.every((f) => f.optional || (credentials[f.key] ?? "").trim().length > 0) &&
+    // Slack accepts EITHER an app-level token (Socket Mode) OR a signing
+    // secret (Events API) — both are marked optional individually, so require
+    // at least one here.
+    (platform !== "slack" ||
+      (credentials.app_token ?? "").trim().length > 0 ||
+      (credentials.signing_secret ?? "").trim().length > 0);
   // Disable Validate when any FILLED field fails its own validator. Empty
   // fields are handled by `credentialsFilled`; we don't double-report.
   const credentialsValid = fields.every((f) => {
@@ -445,6 +482,81 @@ function StepIndicator({ current }: { current: Step }) {
   );
 }
 
+interface ConnectivityConfig {
+  public_bot_url: string;
+  configured: boolean;
+  webhooks: { slack: string; teams: string };
+}
+
+/** Shows the live public webhook URL the user must paste into Slack's Request
+ *  URL / Teams' messaging endpoint, fetched from /api/config/connectivity.
+ *  When PUBLIC_BOT_URL is unset it explains how to configure connectivity
+ *  instead of leaving the user guessing. Only relevant for inbound-webhook
+ *  platforms (Slack Events API, Teams); harmless for Slack Socket Mode. */
+function WebhookUrlCallout({ platform }: { platform: "slack" | "teams" }) {
+  const [cfg, setCfg] = useState<ConnectivityConfig | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    let alive = true;
+    api
+      .get<ConnectivityConfig>("/api/config/connectivity")
+      .then((c) => alive && setCfg(c))
+      .catch(() => alive && setCfg(null));
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  const url = cfg?.webhooks?.[platform] ?? "";
+  const label =
+    platform === "slack" ? "Slack Event Subscriptions → Request URL" : "Teams bot Messaging endpoint";
+
+  async function copy() {
+    if (!url) return;
+    try {
+      await navigator.clipboard.writeText(url);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      /* clipboard may be blocked; the URL is still shown for manual copy */
+    }
+  }
+
+  return (
+    <div className="rounded-lg border border-border bg-muted/40 px-3 py-2.5 space-y-1.5">
+      <p className="text-xs font-medium text-foreground">
+        {platform === "slack" ? "Public URL (Events API only — skip for Socket Mode)" : "Public messaging endpoint"}
+      </p>
+      {cfg?.configured && url ? (
+        <>
+          <div className="flex items-center gap-2">
+            <code className="flex-1 text-xs font-mono text-foreground/90 bg-background border border-border rounded px-2 py-1 truncate">
+              {url}
+            </code>
+            <button
+              type="button"
+              onClick={copy}
+              className="shrink-0 inline-flex items-center gap-1 text-xs text-primary hover:underline"
+            >
+              {copied ? <Check className="w-3 h-3" /> : <Copy className="w-3 h-3" />}
+              {copied ? "Copied" : "Copy"}
+            </button>
+          </div>
+          <p className="text-[11px] text-muted-foreground">Paste this as your {label}.</p>
+        </>
+      ) : (
+        <p className="text-[11px] text-muted-foreground">
+          No public URL is configured. Set <code className="font-mono">PUBLIC_BOT_URL</code> (a tunnel like
+          {" "}<code className="font-mono">ngrok http 3001</code> in local dev, or your public domain in production) so
+          this shows the exact {label} to paste.
+          {platform === "slack" && " Or use Socket Mode (App-Level Token) to skip public URLs entirely."}
+        </p>
+      )}
+    </div>
+  );
+}
+
 function StepInstructions({
   platform,
   instructions,
@@ -464,6 +576,7 @@ function StepInstructions({
         </h3>
         <p className="text-xs text-muted-foreground">Follow these steps before entering your credentials.</p>
       </div>
+      {(platform === "slack" || platform === "teams") && <WebhookUrlCallout platform={platform} />}
       <div className="space-y-1">
         {instructions.map((instruction, i) => (
           <div key={i} className="flex gap-3 items-start px-3 py-2.5 rounded-lg hover:bg-muted/40 transition-colors">

--- a/web/src/components/settings/ConnectionWizard.tsx
+++ b/web/src/components/settings/ConnectionWizard.tsx
@@ -19,9 +19,9 @@ type Step = 1 | 2 | 3 | 4 | 5;
 
 const SLACK_INSTRUCTIONS = [
   { text: "Go to", link: "https://api.slack.com/apps", linkText: "api.slack.com/apps" },
-  { text: "Click Create New App → From scratch" },
+  { text: "Create New App → From scratch, then open your app." },
   {
-    text: "Under OAuth & Permissions → Scopes → Bot Token Scopes, turn on all required scopes:",
+    text: "OAuth & Permissions → Bot Token Scopes — add:",
     details: [
       "channels:history",
       "channels:read",
@@ -31,22 +31,18 @@ const SLACK_INSTRUCTIONS = [
       "users:read",
     ],
   },
-  { text: "Click Install to Workspace and authorize" },
-  { text: "Copy the Bot User OAuth Token (starts with xoxb-)" },
+  { text: "Install to Workspace and authorize." },
+  { text: "OAuth & Permissions → copy the Bot User OAuth Token (starts with xoxb-)." },
   {
-    text: "Choose how Slack delivers events — pick ONE:",
+    text: "Pick how Slack delivers events — Socket Mode is recommended (no public URL, survives restarts):",
     details: [
-      "A) Socket Mode (recommended, no public URL): Settings → Socket Mode → enable it, then Basic Information → App-Level Tokens → generate a token with the connections:write scope. Copy it (starts with xapp-).",
-      "B) Events API (needs a public URL): Basic Information → copy the Signing Secret instead. You will also set a Request URL in the next step.",
+      "Socket Mode → Settings → Socket Mode (enable) → Basic Information → App-Level Tokens → generate with scope connections:write → copy the xapp- token",
+      "Events API → Basic Information → copy the Signing Secret, then set the Request URL shown above",
     ],
   },
   {
-    text: "Under Event Subscriptions → Subscribe to bot events, add the events the bot listens for (both modes):",
+    text: "Event Subscriptions → Subscribe to bot events — add (both modes):",
     details: ["app_mention", "message.channels", "message.groups"],
-  },
-  {
-    text: "Events API only — set Event Subscriptions → Request URL to your public bot URL + /api/slack and wait for the green Verified ✓ (skip this entirely if you chose Socket Mode):",
-    details: ["https://<your-public-url>/api/slack"],
   },
 ];
 
@@ -279,10 +275,12 @@ export function ConnectionWizard({ platform, onClose, onComplete }: ConnectionWi
         onClick={onClose}
       />
 
-      {/* Dialog */}
-      <div className="relative z-10 w-full max-w-3xl bg-card border border-border rounded-2xl shadow-2xl overflow-hidden">
+      {/* Dialog — flex column capped at the viewport so a tall step (e.g. the
+          Slack instructions) scrolls in the middle instead of pushing the
+          footer off-screen / overlapping it. */}
+      <div className="relative z-10 flex flex-col w-full max-w-3xl max-h-[90vh] bg-card border border-border rounded-2xl shadow-2xl overflow-hidden">
         {/* Header */}
-        <div className="px-6 py-4 border-b border-border space-y-3">
+        <div className="shrink-0 px-6 py-4 border-b border-border space-y-3">
           <div className="flex items-center justify-between">
             <h2 className="text-base font-semibold text-foreground">
               Connect {{ slack: "Slack", discord: "Discord", teams: "Microsoft Teams", telegram: "Telegram", mattermost: "Mattermost" }[platform]}
@@ -298,8 +296,9 @@ export function ConnectionWizard({ platform, onClose, onComplete }: ConnectionWi
           <StepIndicator current={step} />
         </div>
 
-        {/* Content */}
-        <div className="px-6 py-5">
+        {/* Content — scrolls independently; min-h-0 lets it shrink within the
+            flex column so overflow-y actually engages. */}
+        <div className="flex-1 min-h-0 overflow-y-auto px-6 py-5">
           {step === 1 && (
             <StepInstructions
               platform={platform}
@@ -338,7 +337,7 @@ export function ConnectionWizard({ platform, onClose, onComplete }: ConnectionWi
         </div>
 
         {/* Footer */}
-        <div className="flex items-center justify-between px-6 py-4 border-t border-border bg-muted/30">
+        <div className="shrink-0 flex items-center justify-between px-6 py-4 border-t border-border bg-muted/30">
           <div>
             {step === 2 && (
               <button


### PR DESCRIPTION
## Why

After a host reboot, **Slack (Events API) and Teams (Bot Framework) bot replies stop while Discord/Mattermost keep working.** Slack/Teams receive messages via an *inbound* public webhook (a tunnel in local dev) that dies with the host; Discord/Mattermost connect *outbound* and auto-reconnect. Two gaps made this worse:

- The Slack adapter ran in **Events API (webhook) mode** even though the SDK supports **Socket Mode** (outbound, no tunnel).
- **Nothing in the product surfaced the public URL** or told users a tunnel was required. The Slack wizard was even missing the Event Subscriptions step, and Teams showed a literal `<your-host>` placeholder.

## What

**1. Slack Socket Mode** — when a connection provides an `appToken` (`xapp-…`), the bot builds the adapter with `mode:"socket"`; the socket auto-starts in the adapter's `initialize()` during the eager `Chat.initialize()` (no custom supervisor, unlike the Discord gateway). Slack then behaves like Discord/Mattermost: no public URL, survives restarts. Falls back to Events API (`signingSecret`) otherwise. The decision is an extracted, unit-tested pure function `planSlackAdapter()`. Env-fallback (`index.ts`) and env-seed (`app.py`) honour `SLACK_APP_TOKEN`.

**2. `PUBLIC_BOT_URL` + `GET /api/config/connectivity`** — a single host-wide setting; the endpoint returns the exact Slack Request URL and Teams messaging endpoint. The connection wizard renders them (with a copy button) or shows guidance when unset.

**3. Wizard + docs** — adds the missing Slack Event Subscriptions step, an `app_token` field, a Socket-Mode-vs-Events explainer, a `make tunnel NGROK_DOMAIN=…` helper, and static-ngrok-domain guidance.

Config-driven so it syncs cleanly to EE: EE sets `PUBLIC_BOT_URL` to its real domain and uses Slack webhook mode (multi-workspace OAuth); OSS/local defaults to Socket Mode + an optional tunnel for Teams.

## Tests

- Bot: **417 pass** (+7 for `planSlackAdapter`), 0 lint errors, build clean
- Backend: **16 config tests** (+5 for `public_bot_base` / connectivity), ruff clean
- Web: typecheck clean, lint clean, **98 settings tests pass**
- Deployed to a local stack and verified live: connectivity endpoint serves the tunnel URL; bot logs the new mode-selection line.

## Constraints / trade-offs

- Slack Socket Mode is **single-workspace only** (incompatible with multi-workspace OAuth) — EE multi-tenant keeps webhook mode behind its public domain.
- Teams (Bot Framework) has **no Socket Mode equivalent** — always needs a public messaging endpoint.
- `PUBLIC_BOT_URL` is host-wide (not per-connection) and read at runtime via the endpoint (the tunnel URL is dynamic, so a build-time `VITE_` var won't do).

## Not covered by tests

- Live Slack Socket Mode handshake (needs a real `xapp-` token)
- Live Teams delivery on a freshly-pointed endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)