### PR TITLE
feat: in-UI credential editing + Socket-Mode switch, safe Remove, and reboot-proof tunnel

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -122,6 +122,18 @@ BRIDGE_URL=http://localhost:3001
 # platforms / Slack Socket Mode.
 PUBLIC_BOT_URL=
 
+# Reboot-proofing for the tunnel (used by `make tunnel-up` / scripts.tunnel_up,
+# and the macOS launchd agent in deploy/launchd/). Only relevant when running
+# inbound platforms (Slack Events API / Teams) behind a local tunnel.
+#   NGROK_DOMAIN: a reserved STATIC ngrok domain (free tier includes one at
+#     dashboard.ngrok.com/domains). With it, the public URL never changes across
+#     restarts, so Slack/Teams are configured once. Without it, the tunnel URL is
+#     ephemeral and tunnel_up re-syncs PUBLIC_BOT_URL + the Teams endpoint each run.
+NGROK_DOMAIN=
+#   TEAMS_APP_ID: the Teams app id from `teams app list` whose messaging endpoint
+#     tunnel_up should re-point to {PUBLIC_BOT_URL}/api/teams. Leave blank to skip.
+TEAMS_APP_ID=
+
 # ── Reply-feature tuning (all optional; safe defaults shown) ─────────────────
 # BOT_SESSION_SECRET: HMAC key for per-thread conversation-memory session ids.
 #   SET THIS IN PRODUCTION — when unset, session ids are derived from a known

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install test lint dev stop docker-up docker-down clean demo demo-regenerate-fixtures reembed-all reembed-resume reembed-dry-run tunnel
+.PHONY: install test lint dev stop docker-up docker-down clean demo demo-regenerate-fixtures reembed-all reembed-resume reembed-dry-run tunnel tunnel-up tunnel-install tunnel-uninstall
 
 install:
 	uv sync --extra dev
@@ -60,6 +60,27 @@ tunnel:
 		echo "Starting ngrok on an EPHEMERAL url → :3001 (set NGROK_DOMAIN for a stable one)"; \
 		ngrok http 3001; \
 	fi
+
+# Reboot-proof tunnel for inbound platforms (Slack Events API, Teams): start the
+# tunnel, write PUBLIC_BOT_URL into .env, restart the backend, and re-point the
+# Teams messaging endpoint — then hold the tunnel open. Config via .env
+# (NGROK_DOMAIN, TEAMS_APP_ID) or flags. `make tunnel-up DRY_RUN=1` to preview.
+tunnel-up:
+	uv run python -m scripts.tunnel_up $(if $(NGROK_DOMAIN),--domain $(NGROK_DOMAIN),) $(if $(DRY_RUN),--dry-run,)
+
+# Install/uninstall the macOS launchd agent so the tunnel comes up at login and
+# survives reboots (re-syncs PUBLIC_BOT_URL + Teams endpoint each start).
+tunnel-install:
+	@sed -e "s#__REPO_DIR__#$(CURDIR)#g" -e "s#__UV__#$$(command -v uv)#g" \
+		deploy/launchd/ai.beever.tunnel.plist.template \
+		> $(HOME)/Library/LaunchAgents/ai.beever.tunnel.plist
+	launchctl load -w $(HOME)/Library/LaunchAgents/ai.beever.tunnel.plist
+	@echo "Installed launchd agent. Logs: /tmp/beever-tunnel.{out,err}.log"
+
+tunnel-uninstall:
+	-launchctl unload -w $(HOME)/Library/LaunchAgents/ai.beever.tunnel.plist
+	-rm -f $(HOME)/Library/LaunchAgents/ai.beever.tunnel.plist
+	@echo "Removed launchd tunnel agent."
 
 demo:
 	docker compose -f docker-compose.yml -f demo/docker-compose.demo.yml up --build

--- a/deploy/launchd/ai.beever.tunnel.plist.template
+++ b/deploy/launchd/ai.beever.tunnel.plist.template
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  macOS launchd agent that keeps the public tunnel up across reboots so inbound
+  webhook platforms (Slack Events API, Microsoft Teams) keep working without
+  manual re-pointing. Discord / Mattermost / Slack Socket Mode do not need this.
+
+  Install (replace the placeholders with absolute paths):
+    sed -e "s#__REPO_DIR__#$(pwd)#g" -e "s#__UV__#$(command -v uv)#g" \
+      deploy/launchd/ai.beever.tunnel.plist.template \
+      > ~/Library/LaunchAgents/ai.beever.tunnel.plist
+    launchctl load -w ~/Library/LaunchAgents/ai.beever.tunnel.plist
+
+  Stop / uninstall:
+    launchctl unload -w ~/Library/LaunchAgents/ai.beever.tunnel.plist
+
+  Logs: /tmp/beever-tunnel.out.log and /tmp/beever-tunnel.err.log
+
+  Tip: reserve a free static ngrok domain (dashboard.ngrok.com/domains) and put
+  NGROK_DOMAIN (+ TEAMS_APP_ID) in the repo .env so the URL never changes and the
+  Teams endpoint is configured once.
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>ai.beever.tunnel</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>__UV__</string>
+        <string>run</string>
+        <string>python</string>
+        <string>-m</string>
+        <string>scripts.tunnel_up</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>__REPO_DIR__</string>
+
+    <!-- Start at login and keep the tunnel alive; if ngrok dies, tunnel_up exits
+         and launchd restarts it, which re-syncs PUBLIC_BOT_URL + Teams endpoint. -->
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+
+    <!-- Back off restarts so a misconfig doesn't hot-loop. -->
+    <key>ThrottleInterval</key>
+    <integer>15</integer>
+
+    <key>StandardOutPath</key>
+    <string>/tmp/beever-tunnel.out.log</string>
+    <key>StandardErrorPath</key>
+    <string>/tmp/beever-tunnel.err.log</string>
+</dict>
+</plist>

--- a/docs/guides/reboot-proof-tunnel.md
+++ b/docs/guides/reboot-proof-tunnel.md
@@ -1,0 +1,76 @@
+# Keep Slack & Teams working across reboots
+
+Some chat platforms deliver messages **inbound** to a public webhook, so they
+need a publicly reachable URL:
+
+| Platform | Transport | Needs a public URL/tunnel? |
+|---|---|---|
+| Discord | Outbound WebSocket (Gateway) | No |
+| Mattermost | Outbound WebSocket | No |
+| **Slack — Socket Mode** | Outbound WebSocket | **No** |
+| Slack — Events API | Inbound webhook | Yes |
+| **Microsoft Teams** | Inbound webhook (Bot Framework) | **Yes — always** |
+
+In local dev that public URL is usually an ngrok tunnel. When the machine
+reboots, the tunnel dies and any **ephemeral** URL changes — so Slack (Events
+API) and Teams stop receiving messages until the tunnel is restarted and their
+endpoints are re-pointed. (Discord, Mattermost, and **Slack Socket Mode** are
+unaffected — prefer Socket Mode for Slack to drop it from this list entirely;
+see [slack-setup.md](./slack-setup.md).)
+
+Teams has no Socket Mode equivalent, so it always needs this. Two ways to make
+it survive reboots:
+
+## Option A — Static domain (recommended)
+
+A reserved domain never changes, so you configure Slack/Teams **once**.
+
+1. Reserve the free static domain at <https://dashboard.ngrok.com/domains>.
+2. Put it (and your Teams app id) in `.env`:
+   ```ini
+   NGROK_DOMAIN=your-name.ngrok-free.app
+   PUBLIC_BOT_URL=https://your-name.ngrok-free.app
+   TEAMS_APP_ID=<id from `teams app list`>
+   ```
+3. Point Teams' messaging endpoint (and Slack's Request URL, if you use Events
+   API) at `https://your-name.ngrok-free.app/api/teams` once.
+4. Start the tunnel: `make tunnel NGROK_DOMAIN=your-name.ngrok-free.app`
+   (or use the launchd agent below to auto-start it).
+
+## Option B — `tunnel-up` auto-sync (works with an ephemeral URL too)
+
+`scripts.tunnel_up` starts the tunnel, writes `PUBLIC_BOT_URL` into `.env`,
+restarts the backend, and re-points the Teams messaging endpoint — then holds
+the tunnel open. With a static domain it's effectively one-time; with an
+ephemeral URL it re-syncs every start.
+
+```bash
+make tunnel-up                 # start + sync + hold
+make tunnel-up DRY_RUN=1       # preview without changing anything
+# flags: --no-restart, --no-teams, --domain, --teams-app-id
+```
+
+It reads `NGROK_DOMAIN` / `TEAMS_APP_ID` / `BOT_PORT` from `.env`. Teams
+re-pointing needs the [Teams CLI](https://aka.ms/teams-cli) logged in (`teams
+login`) and `TEAMS_APP_ID` set; otherwise that step is skipped with a notice.
+
+## Auto-start at login (macOS launchd)
+
+So the tunnel comes up on every reboot without you running anything:
+
+```bash
+make tunnel-install      # installs + loads ~/Library/LaunchAgents/ai.beever.tunnel.plist
+# ...
+make tunnel-uninstall    # stop + remove it
+```
+
+The agent runs `tunnel-up` with `RunAtLoad` + `KeepAlive`, so it starts at login
+and, if ngrok dies, relaunches and re-syncs. Logs: `/tmp/beever-tunnel.out.log`
+and `/tmp/beever-tunnel.err.log`. The template lives at
+`deploy/launchd/ai.beever.tunnel.plist.template`.
+
+## Production
+
+No tunnel: set `PUBLIC_BOT_URL` to your real domain (e.g.
+`https://beever-atlas.example.com`) and point Slack/Teams at it. The webhook
+paths are `/api/slack` and `/api/teams`.

--- a/scripts/tunnel_up.py
+++ b/scripts/tunnel_up.py
@@ -1,0 +1,256 @@
+"""Bring up the public tunnel and keep inbound webhooks (Slack Events API,
+Microsoft Teams) reachable across restarts — the reboot-proofing for platforms
+that can't use an outbound transport.
+
+Discord, Mattermost, and Slack Socket Mode connect outbound and need none of
+this. Teams (Bot Framework) has no Socket Mode equivalent, so it always needs a
+public messaging endpoint — this script automates pointing it at the tunnel.
+
+What it does (idempotent):
+  1. Start ngrok on the bot port (static domain if NGROK_DOMAIN is set, else an
+     ephemeral URL). If an ngrok agent is already running, reuse it.
+  2. Read the public https URL from ngrok's local API (127.0.0.1:4040).
+  3. Write PUBLIC_BOT_URL into .env (so the backend's /api/config/connectivity
+     shows the right webhook URLs).
+  4. Restart the backend container so it picks up the new PUBLIC_BOT_URL.
+  5. Re-point the Teams messaging endpoint to <url>/api/teams (needs the Teams
+     CLI logged in + TEAMS_APP_ID set).
+  6. Stay alive as ngrok's parent. If ngrok exits, this exits too — so a launchd
+     KeepAlive agent restarts the whole thing and re-syncs after a reboot.
+
+With a STATIC domain the URL never changes, so steps 3-5 are effectively
+one-time and reboots "just work". With an ephemeral URL they re-run every start.
+
+Usage:
+    uv run python -m scripts.tunnel_up                 # start + sync + hold
+    uv run python -m scripts.tunnel_up --dry-run       # print plan, change nothing
+    uv run python -m scripts.tunnel_up --no-restart    # skip docker restart
+    uv run python -m scripts.tunnel_up --no-teams      # skip Teams re-point
+    make tunnel-up [NGROK_DOMAIN=your-name.ngrok-free.app]
+
+Config (CLI flag > env var > .env):
+    NGROK_DOMAIN   reserved static ngrok domain (recommended; free tier has one)
+    TEAMS_APP_ID   Teams app id from `teams app list` (the messaging-endpoint owner)
+    BOT_PORT       local bot port (default 3001)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import signal
+import subprocess
+import sys
+import time
+import urllib.request
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+ENV_PATH = REPO_ROOT / ".env"
+NGROK_API = "http://127.0.0.1:4040/api/tunnels"
+
+
+def _log(msg: str) -> None:
+    print(f"[tunnel_up] {msg}", flush=True)
+
+
+def _read_env_file() -> dict[str, str]:
+    """Parse simple KEY=VALUE lines from .env (best-effort, ignores comments)."""
+    values: dict[str, str] = {}
+    if not ENV_PATH.exists():
+        return values
+    for line in ENV_PATH.read_text().splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#") or "=" not in stripped:
+            continue
+        key, _, val = stripped.partition("=")
+        values[key.strip()] = val.strip()
+    return values
+
+
+def _cfg(name: str, cli_value: str | None, env_file: dict[str, str]) -> str:
+    """Resolve config: CLI flag > process env > .env file > ''."""
+    if cli_value:
+        return cli_value
+    return os.environ.get(name) or env_file.get(name, "")
+
+
+def _get_ngrok_url() -> str | None:
+    """Return the https public_url from a running ngrok agent, or None."""
+    try:
+        with urllib.request.urlopen(NGROK_API, timeout=3) as resp:  # noqa: S310 (localhost)
+            data = json.load(resp)
+    except Exception:
+        return None
+    for tunnel in data.get("tunnels", []):
+        url = tunnel.get("public_url", "")
+        if url.startswith("https://"):
+            return url
+    return None
+
+
+def _start_ngrok(port: str, domain: str) -> subprocess.Popen | None:
+    """Start ngrok as a child process. Returns the Popen, or None on dry-run."""
+    cmd = ["ngrok", "http", port, "--log=stdout"]
+    if domain:
+        cmd.append(f"--url=https://{domain}")
+    _log(f"starting: {' '.join(cmd)}")
+    return subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+
+def _wait_for_url(timeout_s: int = 30) -> str | None:
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        url = _get_ngrok_url()
+        if url:
+            return url
+        time.sleep(1)
+    return None
+
+
+def _write_public_bot_url(url: str, dry_run: bool) -> None:
+    """Upsert PUBLIC_BOT_URL=<url> in .env, preserving the rest of the file."""
+    if dry_run:
+        _log(f"DRY-RUN would set PUBLIC_BOT_URL={url} in {ENV_PATH}")
+        return
+    lines = ENV_PATH.read_text().splitlines() if ENV_PATH.exists() else []
+    out, replaced = [], False
+    for line in lines:
+        if line.strip().startswith("PUBLIC_BOT_URL="):
+            out.append(f"PUBLIC_BOT_URL={url}")
+            replaced = True
+        else:
+            out.append(line)
+    if not replaced:
+        out.append(f"PUBLIC_BOT_URL={url}")
+    ENV_PATH.write_text("\n".join(out) + "\n")
+    _log(f"set PUBLIC_BOT_URL={url}")
+
+
+def _restart_backend(dry_run: bool) -> None:
+    cmd = ["docker", "compose", "restart", "beever-atlas"]
+    if dry_run:
+        _log(f"DRY-RUN would run: {' '.join(cmd)}")
+        return
+    if not shutil.which("docker"):
+        _log("docker not found; skipping backend restart")
+        return
+    _log("restarting backend container so it serves the new PUBLIC_BOT_URL…")
+    subprocess.run(cmd, cwd=REPO_ROOT, check=False)
+
+
+def _update_teams_endpoint(app_id: str, url: str, dry_run: bool) -> None:
+    if not app_id:
+        _log(
+            "TEAMS_APP_ID not set; skipping Teams endpoint update "
+            "(set it to the id from `teams app list` to auto re-point Teams)"
+        )
+        return
+    endpoint = f"{url}/api/teams"
+    cmd = ["teams", "app", "update", app_id, "--endpoint", endpoint, "-y"]
+    if dry_run:
+        _log(f"DRY-RUN would run: {' '.join(cmd)}")
+        return
+    if not shutil.which("teams"):
+        _log(
+            "teams CLI not found; skipping Teams endpoint update "
+            "(install it + `teams login`, or re-point manually)"
+        )
+        return
+    _log(f"pointing Teams messaging endpoint at {endpoint}…")
+    subprocess.run(cmd, check=False)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--domain", default=None, help="static ngrok domain (overrides NGROK_DOMAIN)"
+    )
+    parser.add_argument(
+        "--teams-app-id", default=None, help="Teams app id (overrides TEAMS_APP_ID)"
+    )
+    parser.add_argument("--port", default=None, help="bot port (overrides BOT_PORT, default 3001)")
+    parser.add_argument(
+        "--no-restart", action="store_true", help="don't restart the backend container"
+    )
+    parser.add_argument("--no-teams", action="store_true", help="don't re-point the Teams endpoint")
+    parser.add_argument("--dry-run", action="store_true", help="print the plan; change nothing")
+    args = parser.parse_args()
+
+    env_file = _read_env_file()
+    domain = _cfg("NGROK_DOMAIN", args.domain, env_file)
+    teams_app_id = _cfg("TEAMS_APP_ID", args.teams_app_id, env_file)
+    port = _cfg("BOT_PORT", args.port, env_file) or "3001"
+
+    if not shutil.which("ngrok") and not args.dry_run:
+        _log("ERROR: ngrok not installed (brew install ngrok)")
+        return 1
+
+    _log(f"port={port} domain={domain or '(ephemeral)'} teams_app_id={teams_app_id or '(unset)'}")
+    if not domain:
+        _log(
+            "NOTE: no NGROK_DOMAIN — using an ephemeral URL that changes each "
+            "start. Reserve a free static domain (dashboard.ngrok.com/domains) "
+            "so reboots stop changing the URL."
+        )
+
+    # Dry-run: compute the URL we'd use without touching anything.
+    if args.dry_run:
+        url = (
+            f"https://{domain}"
+            if domain
+            else (_get_ngrok_url() or "https://<ephemeral>.ngrok-free.app")
+        )
+        _log(f"DRY-RUN plan for url={url}")
+        _write_public_bot_url(url, dry_run=True)
+        if not args.no_restart:
+            _restart_backend(dry_run=True)
+        if not args.no_teams:
+            _update_teams_endpoint(teams_app_id, url, dry_run=True)
+        _log("DRY-RUN complete (nothing changed).")
+        return 0
+
+    # Reuse a running agent, else start our own child.
+    child: subprocess.Popen | None = None
+    url = _get_ngrok_url()
+    if url:
+        _log(f"reusing running ngrok agent at {url}")
+    else:
+        child = _start_ngrok(port, domain)
+        url = _wait_for_url()
+        if not url:
+            _log("ERROR: ngrok did not report a public URL within timeout")
+            if child:
+                child.terminate()
+            return 1
+        _log(f"tunnel up at {url}")
+
+    # Sync everything that depends on the public URL.
+    _write_public_bot_url(url, dry_run=False)
+    if not args.no_restart:
+        _restart_backend(dry_run=False)
+    if not args.no_teams:
+        _update_teams_endpoint(teams_app_id, url, dry_run=False)
+
+    if child is None:
+        _log("ngrok was already running; sync done. Exiting (not holding a child).")
+        return 0
+
+    # Hold ngrok open. On exit (or ngrok death) a launchd KeepAlive agent
+    # restarts us and re-syncs. Forward SIGTERM/SIGINT to ngrok for clean stop.
+    def _terminate(_signum, _frame):
+        _log("received stop signal; terminating ngrok…")
+        child.terminate()
+
+    signal.signal(signal.SIGTERM, _terminate)
+    signal.signal(signal.SIGINT, _terminate)
+    _log("holding tunnel open (Ctrl-C to stop). Slack(Events)/Teams now reachable.")
+    rc = child.wait()
+    _log(f"ngrok exited with code {rc}")
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/beever_atlas/api/connections.py
+++ b/src/beever_atlas/api/connections.py
@@ -36,6 +36,15 @@ class CreateConnectionRequest(BaseModel):
     credentials: dict[str, str]
 
 
+class UpdateCredentialsRequest(BaseModel):
+    """Partial credential update. Only the provided keys are merged over the
+    stored credentials (e.g. add ``app_token`` to switch Slack to Socket Mode);
+    omitted keys are preserved. Empty-string values are ignored, never stored,
+    so a blank field in the UI means "keep existing" rather than "clear"."""
+
+    credentials: dict[str, str]
+
+
 class UpdateChannelsRequest(BaseModel):
     selected_channels: list[str]
 
@@ -431,6 +440,70 @@ async def _refresh_proxy_hosts(stores) -> None:
         await refresh_runtime_proxy_hosts(stores)
     except Exception:
         logger.exception("connections: failed to refresh proxy host allowlist (non-fatal)")
+
+
+@router.patch("/api/connections/{connection_id}/credentials", response_model=ConnectionResponse)
+async def update_connection_credentials(
+    connection_id: str,
+    body: UpdateCredentialsRequest,
+    principal: Principal = Depends(require_user),
+) -> ConnectionResponse:
+    """Rotate/extend a connection's credentials IN PLACE — no delete, no cascade.
+
+    The only non-destructive way to change credentials: deleting a connection
+    cascade-purges its sole-owned channels' data. This merges the provided
+    non-empty keys over the stored credentials (e.g. add ``app_token`` to flip
+    Slack to Socket Mode), re-registers the adapter so the running bot rebuilds
+    with the change, and persists — leaving channels and synced data intact.
+    """
+    from beever_atlas.capabilities.errors import ConnectionAccessDenied
+    from beever_atlas.infra.channel_access import assert_connection_owned
+
+    stores = get_stores()
+    conn = await stores.platform.get_connection(connection_id)
+    if conn is None:
+        raise HTTPException(status_code=404, detail=f"Connection {connection_id!r} not found")
+
+    # Owner-gated, mirroring delete_connection: only the owner may rotate creds.
+    # (Single-tenant fallback admits legacy/un-owned rows.)
+    try:
+        await assert_connection_owned(principal, connection_id)
+    except ConnectionAccessDenied as e:
+        raise HTTPException(
+            status_code=403, detail="You do not have access to this connection."
+        ) from e
+
+    # Merge only non-empty provided keys; a blank field means "keep existing".
+    incoming = {k: v for k, v in body.credentials.items() if isinstance(v, str) and v.strip()}
+    if not incoming:
+        raise HTTPException(status_code=422, detail="No credential values provided to update.")
+
+    try:
+        merged = stores.platform.decrypt_connection_credentials(conn)
+    except Exception as e:
+        raise HTTPException(
+            status_code=500, detail="Could not read existing credentials for this connection."
+        ) from e
+    merged.update(incoming)
+
+    # Re-register so the running bot rebuilds the adapter with the new creds
+    # (raises HTTPException on bridge failure — surfaced to the UI).
+    await _register_adapter(conn.platform, merged, connection_id=connection_id)
+
+    updated = await stores.platform.update_connection(
+        connection_id, credentials=merged, status="connected"
+    )
+    if updated is None:
+        raise HTTPException(status_code=404, detail=f"Connection {connection_id!r} not found")
+
+    logger.info(
+        "Updated credentials for connection id=%s platform=%s (keys=%s)",
+        connection_id,
+        conn.platform,
+        sorted(incoming.keys()),
+    )
+    await _refresh_proxy_hosts(stores)
+    return _to_response(updated)
 
 
 @router.delete("/api/connections/{connection_id}", status_code=204)

--- a/tests/test_connection_credentials_update.py
+++ b/tests/test_connection_credentials_update.py
@@ -1,0 +1,119 @@
+"""Tests for PATCH /api/connections/{id}/credentials — non-destructive
+credential rotation (e.g. flipping Slack to Socket Mode without a data-purging
+delete). The endpoint merges non-empty provided keys over the stored
+credentials, re-registers the adapter, and persists."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+import beever_atlas.api.connections as conns
+from beever_atlas.api.connections import (
+    UpdateCredentialsRequest,
+    update_connection_credentials,
+)
+
+
+def _conn(**overrides) -> SimpleNamespace:
+    base = dict(
+        id="c1",
+        platform="slack",
+        display_name="Slack",
+        selected_channels=[],
+        status="connected",
+        error_message=None,
+        source="ui",
+        created_at=datetime(2026, 1, 1, tzinfo=UTC),
+        updated_at=datetime(2026, 1, 1, tzinfo=UTC),
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+@pytest.fixture
+def store(monkeypatch):
+    st = MagicMock()
+    st.get_connection = AsyncMock(return_value=_conn())
+    st.decrypt_connection_credentials = MagicMock(
+        return_value={"bot_token": "xoxb-1", "signing_secret": "s1"}
+    )
+    st.update_connection = AsyncMock(
+        return_value=_conn(updated_at=datetime(2026, 1, 2, tzinfo=UTC))
+    )
+    monkeypatch.setattr(conns, "get_stores", lambda: SimpleNamespace(platform=st))
+    monkeypatch.setattr(conns, "_register_adapter", AsyncMock())
+    monkeypatch.setattr(conns, "_refresh_proxy_hosts", AsyncMock())
+    from beever_atlas.infra import channel_access
+
+    monkeypatch.setattr(channel_access, "assert_connection_owned", AsyncMock())
+    return st
+
+
+_PRINCIPAL = SimpleNamespace(id="u1")
+
+
+async def test_merges_app_token_over_existing_and_reregisters(store):
+    resp = await update_connection_credentials(
+        "c1",
+        UpdateCredentialsRequest(credentials={"app_token": "xapp-1", "signing_secret": ""}),
+        principal=_PRINCIPAL,
+    )
+    # signing_secret="" is ignored (keep existing); app_token merged in.
+    _, kwargs = store.update_connection.call_args
+    assert kwargs["credentials"] == {
+        "bot_token": "xoxb-1",
+        "signing_secret": "s1",
+        "app_token": "xapp-1",
+    }
+    # Adapter re-registered with the merged credentials so the bot rebuilds.
+    conns._register_adapter.assert_awaited_once()
+    assert resp.id == "c1"
+
+
+async def test_empty_payload_is_422(store):
+    with pytest.raises(HTTPException) as ei:
+        await update_connection_credentials(
+            "c1",
+            UpdateCredentialsRequest(credentials={"app_token": "   "}),
+            principal=_PRINCIPAL,
+        )
+    assert ei.value.status_code == 422
+    # Must not touch the adapter or persist when there's nothing to do.
+    conns._register_adapter.assert_not_awaited()
+    store.update_connection.assert_not_awaited()
+
+
+async def test_unknown_connection_is_404(store):
+    store.get_connection = AsyncMock(return_value=None)
+    with pytest.raises(HTTPException) as ei:
+        await update_connection_credentials(
+            "missing",
+            UpdateCredentialsRequest(credentials={"app_token": "xapp-1"}),
+            principal=_PRINCIPAL,
+        )
+    assert ei.value.status_code == 404
+
+
+async def test_owner_gate_denies_non_owner(store, monkeypatch):
+    from beever_atlas.capabilities.errors import ConnectionAccessDenied
+    from beever_atlas.infra import channel_access
+
+    monkeypatch.setattr(
+        channel_access,
+        "assert_connection_owned",
+        AsyncMock(side_effect=ConnectionAccessDenied("nope")),
+    )
+    with pytest.raises(HTTPException) as ei:
+        await update_connection_credentials(
+            "c1",
+            UpdateCredentialsRequest(credentials={"app_token": "xapp-1"}),
+            principal=_PRINCIPAL,
+        )
+    assert ei.value.status_code == 403
+    # Denied before any write.
+    store.update_connection.assert_not_awaited()

--- a/web/src/components/settings/ConfirmRemoveDialog.tsx
+++ b/web/src/components/settings/ConfirmRemoveDialog.tsx
@@ -1,0 +1,91 @@
+import { AlertTriangle, X } from "lucide-react";
+import type { PlatformConnection } from "@/lib/types";
+
+interface ConfirmRemoveDialogProps {
+  connection: PlatformConnection;
+  onCancel: () => void;
+  onConfirm: (cascade: boolean) => void;
+}
+
+export function ConfirmRemoveDialog({ connection, onCancel, onConfirm }: ConfirmRemoveDialogProps) {
+  const displayName = connection.display_name || connection.platform;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      {/* Backdrop */}
+      <div
+        className="absolute inset-0 bg-black/40 backdrop-blur-sm"
+        onClick={onCancel}
+      />
+
+      {/* Dialog */}
+      <div className="relative z-10 flex flex-col w-full max-w-md bg-card border border-border rounded-2xl shadow-2xl overflow-hidden">
+        {/* Header */}
+        <div className="shrink-0 px-6 py-4 border-b border-border flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <AlertTriangle className="w-4 h-4 text-rose-500" />
+            <h2 className="text-base font-semibold text-foreground">
+              Remove {displayName}?
+            </h2>
+          </div>
+          <button
+            type="button"
+            onClick={onCancel}
+            className="w-8 h-8 flex items-center justify-center rounded-lg hover:bg-muted transition-colors"
+          >
+            <X className="w-4 h-4 text-muted-foreground" />
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="px-6 py-5 space-y-4">
+          <p className="text-sm text-foreground">
+            Removing this connection will disconnect{" "}
+            <span className="font-medium">{displayName}</span> from Beever Atlas.
+          </p>
+
+          <div className="rounded-lg bg-rose-500/10 border border-rose-500/20 px-4 py-3 space-y-1.5">
+            <p className="text-xs font-semibold text-rose-600 dark:text-rose-400 uppercase tracking-wide">
+              Warning — data loss
+            </p>
+            <p className="text-sm text-foreground/80">
+              This connection's channels may have synced messages, wiki pages, and facts. If those channels are{" "}
+              <span className="font-medium">only used by this connection</span>, removing with data deletion will{" "}
+              <span className="font-medium text-rose-600 dark:text-rose-400">permanently delete</span> all of that synced data.
+            </p>
+          </div>
+
+          <p className="text-xs text-muted-foreground">
+            If you want to preserve the synced data (e.g. to reconnect later or keep the wiki), choose{" "}
+            <span className="font-medium text-foreground">Remove, keep data</span>.
+          </p>
+        </div>
+
+        {/* Footer */}
+        <div className="shrink-0 flex items-center justify-end gap-2 px-6 py-4 border-t border-border bg-muted/30 flex-wrap">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-border text-sm font-medium text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={() => onConfirm(false)}
+            className="inline-flex items-center gap-1.5 px-4 py-1.5 rounded-lg border border-border text-sm font-medium text-foreground hover:bg-muted transition-colors"
+          >
+            Remove, keep data
+          </button>
+          <button
+            type="button"
+            onClick={() => onConfirm(true)}
+            className="inline-flex items-center gap-1.5 px-4 py-1.5 rounded-lg bg-rose-600 text-white text-sm font-medium hover:bg-rose-700 transition-colors"
+          >
+            Remove &amp; delete data
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/settings/ConnectionWizard.tsx
+++ b/web/src/components/settings/ConnectionWizard.tsx
@@ -7,7 +7,7 @@ import { useCreateConnection } from "@/hooks/useConnections";
 import { useConnectionChannels, useUpdateChannels } from "@/hooks/useConnections";
 import type { PlatformConnection } from "@/lib/types";
 
-type Platform = "slack" | "discord" | "teams" | "telegram" | "mattermost";
+export type Platform = "slack" | "discord" | "teams" | "telegram" | "mattermost";
 
 interface ConnectionWizardProps {
   platform: Platform;
@@ -95,7 +95,7 @@ const MATTERMOST_INSTRUCTIONS = [
   { text: "Add the bot user to any channels where it should read from. The bot will only receive events from channels it is a member of" },
 ];
 
-interface CredentialField {
+export interface CredentialField {
   key: string;
   label: string;
   placeholder: string;
@@ -131,7 +131,7 @@ function validateAadGuid(label: string) {
       : `${label} must look like xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`;
 }
 
-const CREDENTIAL_FIELDS: Record<Platform, CredentialField[]> = {
+export const CREDENTIAL_FIELDS: Record<Platform, CredentialField[]> = {
   slack: [
     { key: "bot_token", label: "Bot Token", placeholder: "xoxb-...", type: "password" },
     {

--- a/web/src/components/settings/EditCredentialsDialog.tsx
+++ b/web/src/components/settings/EditCredentialsDialog.tsx
@@ -1,0 +1,165 @@
+import { useState } from "react";
+import { X, Loader2, AlertCircle, KeyRound } from "lucide-react";
+import { useUpdateCredentials } from "@/hooks/useConnections";
+import { CREDENTIAL_FIELDS } from "./ConnectionWizard";
+import type { PlatformConnection } from "@/lib/types";
+import type { Platform } from "./ConnectionWizard";
+
+interface EditCredentialsDialogProps {
+  connection: PlatformConnection;
+  onClose: () => void;
+  onSaved: () => void;
+}
+
+const PLATFORM_LABELS: Record<Platform, string> = {
+  slack: "Slack",
+  discord: "Discord",
+  teams: "Microsoft Teams",
+  telegram: "Telegram",
+  mattermost: "Mattermost",
+};
+
+export function EditCredentialsDialog({ connection, onClose, onSaved }: EditCredentialsDialogProps) {
+  const [values, setValues] = useState<Record<string, string>>({});
+  const { update, loading, error } = useUpdateCredentials();
+
+  // Only render for platforms that have credential fields
+  const platform = connection.platform as Platform;
+  const fields = CREDENTIAL_FIELDS[platform] ?? [];
+
+  const anyFilled = fields.some((f) => (values[f.key] ?? "").trim().length > 0);
+
+  function handleChange(key: string, value: string) {
+    setValues((prev) => ({ ...prev, [key]: value }));
+  }
+
+  async function handleSave() {
+    const filled: Record<string, string> = {};
+    for (const f of fields) {
+      const v = (values[f.key] ?? "").trim();
+      if (v) filled[f.key] = v;
+    }
+    await update(connection.id, filled);
+    onSaved();
+  }
+
+  const platformLabel = PLATFORM_LABELS[platform] ?? connection.platform;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      {/* Backdrop */}
+      <div
+        className="absolute inset-0 bg-black/40 backdrop-blur-sm"
+        onClick={onClose}
+      />
+
+      {/* Dialog */}
+      <div className="relative z-10 flex flex-col w-full max-w-lg max-h-[90vh] bg-card border border-border rounded-2xl shadow-2xl overflow-hidden">
+        {/* Header */}
+        <div className="shrink-0 px-6 py-4 border-b border-border flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <KeyRound className="w-4 h-4 text-muted-foreground" />
+            <h2 className="text-base font-semibold text-foreground">
+              Edit {platformLabel} credentials
+            </h2>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="w-8 h-8 flex items-center justify-center rounded-lg hover:bg-muted transition-colors"
+          >
+            <X className="w-4 h-4 text-muted-foreground" />
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="flex-1 min-h-0 overflow-y-auto px-6 py-5 space-y-4">
+          <p className="text-xs text-muted-foreground">
+            Leave any field blank to keep its current value. Only filled fields will be updated.
+          </p>
+
+          {fields.map((field) => {
+            const isAppToken = field.key === "app_token" && platform === "slack";
+            return (
+              <div key={field.key}>
+                <label className="block text-xs font-medium text-foreground mb-1.5">
+                  {field.label}
+                  {field.optional && (
+                    <span className="ml-1 text-muted-foreground font-normal">(optional)</span>
+                  )}
+                </label>
+                {field.enum ? (
+                  <select
+                    value={values[field.key] ?? ""}
+                    onChange={(e) => handleChange(field.key, e.target.value)}
+                    className="w-full h-9 px-3 rounded-lg border border-border bg-background text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary/20 font-mono"
+                  >
+                    <option value="">— keep current —</option>
+                    {field.enum.map((opt) => (
+                      <option key={opt} value={opt}>{opt}</option>
+                    ))}
+                  </select>
+                ) : (
+                  <input
+                    type="password"
+                    value={values[field.key] ?? ""}
+                    onChange={(e) => handleChange(field.key, e.target.value)}
+                    placeholder={field.placeholder}
+                    className="w-full h-9 px-3 rounded-lg border border-border bg-background text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/20 font-mono"
+                    autoComplete="new-password"
+                    spellCheck={false}
+                  />
+                )}
+                {isAppToken ? (
+                  // Emphasize the Socket Mode token; prefer the shared field hint.
+                  <p className="text-[11px] text-primary/80 mt-1 leading-snug">
+                    {field.hint ??
+                      "Add your App-Level Token (xapp-…) to switch this workspace to Socket Mode — no public URL/tunnel needed, survives restarts."}
+                  </p>
+                ) : field.hint ? (
+                  // Surface the same setup guidance the wizard shows (e.g. Teams
+                  // tenant_id is required). The "leave blank = keep" note at the
+                  // top of the body covers fields without a hint.
+                  <p className="text-[11px] text-muted-foreground/85 mt-1 leading-snug">
+                    {field.hint}
+                  </p>
+                ) : null}
+              </div>
+            );
+          })}
+
+          {error && (
+            <div className="flex items-center gap-2 rounded-lg bg-rose-500/10 border border-rose-500/20 px-3 py-2.5">
+              <AlertCircle className="w-4 h-4 text-rose-500 shrink-0" />
+              <p className="text-xs text-rose-600 dark:text-rose-400">{error}</p>
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="shrink-0 flex items-center justify-end gap-2 px-6 py-4 border-t border-border bg-muted/30">
+          <button
+            type="button"
+            onClick={onClose}
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-border text-sm font-medium text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={handleSave}
+            disabled={!anyFilled || loading}
+            className="inline-flex items-center gap-1.5 px-4 py-1.5 rounded-lg bg-primary text-primary-foreground text-sm font-medium hover:bg-primary/90 transition-colors disabled:opacity-50 disabled:pointer-events-none"
+          >
+            {loading ? (
+              <Loader2 className="w-4 h-4 animate-spin" />
+            ) : (
+              <KeyRound className="w-4 h-4" />
+            )}
+            Save
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/settings/PlatformCard.tsx
+++ b/web/src/components/settings/PlatformCard.tsx
@@ -1,4 +1,4 @@
-import { MessageSquare, XCircle, AlertCircle, Settings, Trash2, RefreshCw, MonitorSmartphone, Send, FileText } from "lucide-react";
+import { MessageSquare, XCircle, AlertCircle, Settings, Trash2, RefreshCw, MonitorSmartphone, Send, FileText, KeyRound } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useTheme } from "@/hooks/useTheme";
 import { getPlatformBadgeStyle } from "@/lib/platform-badge";
@@ -8,6 +8,7 @@ interface PlatformCardProps {
   connection: PlatformConnection;
   onDisconnect: () => void;
   onManage: () => void;
+  onEdit: () => void;
 }
 
 function SlackIcon({ className }: { className?: string }) {
@@ -46,7 +47,7 @@ const PLATFORM_META: Record<
   file: { label: "Uploaded files (CSV / TSV / JSONL)", Icon: FileText },
 };
 
-export function PlatformCard({ connection, onDisconnect, onManage }: PlatformCardProps) {
+export function PlatformCard({ connection, onDisconnect, onManage, onEdit }: PlatformCardProps) {
   const { resolvedTheme } = useTheme();
   const isDark = resolvedTheme === "dark";
   const meta = PLATFORM_META[connection.platform] ?? { label: connection.platform, Icon: MessageSquare };
@@ -120,6 +121,17 @@ export function PlatformCard({ connection, onDisconnect, onManage }: PlatformCar
             {!isEnv && (
               <button
                 type="button"
+                onClick={onEdit}
+                title="Edit credentials"
+                className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg border border-border text-sm font-medium text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
+              >
+                <KeyRound className="w-4 h-4" />
+                Edit credentials
+              </button>
+            )}
+            {!isEnv && (
+              <button
+                type="button"
                 onClick={onDisconnect}
                 className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg border border-border text-sm font-medium text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
               >
@@ -138,6 +150,16 @@ export function PlatformCard({ connection, onDisconnect, onManage }: PlatformCar
               <Settings className="w-4 h-4" />
               Manage Channels
             </button>
+            {!isEnv && (
+              <button
+                type="button"
+                onClick={onEdit}
+                title="Edit credentials"
+                className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg text-sm font-medium text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
+              >
+                <KeyRound className="w-4 h-4" />
+              </button>
+            )}
             {!isEnv && (
               <button
                 type="button"

--- a/web/src/components/settings/__tests__/ConfirmRemoveDialog.test.tsx
+++ b/web/src/components/settings/__tests__/ConfirmRemoveDialog.test.tsx
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ConfirmRemoveDialog } from "../ConfirmRemoveDialog";
+import type { PlatformConnection } from "@/lib/types";
+
+function makeConnection(overrides: Partial<PlatformConnection> = {}): PlatformConnection {
+  return {
+    id: "conn-1",
+    platform: "slack",
+    display_name: "Engineering Workspace",
+    status: "connected",
+    error_message: null,
+    selected_channels: ["C001"],
+    source: "ui",
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("ConfirmRemoveDialog", () => {
+  let onCancel: Mock<() => void>;
+  let onConfirm: Mock<(cascade: boolean) => void>;
+
+  beforeEach(() => {
+    onCancel = vi.fn();
+    onConfirm = vi.fn();
+  });
+
+  it("renders the connection display_name in the title", () => {
+    render(
+      <ConfirmRemoveDialog
+        connection={makeConnection()}
+        onCancel={onCancel}
+        onConfirm={onConfirm}
+      />,
+    );
+    expect(screen.getByText("Remove Engineering Workspace?")).toBeTruthy();
+  });
+
+  it("falls back to platform name when display_name is empty", () => {
+    render(
+      <ConfirmRemoveDialog
+        connection={makeConnection({ display_name: "" })}
+        onCancel={onCancel}
+        onConfirm={onConfirm}
+      />,
+    );
+    expect(screen.getByText("Remove slack?")).toBeTruthy();
+  });
+
+  it("calls onConfirm(true) when 'Remove & delete data' is clicked", () => {
+    render(
+      <ConfirmRemoveDialog
+        connection={makeConnection()}
+        onCancel={onCancel}
+        onConfirm={onConfirm}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /remove.*delete data/i }));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect(onConfirm).toHaveBeenCalledWith(true);
+  });
+
+  it("calls onConfirm(false) when 'Remove, keep data' is clicked", () => {
+    render(
+      <ConfirmRemoveDialog
+        connection={makeConnection()}
+        onCancel={onCancel}
+        onConfirm={onConfirm}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /remove, keep data/i }));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect(onConfirm).toHaveBeenCalledWith(false);
+  });
+
+  it("calls onCancel when Cancel button is clicked", () => {
+    render(
+      <ConfirmRemoveDialog
+        connection={makeConnection()}
+        onCancel={onCancel}
+        onConfirm={onConfirm}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /^cancel$/i }));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows the data loss warning text", () => {
+    render(
+      <ConfirmRemoveDialog
+        connection={makeConnection()}
+        onCancel={onCancel}
+        onConfirm={onConfirm}
+      />,
+    );
+    expect(screen.getByText(/permanently delete/i)).toBeTruthy();
+  });
+});

--- a/web/src/components/settings/__tests__/EditCredentialsDialog.test.tsx
+++ b/web/src/components/settings/__tests__/EditCredentialsDialog.test.tsx
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { EditCredentialsDialog } from "../EditCredentialsDialog";
+import type { PlatformConnection } from "@/lib/types";
+
+// Mock useUpdateCredentials hook
+vi.mock("@/hooks/useConnections", () => ({
+  useUpdateCredentials: () => ({
+    update: mockUpdate,
+    loading: false,
+    error: null,
+  }),
+}));
+
+let mockUpdate: Mock<(id: string, credentials: Record<string, string>) => Promise<PlatformConnection>>;
+
+function makeConnection(overrides: Partial<PlatformConnection> = {}): PlatformConnection {
+  return {
+    id: "conn-1",
+    platform: "slack",
+    display_name: "Engineering Workspace",
+    status: "connected",
+    error_message: null,
+    selected_channels: ["C001", "C002"],
+    source: "ui",
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("EditCredentialsDialog", () => {
+  let onClose: Mock<() => void>;
+  let onSaved: Mock<() => void>;
+
+  beforeEach(() => {
+    onClose = vi.fn();
+    onSaved = vi.fn();
+    mockUpdate = vi.fn<(id: string, credentials: Record<string, string>) => Promise<PlatformConnection>>().mockResolvedValue(makeConnection());
+  });
+
+  it("renders the dialog with the platform name in the header", () => {
+    render(
+      <EditCredentialsDialog
+        connection={makeConnection()}
+        onClose={onClose}
+        onSaved={onSaved}
+      />,
+    );
+    expect(screen.getByText("Edit Slack credentials")).toBeTruthy();
+  });
+
+  it("Save is disabled when all fields are blank", () => {
+    render(
+      <EditCredentialsDialog
+        connection={makeConnection()}
+        onClose={onClose}
+        onSaved={onSaved}
+      />,
+    );
+    const saveBtn = screen.getByRole("button", { name: /save/i });
+    expect((saveBtn as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("Save becomes enabled when at least one field is filled", () => {
+    render(
+      <EditCredentialsDialog
+        connection={makeConnection()}
+        onClose={onClose}
+        onSaved={onSaved}
+      />,
+    );
+    const passwordInputs = document.querySelectorAll('input[type="password"]');
+    fireEvent.change(passwordInputs[0], { target: { value: "xoxb-test-token" } });
+    const saveBtn = screen.getByRole("button", { name: /save/i });
+    expect((saveBtn as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it("sends only non-empty fields and calls onSaved on success", async () => {
+    render(
+      <EditCredentialsDialog
+        connection={makeConnection()}
+        onClose={onClose}
+        onSaved={onSaved}
+      />,
+    );
+    const passwordInputs = document.querySelectorAll('input[type="password"]');
+    // Fill only the first field (bot_token), leave others blank
+    fireEvent.change(passwordInputs[0], { target: { value: "xoxb-new-token" } });
+
+    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(1));
+    const [id, credentials] = mockUpdate.mock.calls[0];
+    expect(id).toBe("conn-1");
+    // Only the filled field should be sent
+    expect(credentials).toEqual({ bot_token: "xoxb-new-token" });
+    await waitFor(() => expect(onSaved).toHaveBeenCalledTimes(1));
+  });
+
+  it("does not send blank fields in the credentials payload", async () => {
+    render(
+      <EditCredentialsDialog
+        connection={makeConnection()}
+        onClose={onClose}
+        onSaved={onSaved}
+      />,
+    );
+    const passwordInputs = document.querySelectorAll('input[type="password"]');
+    // Fill bot_token and app_token, leave signing_secret blank
+    fireEvent.change(passwordInputs[0], { target: { value: "xoxb-token" } });
+    fireEvent.change(passwordInputs[1], { target: { value: "xapp-token" } });
+
+    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(1));
+    const [, credentials] = mockUpdate.mock.calls[0];
+    expect(credentials).toEqual({ bot_token: "xoxb-token", app_token: "xapp-token" });
+    expect("signing_secret" in credentials).toBe(false);
+  });
+
+  it("calls onClose when Cancel is clicked", () => {
+    render(
+      <EditCredentialsDialog
+        connection={makeConnection()}
+        onClose={onClose}
+        onSaved={onSaved}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows the app_token Socket Mode hint for Slack", () => {
+    render(
+      <EditCredentialsDialog
+        connection={makeConnection({ platform: "slack" })}
+        onClose={onClose}
+        onSaved={onSaved}
+      />,
+    );
+    expect(screen.getAllByText(/Socket Mode/).length).toBeGreaterThan(0);
+  });
+});

--- a/web/src/hooks/useConnections.ts
+++ b/web/src/hooks/useConnections.ts
@@ -62,7 +62,7 @@ export function useCreateConnection(): UseCreateConnectionReturn {
 }
 
 export interface UseDeleteConnectionReturn {
-  remove: (id: string) => Promise<void>;
+  remove: (id: string, cascade?: boolean) => Promise<void>;
   loading: boolean;
   error: string | null;
 }
@@ -71,11 +71,11 @@ export function useDeleteConnection(): UseDeleteConnectionReturn {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const remove = useCallback(async (id: string): Promise<void> => {
+  const remove = useCallback(async (id: string, cascade?: boolean): Promise<void> => {
     setLoading(true);
     setError(null);
     try {
-      await api.delete<void>(`/api/connections/${id}`);
+      await api.delete<void>(`/api/connections/${id}?cascade=${cascade !== false}`);
     } catch (err) {
       const msg = err instanceof Error ? err.message : "Failed to delete connection";
       setError(msg);
@@ -86,6 +86,34 @@ export function useDeleteConnection(): UseDeleteConnectionReturn {
   }, []);
 
   return { remove, loading, error };
+}
+
+export interface UseUpdateCredentialsReturn {
+  update: (id: string, credentials: Record<string, string>) => Promise<PlatformConnection>;
+  loading: boolean;
+  error: string | null;
+}
+
+export function useUpdateCredentials(): UseUpdateCredentialsReturn {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const update = useCallback(async (id: string, credentials: Record<string, string>): Promise<PlatformConnection> => {
+    setLoading(true);
+    setError(null);
+    try {
+      const connection = await api.patch<PlatformConnection>(`/api/connections/${id}/credentials`, { credentials });
+      return connection;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "Failed to update credentials";
+      setError(msg);
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  return { update, loading, error };
 }
 
 export interface UseConnectionChannelsReturn {

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -15,6 +15,8 @@ import { PlatformCard } from "@/components/settings/PlatformCard";
 import { ConnectionWizard } from "@/components/settings/ConnectionWizard";
 import { FileImportWizard } from "@/components/settings/FileImportWizard";
 import { ManageChannelsDialog } from "@/components/settings/ManageChannelsDialog";
+import { EditCredentialsDialog } from "@/components/settings/EditCredentialsDialog";
+import { ConfirmRemoveDialog } from "@/components/settings/ConfirmRemoveDialog";
 import type { PlatformConnection } from "@/lib/types";
 
 type Platform = "slack" | "discord" | "teams" | "telegram" | "mattermost";
@@ -31,6 +33,7 @@ export type SettingsOutletContext = {
   onAdd: () => void;
   onDisconnect: (c: PlatformConnection) => void;
   onManage: (c: PlatformConnection) => void;
+  onEdit: (c: PlatformConnection) => void;
 };
 
 function SlackIcon({ className }: { className?: string }) {
@@ -104,16 +107,15 @@ export function SettingsPage() {
   const [showFileImport, setShowFileImport] = useState(false);
   const [managingConnection, setManagingConnection] = useState<PlatformConnection | null>(null);
   const [showPicker, setShowPicker] = useState(false);
+  const [removingConnection, setRemovingConnection] = useState<PlatformConnection | null>(null);
+  const [editingConnection, setEditingConnection] = useState<PlatformConnection | null>(null);
 
-  async function handleDisconnect(connection: PlatformConnection) {
-    if (!confirm(`Disconnect "${connection.display_name || connection.platform}"? This cannot be undone.`)) return;
-    try {
-      await remove(connection.id);
-      refetch();
-      window.dispatchEvent(new Event("connections-changed"));
-    } catch {
-      // error shown by hook
-    }
+  function handleDisconnect(connection: PlatformConnection) {
+    setRemovingConnection(connection);
+  }
+
+  function handleEdit(connection: PlatformConnection) {
+    setEditingConnection(connection);
   }
 
   function handleWizardComplete(_connection: PlatformConnection) {
@@ -140,6 +142,7 @@ export function SettingsPage() {
     onAdd: () => setShowPicker(true),
     onDisconnect: handleDisconnect,
     onManage: setManagingConnection,
+    onEdit: handleEdit,
   };
 
   return (
@@ -259,6 +262,36 @@ export function SettingsPage() {
           onClose={handleManageComplete}
         />
       )}
+
+      {removingConnection && (
+        <ConfirmRemoveDialog
+          connection={removingConnection}
+          onCancel={() => setRemovingConnection(null)}
+          onConfirm={async (cascade) => {
+            try {
+              await remove(removingConnection.id, cascade);
+              refetch();
+              window.dispatchEvent(new Event("connections-changed"));
+            } catch {
+              // error shown by hook
+            } finally {
+              setRemovingConnection(null);
+            }
+          }}
+        />
+      )}
+
+      {editingConnection && (
+        <EditCredentialsDialog
+          connection={editingConnection}
+          onClose={() => setEditingConnection(null)}
+          onSaved={() => {
+            setEditingConnection(null);
+            refetch();
+            window.dispatchEvent(new Event("connections-changed"));
+          }}
+        />
+      )}
     </div>
   );
 }
@@ -266,7 +299,7 @@ export function SettingsPage() {
 /** The Integrations tab content — a route element under ``/settings/integrations``.
  *  Pulls connection state + handlers from the parent ``SettingsPage`` via outlet context. */
 export function IntegrationsTab() {
-  const { loading, error, connections, onAdd, onDisconnect, onManage } =
+  const { loading, error, connections, onAdd, onDisconnect, onManage, onEdit } =
     useOutletContext<SettingsOutletContext>();
   return (
     <>
@@ -312,6 +345,7 @@ export function IntegrationsTab() {
               connection={connection}
               onDisconnect={() => onDisconnect(connection)}
               onManage={() => onManage(connection)}
+              onEdit={() => onEdit(connection)}
             />
           ))}
         </div>


### PR DESCRIPTION
## Why

Follow-ups to #250. Two gaps remained:

1. **No safe way to change a connection's credentials.** The only path was the destructive **Remove** button, which deletes with `cascade=true` — hard-purging the messages/wiki/facts of channels solely owned by that connection. Switching Slack to Socket Mode therefore risked data loss (we hit this live and worked around it with a one-off script).
2. **Teams still broke on reboot.** Its inbound webhook is tunnel-dependent and the ephemeral URL changed on every restart.

## What

**1. Non-destructive credential editing (backend + UI)**
- `PATCH /api/connections/{id}/credentials` — merges only non-empty provided keys over the stored credentials, re-registers the adapter so the running bot rebuilds, and persists. Owner-gated; `422` on empty; `404` on missing. No delete, no cascade, no data loss.
- `EditCredentialsDialog` — edit/rotate creds from the Settings card; fields are blank ("leave blank to keep existing", secrets never returned to the client). Slack's App-Level Token field is highlighted for the Socket Mode switch; all fields surface the same setup hints the wizard shows (e.g. Teams tenant_id).

**2. Safe Remove**
- `ConfirmRemoveDialog` replaces the bare `window.confirm`. It warns that "Remove & delete data" permanently purges sole-owned channels' synced data, and offers a non-destructive **"Remove, keep data"** (`cascade=false`). Destructive action is visually distinct.

**3. Reboot-proof tunnel (Teams/Slack-Events)**
- `scripts.tunnel_up` starts ngrok (static `NGROK_DOMAIN` or ephemeral), writes `PUBLIC_BOT_URL` into `.env`, restarts the backend, re-points the Teams messaging endpoint, then holds the tunnel open.
- macOS launchd agent (`deploy/launchd/...` + `make tunnel-install`) runs it at login with `KeepAlive` so reboots re-sync automatically. With a static domain it's one-time.
- `make tunnel-up`, `.env.example` vars, and `docs/guides/reboot-proof-tunnel.md`.

## Reviewed & verified

Ran a multi-agent review (correctness / security / regression / ux-ops) with adversarial verification + independent test validation:
- **1 finding confirmed** (medium UX: edit dialog ignored per-field hints) — **fixed** in this branch.
- **Validation green:** web typecheck 0, **103 web tests**, **20 backend tests**, ruff check + format clean, tunnel dry-run clean.

## Constraints / trade-offs

- Secrets are never returned to the client → edit fields are blank ("keep existing") rather than pre-filled.
- Teams (Bot Framework) has no Socket Mode equivalent — it always needs a public messaging endpoint, hence the auto re-point.
- Slack should prefer Socket Mode (now one click via the edit dialog) to avoid needing the tunnel at all.

## Not covered by tests
- Live launchd boot cycle (dry-run + manual run verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)