### PR TITLE
feat(qa): richer, more structured bot replies (overview cards + structure contract)

### DIFF
--- a/src/beever_atlas/agents/query/prompts.py
+++ b/src/beever_atlas/agents/query/prompts.py
@@ -229,29 +229,43 @@ OUTPUT_CONTRACT_STRICT = """\
 This is a CHAT reply. Lead with the answer; match length to the question. Be the kind \
 of message someone is glad to read in a channel — not a document.
 
-SHAPE (adaptive):
+SHAPE (adaptive — match the structure to the question):
 - Open with a 1-2 sentence TL;DR that answers the question directly. The reader should \
-  get the point from the first line.
-- Headings are OPTIONAL. For a short answer (≤50 words) skip headings entirely. Add a \
-  `##` heading only when the answer runs long (well past ~80 words) or genuinely covers \
-  2+ distinct sub-topics that need separating.
-- Bullets, tables, and Mermaid diagrams are tools you SHOULD reach for when they make \
-  the answer clearer — NOT mandatory ceremony. When brevity wins, plain sentences win.
-  - Use a markdown table when listing 3+ items that each have 2+ attributes AND a table \
-    is genuinely easier to scan than prose.
+  get the point from the first line. For an entity/overview answer, bold the subject in \
+  the TL;DR (e.g. "**Votee AI** is …").
+- A FOCUSED factual question (≤50 words to answer) stays plain prose — no headings, just \
+  answer it and stop.
+- A SUBSTANTIVE answer (an overview, "what is X", "tell me about X", a multi-facet or \
+  multi-part question, or anything running past ~80 words) MUST be structured and \
+  scannable, not a wall of prose:
+  - Group distinct facets under `##` (or `###` for sub-points) headings — e.g. `## What \
+    they do`, `## Notable`, `## How it works`. Aim for 2-4 short sections.
+  - When describing an entity's attributes (a company, tool, project, person, product), \
+    lead with a **Quick facts** block of bold-label bullets — one attribute per line:
+    `- **Founded:** 2012` / `- **HQ:** Hong Kong` / `- **Focus:** generative AI, OCR`. \
+    This is the preferred way to present structured data.
+  - Turn any enumeration of 3+ items (clients, collaborators, features, steps) into a \
+    bullet list — never bury 3+ items in an inline comma-separated sentence.
+- DATA REPRESENTATION — portability rule: do NOT use markdown tables for entity \
+  attributes or lists; they do not render on all chat platforms (e.g. Slack). Use \
+  bold-label "Quick facts" bullets instead. (Tables are reserved for the explicit \
+  side-by-side comparison skill; Mermaid for directional relationships only.)
   - Use a Mermaid fenced block (```mermaid) for directional relationships (pipelines, \
     supersedes chains, org structures, decision → outcome) only when the structure is \
     the point and the diagram beats a sentence. Keep nodes ≤12 and label every edge.
-- Every bullet you do write must be a complete, fact-bearing sentence — no one-word \
-  bullets, no bullets that only restate a heading.
+- Every bullet must be a complete, fact-bearing sentence or a `**Label:** value` quick- \
+  fact — no one-word bullets, no bullets that only restate a heading.
 - When the answer braids internal (channel) knowledge with external (web) context, \
   separate them with `## From your knowledge base` and `## External context`, then a \
   short `## Synthesis`. Do NOT mix internal and external facts in one bullet.
 
 LENGTH (adaptive):
 - Chat target: 20-80 words for a focused question — answer it and stop.
-- Substantive/multi-part question: 150-300 words, organized with light headings.
-- Never pad to hit a length. A correct one-line answer beats a padded paragraph.
+- Substantive/overview/multi-part question: 150-350 words, organized with headings and \
+  bullet structure as above. Prefer depth that is genuinely informative — cover the \
+  distinct facets the reader needs — over a single dense paragraph.
+- Never pad to hit a length. A correct one-line answer beats a padded paragraph; but for \
+  a real overview question, a flat 3-sentence prose blob is too thin — structure it.
 
 CITATION RIGOR (non-negotiable):
 - EVERY factual claim drawn from a tool result MUST carry an inline citation. Brevity \

--- a/src/beever_atlas/agents/query/prompts.py
+++ b/src/beever_atlas/agents/query/prompts.py
@@ -244,8 +244,10 @@ SHAPE (adaptive — match the structure to the question):
     lead with a **Quick facts** block of bold-label bullets — one attribute per line:
     `- **Founded:** 2012` / `- **HQ:** Hong Kong` / `- **Focus:** generative AI, OCR`. \
     This is the preferred way to present structured data.
-  - Turn any enumeration of 3+ items (clients, collaborators, features, steps) into a \
-    bullet list — never bury 3+ items in an inline comma-separated sentence.
+  - Turn any enumeration of 3+ items where EACH item carries its own detail (a fact, a \
+    role, a date) into a bullet list — one item per bullet. A bare name-only list (e.g. \
+    client or partner names with no per-item detail) stays as ONE grouped bullet or \
+    sentence — do not explode it into one-word bullets.
 - DATA REPRESENTATION — portability rule: do NOT use markdown tables for entity \
   attributes or lists; they do not render on all chat platforms (e.g. Slack). Use \
   bold-label "Quick facts" bullets instead. (Tables are reserved for the explicit \

--- a/src/beever_atlas/agents/query/skills/resources/overview_template.md
+++ b/src/beever_atlas/agents/query/skills/resources/overview_template.md
@@ -1,0 +1,61 @@
+# Entity Overview Card Template
+
+Render a structured overview of ONE named entity (company / product / tool / project /
+technology / concept) from `search_channel_facts` and/or `search_external_knowledge`
+evidence. Works for both internal (channel) and external (web) answers.
+
+## Format
+
+```
+**<Entity>** is <one-sentence what-it-is TL;DR>. [src:src_xxx]
+
+**Quick facts**
+- **<Label>:** <value> [src:src_xxx]
+- **<Label>:** <value> [src:src_xxx]
+- **<Label>:** <value> [src:src_xxx]
+
+### <Facet heading, e.g. What it does>
+- <fact-bearing sentence> [src:src_xxx]
+- <fact-bearing sentence> [src:src_xxx]
+
+### <Facet heading, e.g. Notable>
+- <fact-bearing sentence> [src:src_xxx]
+```
+
+## Rules
+
+- TL;DR: bold the entity name, one sentence, answers "what is it" before anything else.
+- **Quick facts**: 2-6 bold-label bullets, one attribute per line. Include only the
+  attributes the evidence supports — common ones: Founded, HQ / Location, Focus, Type,
+  Owner / Maker, License, Released, Used for. OMIT any you don't have evidence for.
+- DATA REPRESENTATION: bold-label bullets ONLY. Do NOT use a markdown table — it does
+  not render on all chat platforms (e.g. Slack).
+- 1-3 `###` sections after Quick facts, each a distinct facet, each with 2-4 bullets.
+  Every bullet is a complete, fact-bearing sentence — never a one-word bullet.
+- Turn any enumeration of 3+ items (clients, collaborators, features) into bullets, not
+  an inline comma-separated sentence.
+- Cite every claim with `[src:...]`. For external-knowledge answers, still cite the
+  external sources and keep the honesty signal the tone rules require.
+- Never invent a fact to fill the template. Fewer accurate bullets beat padded ones.
+
+## Example
+
+```
+**Votee AI** is a Hong Kong-based company building tailored AI solutions for
+businesses. [src:src_aaa1111111]
+
+**Quick facts**
+- **Founded:** 2012 [src:src_aaa1111111]
+- **HQ:** Hong Kong [src:src_bbb2222222]
+- **Focus:** generative AI and OCR [src:src_aaa1111111]
+
+### What they do
+- Build generative-AI and OCR products that help companies optimize processes and
+  improve customer experience. [src:src_aaa1111111]
+- Open-sourced Beever Atlas, an LLM knowledge base, with their Toronto lab Beever AI on
+  May 8, 2026. [src:src_ccc3333333]
+
+### Notable collaborators
+- KPMG, Bloomberg, GoToDoctor, Amazon, and Bayer. [src:src_bbb2222222]
+- Hong Kong University of Science and Technology. [src:src_bbb2222222]
+```

--- a/src/beever_atlas/agents/query/skills/resources/overview_template.md
+++ b/src/beever_atlas/agents/query/skills/resources/overview_template.md
@@ -32,8 +32,9 @@ evidence. Works for both internal (channel) and external (web) answers.
   not render on all chat platforms (e.g. Slack).
 - 1-3 `###` sections after Quick facts, each a distinct facet, each with 2-4 bullets.
   Every bullet is a complete, fact-bearing sentence — never a one-word bullet.
-- Turn any enumeration of 3+ items (clients, collaborators, features) into bullets, not
-  an inline comma-separated sentence.
+- Enumerations: if each item carries its own detail (a fact, role, or date), give each
+  its own bullet. A bare name-only list (e.g. partner/client names with no per-item
+  detail) stays as ONE grouped bullet — never explode it into one-word bullets.
 - Cite every claim with `[src:...]`. For external-knowledge answers, still cite the
   external sources and keep the honesty signal the tone rules require.
 - Never invent a fact to fill the template. Fewer accurate bullets beat padded ones.

--- a/src/beever_atlas/agents/query/skills/skills.py
+++ b/src/beever_atlas/agents/query/skills/skills.py
@@ -25,6 +25,7 @@ QA_SKILL_NAMES: tuple[str, ...] = (
     "visual-graph",
     "media-gallery",
     "channel-digest",
+    "entity-overview",
     "source-braid",
     "typed-followups",
 )
@@ -203,6 +204,33 @@ def _build_skills() -> list[Skill]:
             ),
         ),
         _skill(
+            name="entity-overview",
+            description=(
+                "Entity overview card, 'what is X', 'tell me about X', 'who is <company>', "
+                "'overview of', 'explain X', 'describe X': renders a structured profile of a "
+                "single company / product / tool / project / technology / concept — a bold "
+                "TL;DR, a Quick facts block of bold-label bullets, and 1-3 short `###` "
+                "sections (What it does / Notable / How it works). USE for any "
+                "definition-or-overview question about ONE named thing, whether the evidence "
+                "is internal (channel) or external (web)."
+            ),
+            allowed_tools="search_channel_facts search_external_knowledge",
+            resource_files=("overview_template.md",),
+            instructions=(
+                "Use when the user asks 'what is X', 'tell me about X', 'overview of X', "
+                "'explain/describe X' for a single named entity (company, product, tool, "
+                "project, technology, concept).\n"
+                "1. Gather evidence: `search_channel_facts(query=X)` first; if the channel has "
+                "<3 relevant facts, add `search_external_knowledge(query=X)`.\n"
+                "2. Load `overview_template.md` via `load_resource` and follow it EXACTLY: a "
+                "bold-subject TL;DR line, a **Quick facts** bullet block (`- **Label:** value`, "
+                "only attributes the evidence supports), then 1-3 `###` sections with "
+                "fact-bearing bullets. Cite every claim with `[src:...]`.\n"
+                "3. Do NOT use a markdown table (it breaks on some platforms) — bold-label "
+                "bullets only. Omit any Quick fact you don't have evidence for; never invent."
+            ),
+        ),
+        _skill(
             name="source-braid",
             description=(
                 "Source braid, internal plus external synthesis: braids team knowledge with "
@@ -252,5 +280,5 @@ def _build_skills() -> list[Skill]:
 
 @lru_cache(maxsize=1)
 def build_qa_skill_pack() -> list[Skill]:
-    """Return the cached QA skill pack (8 skills). Parsed once."""
+    """Return the cached QA skill pack (9 skills). Parsed once."""
     return _build_skills()

--- a/src/beever_atlas/infra/config.py
+++ b/src/beever_atlas/infra/config.py
@@ -423,7 +423,7 @@ class Settings(BaseSettings):
     )
 
     # QA Agent Skills (progressive disclosure via ADK SkillToolset).
-    # When ON, create_qa_agent() wires an 8-skill pack into the QA LlmAgent
+    # When ON, create_qa_agent() wires a 9-skill pack into the QA LlmAgent
     # so the model can load_skill / load_resource on demand for richer
     # formatted output (timelines, profile cards, comparison tables, etc.).
     # REQUIRES qa_new_prompt=True (QA_RICH_OUTPUT); agent-build raises

--- a/tests/agents/query/test_skills.py
+++ b/tests/agents/query/test_skills.py
@@ -37,9 +37,25 @@ def _tool_registry_names() -> set[str]:
 
 def test_skill_pack_count() -> None:
     skills = build_qa_skill_pack()
-    assert len(skills) == 8
-    assert len(QA_SKILL_NAMES) == 8
+    assert len(skills) == 9
+    assert len(QA_SKILL_NAMES) == 9
     assert {s.frontmatter.name for s in skills} == set(QA_SKILL_NAMES)
+
+
+def test_entity_overview_skill_present_and_loads_template() -> None:
+    """The entity-overview skill (richer 'what is X' cards) is registered and its
+    L3 template resource is bundled."""
+    skills = {s.frontmatter.name: s for s in build_qa_skill_pack()}
+    assert "entity-overview" in skills
+    overview = skills["entity-overview"]
+    # Template asset is loaded and carries the portable "Quick facts" pattern
+    # (bold-label bullets, not a table).
+    assets = overview.resources.assets
+    assert "overview_template.md" in assets
+    raw = assets["overview_template.md"]
+    body = raw.decode() if isinstance(raw, bytes) else raw
+    assert "Quick facts" in body
+    assert "Do NOT use a markdown table" in body
 
 
 def test_skill_names_are_kebab() -> None:


### PR DESCRIPTION
## Why
Bot replies came out as flat prose even with `QA_RICH_OUTPUT` on (see screenshots): the active `OUTPUT_CONTRACT_STRICT` over-favored brevity ("20-80 words / headings optional / not a document"), and the skill pack had no entity/overview skill — so "what is X" answers fell through to a wall of prose.

## What
- **Rebalance `OUTPUT_CONTRACT_STRICT`**: substantive / overview / multi-part answers must be scannable — bold TL;DR, `##`/`###` subheadings per facet, a **Quick facts** bold-label bullet block for entity attributes, bullet lists for 3+ item enumerations. Focused factual questions still stay short.
- **Portability codified**: NO markdown tables for attributes/lists (they don't render on Slack mrkdwn) — bold-label bullets are the cross-platform data-representation primitive. Tables stay reserved for the explicit comparison skill.
- **New `entity-overview` skill** + `overview_template.md`: structured card for "what is X / tell me about X / overview of X" (channel or external evidence).
- Substantive length target 150-300 → 150-350 with real structure.

Portable markdown only (`##` / `**bold**` / `- bullets`) so the chat SDK converts per platform.

## Verified live (against `/api/channels/{id}/ask`, the endpoint the bot calls)
- **"What is Votee AI?"** → bold TL;DR + `## Quick facts` (HQ / Focus / Collaborations bullets) + `## What they do` + `## Specializations` bullet list, every claim cited. (Was: flat prose.)
- **"Who won the 2024 NBA championship?"** → stays short (3 sentences, no headings). Brevity preserved.
- Answer-doubling (pre-existing, handled by `_dedup_exact_double` + bot block-dedup) unaffected — 53 bot dedup tests pass.

## Tests
- 9-skill pack builds; new `test_entity_overview_skill_present_and_loads_template`; skills suite green; ruff check+format clean; assembled rich prompt contains all new directives.

Constraint: tables aren't portable (Slack mrkdwn) — bold-label bullets are the primitive
Confidence: high
Scope-risk: moderate
Not-tested: live model output on every platform (verified Slack/ask shape)

🤖 Generated with [Claude Code](https://claude.com/claude-code)