### PR TITLE
fix(deploy): backend healthcheck start_period (prevent slow-boot deploy aborts)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,6 +47,12 @@ services:
       interval: 30s
       timeout: 10s
       retries: 3
+      # Cold start (ADK init, store connections, migration shim) can exceed
+      # interval*retries on a small host. Without start_period the container is
+      # marked unhealthy mid-boot, which aborts `docker compose up` and leaves
+      # depends_on services (the bot) unstarted. Give boot up to 3 min before
+      # failures count.
+      start_period: 180s
 
   web:
     build:


### PR DESCRIPTION
Backend cold start can exceed the healthcheck window (interval 30s × 3 retries = 90s), marking it unhealthy mid-boot. That aborts `docker compose up` and leaves `depends_on` services (the **bot**) unstarted — seen on the EE auto-deploy (bot didn't start until a manual `compose up -d`). Adds `start_period: 180s` so boot finishes before failures count.

Verified: `docker compose config` validates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)