### PR TITLE
feat(bot): real-time image vision on @mention (SSRF-safe, fail-open)

### DIFF
--- a/bot/src/bridge.ts
+++ b/bot/src/bridge.ts
@@ -2626,6 +2626,32 @@ function getFirstBridge(chatManager: ChatManager): { platform: string; bridge: P
   return null;
 }
 
+/**
+ * Resolve the per-connection `proxyFile` for an inbound message's platform.
+ *
+ * SAFETY-CRITICAL: callers (e.g. the bot's @mention vision path) MUST fetch
+ * attachment bytes through this `proxyFile`, NEVER the chat-sdk adapter's raw
+ * `fetchData`. `proxyFile` runs `assertHostAllowedAndPublic` (RFC1918 /
+ * loopback / link-local / cloud-metadata block) plus Discord CDN-expiry refresh
+ * and Slack files.info fallback. A leaked/attacker-influenced url cannot reach
+ * a private host through it.
+ *
+ * The SDK `Message`/`Thread` objects passed to handlers carry no connection id,
+ * only the platform (recovered from the thread-id prefix). We therefore resolve
+ * by platform — the single-connection-per-platform default — which mirrors how
+ * the existing webhook routing resolves a bridge. Returns `null` when no bridge
+ * is registered for the platform, in which case the caller MUST skip the image
+ * (do NOT fall back to a raw fetch).
+ */
+export function resolveProxyFile(
+  chatManager: ChatManager,
+  platform: string,
+): ((url: string) => Promise<{ contentType: string; buffer: Buffer }>) | null {
+  const bridge = getBridge(chatManager, platform);
+  if (!bridge) return null;
+  return (url: string) => bridge.proxyFile(url);
+}
+
 /** Infer platform from a file URL.
  *
  * Uses parsed-URL hostname checks (exact match or proper subdomain suffix),

--- a/bot/src/index.ts
+++ b/bot/src/index.ts
@@ -125,12 +125,12 @@ function registerHandlers(bot: Chat): void {
     // If the image-answerable override was the only reason we got here but no
     // image actually described (all skipped / no proxyFile), honour the original
     // text-only gate instead of answering a hollow default question.
-    if (!gotImages && decision !== "respond") {
-      if (decision === "prompt") {
-        await thread.post("Please ask me a question! For example: @beever what is our tech stack?");
-      }
+    const after = resolvePostExtraction(decision, gotImages);
+    if (after === "prompt") {
+      await thread.post("Please ask me a question! For example: @beever what is our tech stack?");
       return;
     }
+    if (after === "skip") return;
     // The backend requires a non-empty question; a bare image ping has none, so
     // ask a sensible default about the attached image.
     const finalQuestion = question.trim() || (gotImages ? "What is in this image?" : question);
@@ -442,6 +442,27 @@ export function decideMentionGate(input: {
   });
   if (input.hasImage && decision !== "respond") return "respond";
   return decision;
+}
+
+/**
+ * Recover the original text-only intent after image extraction.
+ *
+ * The image override (decideMentionGate) can turn a bare/quiet mention into
+ * "respond" purely because an image was attached. If extraction then yields
+ * NOTHING (all images skipped — no proxyFile, fetch failed, non-image), we must
+ * NOT answer a hollow default question; honour what the text alone warranted.
+ *
+ *  - images described  → "proceed" (answer about the image)
+ *  - no images, text warranted a reply → "proceed"
+ *  - no images, text was a bare mention → "prompt" (nudge)
+ *  - no images, text was an announcement/pleasantry → "skip" (stay quiet)
+ */
+export function resolvePostExtraction(
+  originalTextDecision: RespondDecision,
+  gotImages: boolean,
+): "proceed" | "prompt" | "skip" {
+  if (gotImages) return "proceed";
+  return originalTextDecision === "respond" ? "proceed" : originalTextDecision;
 }
 
 /** A safe per-connection byte fetcher (the bridge `proxyFile` contract). */

--- a/bot/src/index.ts
+++ b/bot/src/index.ts
@@ -13,6 +13,7 @@ import {
   decideShouldRespond,
   decideSubscribedThreadActionWithLookup,
   isBroadcast,
+  type RespondDecision,
 } from "./trigger.js";
 import { stripMention } from "./mentions.js";
 import { ParticipantCache } from "./participant-cache.js";
@@ -20,7 +21,7 @@ import { logReplySent, type ReplySurface } from "./reply-metrics.js";
 import { deriveSessionId } from "./session-id.js";
 import { RateLimiter } from "./rate-limiter.js";
 import type { AskResult } from "./types.js";
-import { registerBridgeRoutes, recordTelegramChat, recordTeamsConversation, warmTeamsGraphToken, seedTeamsKnownTeamIds } from "./bridge.js";
+import { registerBridgeRoutes, recordTelegramChat, recordTeamsConversation, warmTeamsGraphToken, seedTeamsKnownTeamIds, resolveProxyFile } from "./bridge.js";
 import { jsonResponse, readBody, MAX_BODY_SIZE, BodyTooLargeError, safeErrorMessage } from "./http-utils.js";
 import { ChatManager } from "./chat-manager.js";
 import { DiscordGatewaySupervisor } from "./discord-gateway.js";
@@ -53,6 +54,21 @@ const PARTICIPANT_CACHE_TTL_MS = parseInt(process.env.BOT_PARTICIPANT_CACHE_TTL_
 //    minute before a one-time "give me a moment" notice and silent drop.
 const RATE_LIMIT_PER_MIN = parseInt(process.env.BOT_RATELIMIT_PER_MIN || "12", 10);
 const RATE_WINDOW_MS = 60_000;
+//  - VISION_ENABLED: real-time image vision on @mention. Set BOT_VISION_ENABLED=off
+//    to kill-switch the whole image path (mentions still answer from text).
+//  - VISION_MAX_IMAGES: cap per message so a flood of attachments can't fan out
+//    into many vision calls. VISION_MAX_BYTES mirrors the backend MAX_UPLOAD_SIZE
+//    (10MB decoded) and is enforced client-side before we base64 + POST.
+//  - VISION_TIMEOUT_MS bounds a single extract-text call (per image).
+const VISION_ENABLED = (process.env.BOT_VISION_ENABLED || "on").toLowerCase() !== "off";
+const VISION_MAX_IMAGES = parseInt(process.env.BOT_VISION_MAX_IMAGES || "4", 10);
+const VISION_MAX_BYTES = parseInt(process.env.BOT_VISION_MAX_BYTES || `${10 * 1024 * 1024}`, 10);
+const VISION_TIMEOUT_MS = parseInt(process.env.BOT_VISION_TIMEOUT_MS || "30000", 10);
+
+// Set in main() so the mention handler (a closure passed to ChatManager) can
+// resolve the inbound message's per-connection bridge `proxyFile`. The SDK
+// Message carries no connection handle, and the handler only receives `bot`.
+let _chatManager: ChatManager | undefined;
 
 const participantCache = new ParticipantCache(PARTICIPANT_CACHE_TTL_MS);
 const rateLimiter = new RateLimiter(RATE_LIMIT_PER_MIN, RATE_WINDOW_MS);
@@ -77,22 +93,47 @@ function registerHandlers(bot: Chat): void {
 
     const platform = extractPlatform(thread.id);
     const question = stripMention(message.text || "", platform);
-    // Addressing & intent gate: only speak when actually asked something. Bare
-    // mention → nudge; an announcement (@channel/@here/@everyone) or a pleasantry
-    // that happens to tag the bot → stay quiet.
+    // An image @mention ("@bot what is this?" + screenshot, or a bare image
+    // ping) is a real question ABOUT the image. Detect it so the gate below
+    // treats it as answerable instead of nudging on the thin text.
+    const hasImage =
+      VISION_ENABLED &&
+      (message.attachments || []).some(isImageAttachment);
+    const broadcast = isBroadcast(message.text || "");
+    // Original text-only intent (drives the post-extraction fallback below).
     const decision = decideShouldRespond({
       text: question,
-      broadcast: isBroadcast(message.text || ""),
+      broadcast,
       isMention: true,
       surface: "mention",
     });
-    if (decision === "prompt") {
+    // Addressing & intent gate, with the additive image override: only speak
+    // when actually asked something OR an image is attached. Bare mention →
+    // nudge; an announcement or pleasantry that tags the bot → stay quiet.
+    const gate = decideMentionGate({ text: question, broadcast, hasImage });
+    if (gate === "prompt") {
       await thread.post("Please ask me a question! For example: @beever what is our tech stack?");
       return;
     }
-    if (decision === "skip") return;
+    if (gate === "skip") return;
 
     if (!(await passesRateLimit(thread, message))) return;
+
+    // Describe any images (fail-open: never blocks the text reply).
+    const atts = hasImage ? await extractImageAttachments(message, thread.id) : undefined;
+    const gotImages = !!atts && atts.length > 0;
+    // If the image-answerable override was the only reason we got here but no
+    // image actually described (all skipped / no proxyFile), honour the original
+    // text-only gate instead of answering a hollow default question.
+    if (!gotImages && decision !== "respond") {
+      if (decision === "prompt") {
+        await thread.post("Please ask me a question! For example: @beever what is our tech stack?");
+      }
+      return;
+    }
+    // The backend requires a non-empty question; a bare image ping has none, so
+    // ask a sensible default about the attached image.
+    const finalQuestion = question.trim() || (gotImages ? "What is in this image?" : question);
     // P2 — key on the THREAD (isThreaded=true), same as onSubscribedMessage.
     // On every supported platform `thread.id` is the STABLE thread ROOT: Slack
     // encodes it as `slack:<channel>:<threadTs>` where threadTs is
@@ -102,7 +143,7 @@ function registerHandlers(bot: Chat): void {
     // backend session — the old `false` here put the root on a separate
     // idle-window key, so memory never carried into the thread. Fall back to the
     // loose idle-window key only for a degenerate id with no thread segment.
-    await answerInThread(thread, question, "mention", message.author, hasThreadRoot(thread.id));
+    await answerInThread(thread, finalQuestion, "mention", message.author, hasThreadRoot(thread.id), atts);
   });
 
   // Handler: follow-up messages in subscribed threads. The SDK routes EVERY
@@ -292,6 +333,7 @@ export async function answerInThread(
   surface: ReplySurface,
   author?: unknown,
   isThreaded: boolean = true,
+  attachments?: ImageAttachment[],
 ): Promise<void> {
   const platform = extractPlatform(thread.id);
   const startedAt = Date.now();
@@ -315,6 +357,7 @@ export async function answerInThread(
       question,
       deriveSessionId(threadId, userId, channelId, isThreaded),
       userId,
+      attachments,
     );
     // Post as `{ markdown }`: the renderer emits canonical CommonMark and the
     // chat SDK converts it to each platform's native format (Slack Block Kit,
@@ -359,11 +402,144 @@ function backendApiKey(): string {
   return raw.split(",").map((k) => k.trim()).find(Boolean) || "";
 }
 
+/** Extracted image description, shaped for the backend AskRequest.attachments field. */
+export interface ImageAttachment {
+  filename: string;
+  extracted_text: string;
+  mime_type: string;
+}
+
+/** Minimal shape of a chat-sdk attachment we read off an inbound Message. */
+interface IncomingAttachment {
+  type?: string;
+  mimeType?: string;
+  name?: string;
+  url?: string;
+}
+
+/** True when an attachment is an image we can describe. */
+export function isImageAttachment(att: IncomingAttachment): boolean {
+  if (att.type === "image") return true;
+  return typeof att.mimeType === "string" && att.mimeType.startsWith("image/");
+}
+
+/**
+ * Pre-extraction mention gate. Runs the normal text intent gate, then applies
+ * an ADDITIVE override: a mention that carries an image is answerable even when
+ * its text alone would only prompt/skip (so "image + 'what is this?'" doesn't
+ * hit the bare-mention greeting branch). Text-only gating is unchanged.
+ */
+export function decideMentionGate(input: {
+  text: string;
+  broadcast: boolean;
+  hasImage: boolean;
+}): RespondDecision {
+  const decision = decideShouldRespond({
+    text: input.text,
+    broadcast: input.broadcast,
+    isMention: true,
+    surface: "mention",
+  });
+  if (input.hasImage && decision !== "respond") return "respond";
+  return decision;
+}
+
+/** A safe per-connection byte fetcher (the bridge `proxyFile` contract). */
+type ProxyFile = (url: string) => Promise<{ contentType: string; buffer: Buffer }>;
+
+/** Production proxyFile resolver: the real per-connection bridge SSRF-guarded
+ *  fetch. Injectable so tests can supply a fake without the live ChatManager. */
+function defaultProxyFileResolver(platform: string): ProxyFile | null {
+  return _chatManager ? resolveProxyFile(_chatManager, platform) : null;
+}
+
+/**
+ * Fetch each image attachment's bytes SAFELY (via the connection's bridge
+ * `proxyFile` — never the adapter `fetchData`, which lacks an SSRF guard and
+ * would leak the bot token), run them through the backend vision pipeline, and
+ * return `{ filename, extracted_text, mime_type }` for the /ask attachments
+ * field.
+ *
+ * FAIL-OPEN by design: every step is wrapped per-image; on ANY error (no
+ * proxyFile for the platform, proxyFile throw, oversize, missing BRIDGE_API_KEY
+ * → 401, timeout, non-2xx) the image is skipped and the others continue. Image
+ * processing must NEVER abort the reply. Logs lengths/counts only — never bytes
+ * or extracted tokens (they can carry PII).
+ */
+export async function extractImageAttachments(
+  message: { attachments?: IncomingAttachment[]; text?: string },
+  threadId: string,
+  resolveProxy: (platform: string) => ProxyFile | null = defaultProxyFileResolver,
+): Promise<ImageAttachment[]> {
+  if (!VISION_ENABLED) return [];
+  const all = message.attachments || [];
+  const images = all.filter(isImageAttachment).slice(0, VISION_MAX_IMAGES);
+  if (images.length === 0) return [];
+
+  const platform = extractPlatform(threadId);
+  const proxyFile = resolveProxy(platform);
+  if (!proxyFile) {
+    // No safe byte-fetch path for this platform → skip every image. Never fall
+    // back to a raw fetch (SSRF + token-leak risk).
+    console.log(`[vision] no proxyFile for ${platform}; skipping ${images.length} image(s)`);
+    return [];
+  }
+
+  const bridgeKey = process.env.BRIDGE_API_KEY || "";
+  const messageText = message.text || "";
+  const results: ImageAttachment[] = [];
+
+  for (const att of images) {
+    try {
+      if (!att.url) continue;
+      const { buffer, contentType } = await proxyFile(att.url);
+      if (buffer.length > VISION_MAX_BYTES) {
+        console.log(`[vision] image over ${VISION_MAX_BYTES}B (${buffer.length}B); skipped`);
+        continue;
+      }
+      const mimeType = att.mimeType || contentType || "image/png";
+      const headers: Record<string, string> = { "Content-Type": "application/json" };
+      // BRIDGE_API_KEY (the internal bridge bearer) — a DIFFERENT secret than
+      // the BEEVER_API_KEYS the public askBackend uses.
+      if (bridgeKey) headers["Authorization"] = `Bearer ${bridgeKey}`;
+      const resp = await fetch(`${BACKEND_URL}/api/internal/media/extract-text`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify({
+          filename: att.name || "image",
+          mime_type: mimeType,
+          data_b64: buffer.toString("base64"),
+          message_text: messageText,
+        }),
+        signal: AbortSignal.timeout(VISION_TIMEOUT_MS),
+      });
+      if (!resp.ok) {
+        console.log(`[vision] extract-text returned ${resp.status}; image skipped`);
+        continue;
+      }
+      const data = (await resp.json()) as ImageAttachment;
+      if (data && typeof data.extracted_text === "string") {
+        results.push({
+          filename: data.filename || att.name || "image",
+          extracted_text: data.extracted_text,
+          mime_type: data.mime_type || mimeType,
+        });
+      }
+    } catch (err) {
+      // Per-image isolation: one failure never aborts the reply or the others.
+      console.error("[vision] image processing failed; skipped:", safeErrorMessage(err));
+    }
+  }
+  console.log(`[vision] described ${results.length}/${images.length} image(s) for ${platform}`);
+  return results;
+}
+
 async function askBackend(
   channelId: string,
   question: string,
   sessionId: string,
   userId: string,
+  attachments?: ImageAttachment[],
 ): Promise<AskResult> {
   // Encode the channel id so a value with slashes/`..` can't escape the route
   // path and reach an unintended backend endpoint.
@@ -373,12 +549,18 @@ async function askBackend(
   if (apiKey) {
     headers["Authorization"] = `Bearer ${apiKey}`;
   }
+  // Include `attachments` ONLY when non-empty so the text-only body stays
+  // byte-identical to before — existing SSE tests assert on the exact body.
+  const payload: Record<string, unknown> = { question, session_id: sessionId, user_id: userId };
+  if (attachments && attachments.length > 0) {
+    payload.attachments = attachments;
+  }
   // Bound the whole call (the timeout budget is shared across retries) and let
   // fetchSSEWithRetry absorb transient 5xx / network blips with backoff so a
   // slow or flapping backend doesn't surface a hard error to the user.
   return fetchSSEWithRetry(
     url,
-    { method: "POST", headers, body: JSON.stringify({ question, session_id: sessionId, user_id: userId }) },
+    { method: "POST", headers, body: JSON.stringify(payload) },
     // Pass the channel id so the SSE client can scrub a leaked raw channel id
     // from the answer and use it to collapse an `(id)`-variant near-duplicate.
     { maxAttempts: 3, signal: AbortSignal.timeout(ASK_TIMEOUT_MS), channelId },
@@ -1040,6 +1222,9 @@ async function main(): Promise<void> {
   console.log(`Redis URL: ${REDIS_URL}`);
 
   const chatManager = new ChatManager(REDIS_URL, registerHandlers);
+  // Expose to the mention handler closure so it can resolve a message's
+  // per-connection bridge `proxyFile` for safe image-byte fetches.
+  _chatManager = chatManager;
 
   // Attempt to load connections from backend with retry + .env fallback
   await loadConnectionsFromBackend(chatManager);

--- a/bot/src/vision.test.ts
+++ b/bot/src/vision.test.ts
@@ -1,0 +1,227 @@
+/**
+ * Tests for the @mention image-vision path in index.ts.
+ *
+ * Locks the load-bearing contracts:
+ *   1. extractImageAttachments returns `{ filename, extracted_text, mime_type }`
+ *      dicts for image attachments, fetching bytes via the injected (bridge)
+ *      proxyFile — NEVER a raw fetch.
+ *   2. FAIL-OPEN: a proxyFile throw skips THAT image, the others continue, and
+ *      no exception escapes.
+ *   3. Caps: respects BOT_VISION_MAX_IMAGES and BOT_VISION_MAX_BYTES.
+ *   4. askBackend includes `attachments` only when non-empty; the text-only
+ *      body stays byte-identical (so existing SSE tests don't break).
+ *   5. Gating: an image + short-text mention resolves to "respond".
+ *
+ * Env knobs are set BEFORE importing index.ts because the BOT_VISION_* consts
+ * are read at module load. Each test file runs in its own process under
+ * `tsx --test`, so this does not leak into other suites.
+ */
+import { describe, it, afterEach } from "node:test";
+import assert from "node:assert";
+import { Buffer } from "node:buffer";
+// Type-only imports are erased at compile time, so they do NOT trigger module
+// execution before the env is set below.
+import type { ImageAttachment, PostableThread } from "./index.js";
+
+// ESM value imports are hoisted, so the BOT_VISION_* consts in index.ts would be
+// read with their defaults before any top-level `process.env` assignment ran.
+// Set the env FIRST, then load index.ts via a dynamic import so the consts pick
+// up these test values.
+process.env.BOT_VISION_MAX_IMAGES = "2";
+process.env.BOT_VISION_MAX_BYTES = "1000";
+process.env.BRIDGE_API_KEY = "bridge-secret";
+
+const { extractImageAttachments, decideMentionGate, isImageAttachment, answerInThread } =
+  await import("./index.js");
+
+type ProxyFile = (url: string) => Promise<{ contentType: string; buffer: Buffer }>;
+
+const PNG_HEADER = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+function imageAtt(name: string, url = `https://files.slack.com/${name}`) {
+  return { type: "image", mimeType: "image/png", name, url };
+}
+
+// A proxyFile that returns a small valid buffer for every url.
+function okProxy(buf: Buffer = PNG_HEADER): ProxyFile {
+  return async () => ({ contentType: "image/png", buffer: buf });
+}
+
+function extractResponse(text: string): Response {
+  return new Response(
+    JSON.stringify({ filename: "image", extracted_text: text, mime_type: "image/png" }),
+    { status: 200, headers: { "Content-Type": "application/json" } },
+  );
+}
+
+describe("isImageAttachment", () => {
+  it("matches by type and by image/* mime", () => {
+    assert.ok(isImageAttachment({ type: "image" }));
+    assert.ok(isImageAttachment({ mimeType: "image/jpeg" }));
+    assert.ok(!isImageAttachment({ type: "file", mimeType: "application/pdf" }));
+  });
+});
+
+describe("decideMentionGate", () => {
+  it("makes an image + short-text mention answerable", () => {
+    // Bare "what?" text alone would still be a question, so use empty text +
+    // image: empty text → prompt, but the image override makes it respond.
+    assert.strictEqual(decideMentionGate({ text: "", broadcast: false, hasImage: true }), "respond");
+  });
+
+  it("nudges (prompt) on an empty mention with NO image", () => {
+    assert.strictEqual(decideMentionGate({ text: "", broadcast: false, hasImage: false }), "prompt");
+  });
+
+  it("leaves a normal text question answerable", () => {
+    assert.strictEqual(
+      decideMentionGate({ text: "what is our stack?", broadcast: false, hasImage: false }),
+      "respond",
+    );
+  });
+});
+
+describe("extractImageAttachments", () => {
+  const originalFetch = globalThis.fetch;
+  afterEach(() => { globalThis.fetch = originalFetch; });
+
+  it("returns extracted-text dicts for image attachments", async () => {
+    globalThis.fetch = (async () => extractResponse("a chart of Q3 revenue")) as typeof fetch;
+    const msg = { attachments: [imageAtt("a.png")], text: "what is this?" };
+    const out = await extractImageAttachments(msg, "slack:C1:T1", () => okProxy());
+    assert.strictEqual(out.length, 1);
+    assert.strictEqual(out[0].extracted_text, "a chart of Q3 revenue");
+    assert.strictEqual(out[0].mime_type, "image/png");
+  });
+
+  it("sends the bytes via proxyFile and posts to the internal endpoint with the BRIDGE key", async () => {
+    let sentUrl = "";
+    let sentAuth = "";
+    let proxied = false;
+    globalThis.fetch = (async (url: string, init: RequestInit) => {
+      sentUrl = String(url);
+      sentAuth = String((init.headers as Record<string, string>)["Authorization"] || "");
+      return extractResponse("ok");
+    }) as unknown as typeof fetch;
+    const proxy: ProxyFile = async () => { proxied = true; return { contentType: "image/png", buffer: PNG_HEADER }; };
+    await extractImageAttachments({ attachments: [imageAtt("a.png")] }, "slack:C1:T1", () => proxy);
+    assert.ok(proxied, "bytes must be fetched via proxyFile, never a raw fetch");
+    assert.ok(sentUrl.endsWith("/api/internal/media/extract-text"));
+    assert.strictEqual(sentAuth, "Bearer bridge-secret");
+  });
+
+  it("FAIL-OPEN: a proxyFile throw skips that image, others continue, no throw escapes", async () => {
+    globalThis.fetch = (async () => extractResponse("second image ok")) as typeof fetch;
+    let call = 0;
+    const proxy: ProxyFile = async () => {
+      call += 1;
+      if (call === 1) throw new Error("proxyFile boom");
+      return { contentType: "image/png", buffer: PNG_HEADER };
+    };
+    const msg = { attachments: [imageAtt("a.png"), imageAtt("b.png")] };
+    let out: ImageAttachment[] = [];
+    await assert.doesNotReject(async () => {
+      out = await extractImageAttachments(msg, "slack:C1:T1", () => proxy);
+    });
+    assert.strictEqual(out.length, 1, "the surviving image is still described");
+    assert.strictEqual(out[0].extracted_text, "second image ok");
+  });
+
+  it("skips ALL images (no raw fetch) when no proxyFile resolves for the platform", async () => {
+    let fetched = false;
+    globalThis.fetch = (async () => { fetched = true; return extractResponse("x"); }) as typeof fetch;
+    const out = await extractImageAttachments(
+      { attachments: [imageAtt("a.png")] },
+      "discord:G1:C1:T1",
+      () => null, // no bridge for this platform
+    );
+    assert.strictEqual(out.length, 0);
+    assert.ok(!fetched, "must NOT raw-fetch when there is no safe proxyFile");
+  });
+
+  it("respects BOT_VISION_MAX_IMAGES (=2 here)", async () => {
+    let posts = 0;
+    globalThis.fetch = (async () => { posts += 1; return extractResponse("ok"); }) as typeof fetch;
+    const msg = { attachments: [imageAtt("a"), imageAtt("b"), imageAtt("c"), imageAtt("d")] };
+    const out = await extractImageAttachments(msg, "slack:C1:T1", () => okProxy());
+    assert.strictEqual(out.length, 2);
+    assert.strictEqual(posts, 2, "only the first MAX_IMAGES are processed");
+  });
+
+  it("respects BOT_VISION_MAX_BYTES (=1000 here) and skips an oversized image", async () => {
+    let posted = false;
+    globalThis.fetch = (async () => { posted = true; return extractResponse("ok"); }) as typeof fetch;
+    const big = Buffer.alloc(2000, 1); // > 1000-byte cap
+    const out = await extractImageAttachments(
+      { attachments: [imageAtt("big.png")] },
+      "slack:C1:T1",
+      () => okProxy(big),
+    );
+    assert.strictEqual(out.length, 0);
+    assert.ok(!posted, "oversized image is dropped before the extract POST");
+  });
+
+  it("returns [] for a message with no image attachments", async () => {
+    const out = await extractImageAttachments(
+      { attachments: [{ type: "file", mimeType: "application/pdf", url: "u" }] },
+      "slack:C1:T1",
+      () => okProxy(),
+    );
+    assert.strictEqual(out.length, 0);
+  });
+});
+
+// ── askBackend body shape (via answerInThread) ───────────────────────────────
+
+const HAPPY_SSE =
+  'event: response_delta\ndata: {"delta": "It is a bar chart."}\n\n' +
+  'event: metadata\ndata: {"route": "qa_agent", "confidence": 0.9}\n\n' +
+  "event: done\ndata: {}\n\n";
+
+function sseResponse(body: string): Response {
+  return new Response(body, { status: 200, headers: { "Content-Type": "text/event-stream" } });
+}
+
+describe("askBackend attachments plumbing", () => {
+  const originalFetch = globalThis.fetch;
+  afterEach(() => { globalThis.fetch = originalFetch; });
+
+  it("includes `attachments` in the body ONLY when non-empty", async () => {
+    let sentBody: Record<string, unknown> = {};
+    globalThis.fetch = (async (_url: string, init: RequestInit) => {
+      sentBody = JSON.parse(String(init.body));
+      return sseResponse(HAPPY_SSE);
+    }) as unknown as typeof fetch;
+    const thread: PostableThread = { id: "slack:C1:T1", post: async () => {} };
+    const atts: ImageAttachment[] = [
+      { filename: "a.png", extracted_text: "a chart", mime_type: "image/png" },
+    ];
+    await answerInThread(thread, "what is this?", "mention", { userId: "U1" }, true, atts);
+    assert.deepStrictEqual(sentBody.attachments, atts);
+  });
+
+  it("keeps the text-only body byte-identical to today (no attachments key)", async () => {
+    let rawBody = "";
+    globalThis.fetch = (async (_url: string, init: RequestInit) => {
+      rawBody = String(init.body);
+      return sseResponse(HAPPY_SSE);
+    }) as unknown as typeof fetch;
+    const thread: PostableThread = { id: "slack:C1:T1", post: async () => {} };
+    // No attachments arg at all → behaves exactly like the legacy call.
+    await answerInThread(thread, "why?", "mention", { userId: "U1" }, true);
+    const parsed = JSON.parse(rawBody);
+    assert.ok(!("attachments" in parsed), "text-only body must not carry an attachments key");
+    assert.deepStrictEqual(Object.keys(parsed).sort(), ["question", "session_id", "user_id"].sort());
+  });
+
+  it("omits `attachments` when an empty array is passed (all images failed)", async () => {
+    let parsed: Record<string, unknown> = {};
+    globalThis.fetch = (async (_url: string, init: RequestInit) => {
+      parsed = JSON.parse(String(init.body));
+      return sseResponse(HAPPY_SSE);
+    }) as unknown as typeof fetch;
+    const thread: PostableThread = { id: "slack:C1:T1", post: async () => {} };
+    await answerInThread(thread, "q", "mention", { userId: "U1" }, true, []);
+    assert.ok(!("attachments" in parsed));
+  });
+});

--- a/bot/src/vision.test.ts
+++ b/bot/src/vision.test.ts
@@ -31,8 +31,13 @@ process.env.BOT_VISION_MAX_IMAGES = "2";
 process.env.BOT_VISION_MAX_BYTES = "1000";
 process.env.BRIDGE_API_KEY = "bridge-secret";
 
-const { extractImageAttachments, decideMentionGate, isImageAttachment, answerInThread } =
-  await import("./index.js");
+const {
+  extractImageAttachments,
+  decideMentionGate,
+  resolvePostExtraction,
+  isImageAttachment,
+  answerInThread,
+} = await import("./index.js");
 
 type ProxyFile = (url: string) => Promise<{ contentType: string; buffer: Buffer }>;
 
@@ -78,6 +83,24 @@ describe("decideMentionGate", () => {
       decideMentionGate({ text: "what is our stack?", broadcast: false, hasImage: false }),
       "respond",
     );
+  });
+});
+
+describe("resolvePostExtraction (gate recovery when images fail)", () => {
+  it("proceeds when at least one image was described", () => {
+    // Even if the text alone would have been a bare mention, a described image
+    // is a real answerable subject.
+    assert.strictEqual(resolvePostExtraction("prompt", true), "proceed");
+    assert.strictEqual(resolvePostExtraction("skip", true), "proceed");
+    assert.strictEqual(resolvePostExtraction("respond", true), "proceed");
+  });
+
+  it("falls back to the text-only intent when no image was described", () => {
+    // The image override turned these into "respond"; with zero images
+    // extracted we must honour what the text alone warranted.
+    assert.strictEqual(resolvePostExtraction("prompt", false), "prompt"); // bare @mention → nudge
+    assert.strictEqual(resolvePostExtraction("skip", false), "skip"); // announcement → stay quiet
+    assert.strictEqual(resolvePostExtraction("respond", false), "proceed"); // real question → answer
   });
 });
 

--- a/src/beever_atlas/api/ask.py
+++ b/src/beever_atlas/api/ask.py
@@ -39,6 +39,12 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
+# Internal routes (bot → backend). Mounted separately in `server/app.py` with
+# `Depends(require_bridge)` so they stay OFF the public surface and behind
+# BRIDGE_API_KEY — a leaked user key can NOT reach the vision pipeline. Mirrors
+# the `internal_router` pattern in `api/connections.py`.
+internal_router = APIRouter()
+
 MAX_UPLOAD_SIZE = 10 * 1024 * 1024  # 10MB
 
 # Process-local cache of channel_id -> Slack workspace subdomain (e.g.
@@ -2758,3 +2764,82 @@ async def submit_ask_feedback(
     )
 
     return {"status": "ok", "feedback": doc}
+
+
+# ---------------------------------------------------------------------------
+# Internal: ephemeral image → text (bot @mention vision path)
+# ---------------------------------------------------------------------------
+
+
+class _ExtractMediaTextRequest(BaseModel):
+    """Body for the bot's describe-only image extraction call.
+
+    `data_b64` is the base64-encoded raw image bytes the bot fetched (safely,
+    via its per-connection `proxyFile` SSRF guard). This path is ephemeral —
+    nothing is persisted to GridFS; it only returns a vision description for
+    injection into the `/ask` attachments field.
+    """
+
+    filename: str
+    mime_type: str
+    data_b64: str
+    message_text: str = ""
+
+
+# Magic-byte signatures for the image mimes ImageExtractor supports. We verify
+# the DECODED bytes actually start with a real image signature (defence against
+# a mislabelled/poisoned `mime_type`), not just trust the claimed mime.
+# NOTE: Pillow-based dimension / decode-bomb checks (pixel-count caps) are a
+# deferred v2 hardening — Pillow is not installed in this image.
+def _looks_like_image(data: bytes) -> bool:
+    if data.startswith(b"\x89PNG\r\n\x1a\n"):
+        return True  # PNG
+    if data.startswith(b"\xff\xd8\xff"):
+        return True  # JPEG
+    if data.startswith(b"GIF87a") or data.startswith(b"GIF89a"):
+        return True  # GIF
+    if data[:4] == b"RIFF" and data[8:12] == b"WEBP":
+        return True  # WEBP
+    return False
+
+
+@internal_router.post("/api/internal/media/extract-text")
+async def extract_media_text(body: _ExtractMediaTextRequest) -> dict:
+    """Describe an image via the existing vision pipeline (bot @mention path).
+
+    Secured by the router-level `require_bridge` dependency (mounted in
+    `server/app.py`). Never expose to end users — a leaked user API key must
+    not reach the vision pipeline.
+    """
+    import base64
+    import binascii
+
+    from beever_atlas.services.media_extractors import ImageExtractor
+
+    try:
+        decoded = base64.b64decode(body.data_b64, validate=True)
+    except (binascii.Error, ValueError):
+        raise HTTPException(status_code=400, detail="Invalid base64 payload")
+
+    # Single source of truth for the size cap — reuse the upload limit on the
+    # DECODED bytes (not the inflated base64 string).
+    if len(decoded) > MAX_UPLOAD_SIZE:
+        raise HTTPException(status_code=413, detail="File too large. Maximum size: 10MB")
+
+    extractor = ImageExtractor()
+    if body.mime_type not in extractor.supported_mime_types or not _looks_like_image(decoded):
+        raise HTTPException(status_code=415, detail="Unsupported or non-image file")
+
+    result = await extractor.extract(decoded, body.filename, {"message_text": body.message_text})
+    extracted_text = result.text
+    # Truncate to 4000 chars (mirror upload_attachment).
+    if len(extracted_text) > 4000:
+        extracted_text = (
+            extracted_text[:4000] + "\n\n[... truncated, showing first 4000 characters ...]"
+        )
+
+    return {
+        "filename": body.filename,
+        "extracted_text": extracted_text,
+        "mime_type": body.mime_type,
+    }

--- a/src/beever_atlas/server/app.py
+++ b/src/beever_atlas/server/app.py
@@ -24,7 +24,11 @@ from beever_atlas.infra.loader_url_headers import LoaderUrlSecurityHeadersMiddle
 
 from beever_atlas.adapters import close_adapter
 from beever_atlas.infra.rate_limit import limiter
-from beever_atlas.api.ask import router as ask_router, public_router as ask_public_router
+from beever_atlas.api.ask import (
+    router as ask_router,
+    public_router as ask_public_router,
+    internal_router as ask_internal_router,
+)
 from beever_atlas.api.channels import router as channels_router
 from beever_atlas.api.connections import (
     router as connections_router,
@@ -1107,6 +1111,7 @@ app.include_router(channels_router, dependencies=_auth)
 app.include_router(connections_router, dependencies=_auth)
 # Internal bot→backend routes: bridge key only, never exposed to end users.
 app.include_router(connections_internal_router, dependencies=[Depends(require_bridge)])
+app.include_router(ask_internal_router, dependencies=[Depends(require_bridge)])
 app.include_router(imports_router, dependencies=_auth)
 app.include_router(sync_router, dependencies=_auth)
 app.include_router(memories_router, dependencies=_auth)

--- a/tests/api/test_ask_internal_media.py
+++ b/tests/api/test_ask_internal_media.py
@@ -1,0 +1,166 @@
+"""Tests for the internal image → text endpoint (bot @mention vision path).
+
+`POST /api/internal/media/extract-text` is mounted behind `require_bridge`, so
+a leaked user API key (or no auth at all) must never reach the vision pipeline.
+The vision call itself is monkeypatched out — these tests exercise auth, the
+size/magic-byte guards, the happy path, and the 4000-char truncation, NOT a
+live Gemini call.
+"""
+
+from __future__ import annotations
+
+import base64
+
+import pytest
+from fastapi import Depends, FastAPI
+from httpx import ASGITransport, AsyncClient
+
+import beever_atlas.infra.auth as auth_mod
+from beever_atlas.api.ask import internal_router
+from beever_atlas.infra.auth import require_bridge
+from beever_atlas.infra.config import Settings
+from beever_atlas.services.media_extractors import ImageExtractor, MediaContent
+
+
+def _png_bytes() -> bytes:
+    # Minimal 1×1 PNG (same fixture used in test_image_extractor_concurrency).
+    return (
+        b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01"
+        b"\x00\x00\x00\x01\x08\x02\x00\x00\x00\x90wS\xde\x00\x00"
+        b"\x00\x0cIDATx\x9cc\xf8\x0f\x00\x00\x01\x01\x00\x05\x18"
+        b"\xd8N\x00\x00\x00\x00IEND\xaeB`\x82"
+    )
+
+
+def _patch_bridge_settings(monkeypatch, **overrides):
+    base: dict = dict(
+        api_keys="user-key",
+        bridge_api_key="s3cret",
+        admin_token="admin-tok",
+    )
+    base.update(overrides)
+
+    def fake_get_settings() -> Settings:
+        return Settings(**base)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(auth_mod, "get_settings", fake_get_settings)
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(internal_router, dependencies=[Depends(require_bridge)])
+    return app
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture
+async def client(monkeypatch):
+    _patch_bridge_settings(monkeypatch)
+    transport = ASGITransport(app=_build_app())
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+_BRIDGE_HEADERS = {"Authorization": "Bearer s3cret"}
+
+
+def _body(data: bytes, mime: str = "image/png", message_text: str = "") -> dict:
+    return {
+        "filename": "shot.png",
+        "mime_type": mime,
+        "data_b64": base64.b64encode(data).decode("ascii"),
+        "message_text": message_text,
+    }
+
+
+@pytest.mark.anyio
+async def test_rejects_missing_bridge_auth(client):
+    resp = await client.post("/api/internal/media/extract-text", json=_body(_png_bytes()))
+    assert resp.status_code == 401
+
+
+@pytest.mark.anyio
+async def test_rejects_user_key(client):
+    """A user API key must never satisfy the bridge dependency."""
+    resp = await client.post(
+        "/api/internal/media/extract-text",
+        json=_body(_png_bytes()),
+        headers={"Authorization": "Bearer user-key"},
+    )
+    assert resp.status_code == 401
+
+
+@pytest.mark.anyio
+async def test_oversize_decoded_payload_413(client, monkeypatch):
+    import beever_atlas.api.ask as ask_mod
+
+    # Shrink the cap so we don't have to ship 10MB of base64 over the wire.
+    monkeypatch.setattr(ask_mod, "MAX_UPLOAD_SIZE", 16)
+    big = _png_bytes() + b"\x00" * 64  # > 16 bytes decoded, still a valid PNG header
+    resp = await client.post(
+        "/api/internal/media/extract-text",
+        json=_body(big),
+        headers=_BRIDGE_HEADERS,
+    )
+    assert resp.status_code == 413
+
+
+@pytest.mark.anyio
+async def test_unsupported_mime_415(client):
+    resp = await client.post(
+        "/api/internal/media/extract-text",
+        json=_body(_png_bytes(), mime="application/pdf"),
+        headers=_BRIDGE_HEADERS,
+    )
+    assert resp.status_code == 415
+
+
+@pytest.mark.anyio
+async def test_non_image_magic_bytes_415(client):
+    # Supported mime but the bytes are not a real image (poisoned mime_type).
+    resp = await client.post(
+        "/api/internal/media/extract-text",
+        json=_body(b"this is definitely not a png", mime="image/png"),
+        headers=_BRIDGE_HEADERS,
+    )
+    assert resp.status_code == 415
+
+
+@pytest.mark.anyio
+async def test_happy_path_returns_extracted_text(client, monkeypatch):
+    async def fake_extract(self, data, filename, metadata=None):  # noqa: ANN001
+        return MediaContent(text="A diagram of the deploy pipeline.", media_type="image")
+
+    monkeypatch.setattr(ImageExtractor, "extract", fake_extract)
+    resp = await client.post(
+        "/api/internal/media/extract-text",
+        json=_body(_png_bytes(), message_text="what is this?"),
+        headers=_BRIDGE_HEADERS,
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["filename"] == "shot.png"
+    assert data["mime_type"] == "image/png"
+    assert data["extracted_text"] == "A diagram of the deploy pipeline."
+
+
+@pytest.mark.anyio
+async def test_extracted_text_truncated_to_4000(client, monkeypatch):
+    async def fake_extract(self, data, filename, metadata=None):  # noqa: ANN001
+        return MediaContent(text="x" * 9000, media_type="image")
+
+    monkeypatch.setattr(ImageExtractor, "extract", fake_extract)
+    resp = await client.post(
+        "/api/internal/media/extract-text",
+        json=_body(_png_bytes()),
+        headers=_BRIDGE_HEADERS,
+    )
+    assert resp.status_code == 200
+    text = resp.json()["extracted_text"]
+    assert text.startswith("x" * 4000)
+    assert "truncated" in text
+    assert len(text) < 9000


### PR DESCRIPTION
## What
@mention the bot with an image and it answers about the image **in real time** — no channel sync required. The bot fetches the image bytes, runs them through the existing Gemini vision pipeline, and injects the description into the `/ask` attachments field the agent already consumes.

## Security (this was adversarially planned — the naive approach had a token-leak hole)
- **Byte fetch goes through the SSRF-guarded bridge `proxyFile`** (allowlist + private-IP guard + Discord CDN refresh + Slack `files.info` fallback) — **never** the adapter `fetchData`, which raw-fetches an attacker-influenceable `url_private` *with the bot token* and no private-IP guard.
- New `POST /api/internal/media/extract-text` is mounted behind **`require_bridge`** (off the public surface; a leaked user key can't reach the vision pipeline).
- **Magic-byte image validation** + the existing **10 MB `MAX_UPLOAD_SIZE`** cap on decoded bytes.
- **Fail-open:** any error (proxyFile throw, 401 when `BRIDGE_API_KEY` unset, timeout, non-2xx) skips that image and still answers from text — never aborts the mention. No bytes/tokens logged.
- Routed through **`ImageExtractor`** → inherits SHA-256 media cache + `_should_use_vision` gate.

## Config (kill switch + caps)
`BOT_VISION_ENABLED` (default on), `BOT_VISION_MAX_IMAGES` (4), `BOT_VISION_MAX_BYTES` (10 MB), `BOT_VISION_TIMEOUT_MS` (30000).

## Tests
Backend 7 (auth/413/415/200/truncation), bot vision suite; full bot suite **431 pass**, ruff + tsc clean.

## Scope / deferred (v2)
Images only in v1. PDFs/doc-Q&A and multi-image are easy follow-ons (same path); Pillow decode-bomb dimension check deferred (Pillow isn't a dep). Telegram best-effort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)