### PR TITLE
fix(bot): decode base64 Mattermost channel id so /ask hits the indexed channel

### DIFF
--- a/bot/src/thread-id.test.ts
+++ b/bot/src/thread-id.test.ts
@@ -23,6 +23,23 @@ describe("extractChannelId", () => {
     assert.strictEqual(extractChannelId("nocolons"), "nocolons");
     assert.strictEqual(extractChannelId("discord:guild456"), "guild456");
   });
+
+  it("base64-decodes the Mattermost channel to the raw indexed id", () => {
+    // The SDK base64-encodes the Mattermost channel; ingestion stores facts
+    // under the raw id. extractChannelId must return the raw id so /ask
+    // retrieval hits the indexed channel (regression: "nothing indexed" on a
+    // fully-synced Mattermost channel).
+    const raw = "ykamsyq77tf13ybrnybsnh4bgh";
+    const enc = Buffer.from(raw, "utf8").toString("base64"); // eWthbXN5cTc3...=
+    assert.strictEqual(extractChannelId(`mattermost:${enc}:thread123`), raw);
+    // Padding-stripped form (as it appears in real thread ids) decodes too.
+    assert.strictEqual(extractChannelId(`mattermost:${enc.replace(/=+$/, "")}:t`), raw);
+  });
+
+  it("leaves a non-base64 / already-raw Mattermost segment unchanged", () => {
+    // A segment that doesn't decode to a canonical 26-char id is returned as-is.
+    assert.strictEqual(extractChannelId("mattermost:plainchannel:t"), "plainchannel");
+  });
 });
 
 describe("extractThreadId", () => {

--- a/bot/src/thread-id.ts
+++ b/bot/src/thread-id.ts
@@ -19,19 +19,49 @@ function isDiscord(parts: string[]): boolean {
   return parts[0]?.toLowerCase() === "discord";
 }
 
+/** A canonical Mattermost id is 26 lowercase base32 chars (a–z, 0–9). */
+const MATTERMOST_ID_RE = /^[a-z0-9]{26}$/;
+
+/**
+ * Recover the RAW Mattermost channel id from a thread-id segment.
+ *
+ * The SDK base64-encodes the Mattermost channel id inside the thread id
+ * (`mattermost:<base64-channel>:<thread>`), but ingestion/sync — and therefore
+ * the stored facts, wiki, and the `/api/channels/{id}/...` routes — key on the
+ * RAW Mattermost channel id. Passing the base64 segment to `/ask` queries a
+ * non-existent channel and returns "nothing indexed" even for a fully-synced
+ * channel (observed live). Decode it back. Guarded: only accept a decode that
+ * yields a canonical 26-char Mattermost id, so a segment that is already raw
+ * (or any non-base64 value) is returned unchanged.
+ */
+function decodeMattermostChannel(segment: string): string {
+  try {
+    const decoded = Buffer.from(segment, "base64").toString("utf8");
+    if (MATTERMOST_ID_RE.test(decoded)) return decoded;
+  } catch {
+    /* not base64 — fall through to the raw segment */
+  }
+  return segment;
+}
+
 /**
  * Extract the channel id, falling back to the whole id.
- * Slack/Teams/Telegram/Mattermost: the second segment. Discord: the THIRD
- * segment (the second is the guild id) — using the second there routes the
+ * Slack/Teams/Telegram: the second segment. Discord: the THIRD segment (the
+ * second is the guild id) — using the second there routes the
  * `/api/channels/{id}/ask` call to the guild and misses the channel's indexed
- * knowledge entirely.
+ * knowledge entirely. Mattermost: the second segment, base64-DECODED to the raw
+ * channel id that ingestion stored facts under (see decodeMattermostChannel).
  */
 export function extractChannelId(threadId: string): string {
   const parts = threadId.split(":");
   if (isDiscord(parts) && parts.length >= 3) {
     return parts[2];
   }
-  return parts.length >= 2 ? parts[1] : threadId;
+  if (parts.length < 2) return threadId;
+  if (parts[0]?.toLowerCase() === "mattermost") {
+    return decodeMattermostChannel(parts[1]);
+  }
+  return parts[1];
 }
 
 /**


### PR DESCRIPTION
## Bug
On Mattermost, @mentioning the bot returned **"I don't have anything indexed for that in this channel yet"** even for a fully-synced channel (verified live on EE: 768 messages, 53 wiki pages, **832 facts**).

## Root cause
The SDK base64-encodes the Mattermost channel id in the thread id (`mattermost:<base64-channel>:<thread>`), but ingestion/sync store facts under the **raw** channel id. `extractChannelId()` passed the base64 segment verbatim to `/api/channels/{id}/ask` → retrieval queried a non-existent channel → empty. Slack/Discord pass raw ids, so they were unaffected.

Verified the exact round-trip on live data: `base64("ykamsyq77tf13ybrnybsnh4bgh") == "eWthbXN5cTc3dGYxM3licm55YnNuaDRiZ2g"`.

## Fix
`extractChannelId` base64-decodes the Mattermost segment, **guarded** to only accept a canonical 26-char Mattermost id (`/^[a-z0-9]{26}$/`) so an already-raw or non-base64 segment is returned unchanged. +2 regression tests; full bot suite 435 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)