### PR TITLE
fix(bot): render ## headings & lists as blocks (kill wall-of-text replies)

### DIFF
--- a/bot/src/renderer.test.ts
+++ b/bot/src/renderer.test.ts
@@ -9,9 +9,51 @@ import {
   enforceCap,
   relativeTime,
   ageInDays,
+  normalizeBlocks,
   CHAR_CAP,
 } from "./renderer.js";
 import type { AskResult } from "./types.js";
+
+describe("normalizeBlocks", () => {
+  it("breaks a heading glued mid-line onto its own block", () => {
+    const out = normalizeBlocks("...data persistence. ## Beever Atlas Overview\nbody");
+    assert.ok(out.includes("persistence.\n\n## Beever Atlas Overview"), out);
+    // The heading is now at line-start (a chat platform will promote it).
+    assert.ok(/\n## Beever Atlas Overview/.test(out));
+  });
+
+  it("breaks a list item glued after sentence-ending punctuation", () => {
+    const out = normalizeBlocks("memory [4]. * Long-term Recall: enables recall");
+    assert.ok(out.includes("[4].\n\n* Long-term Recall"), out);
+  });
+
+  it("adds a blank line before a heading on a single newline, not between list items", () => {
+    const out = normalizeBlocks("prose\n## H\n- a\n- b");
+    assert.ok(out.includes("prose\n\n## H"), out);
+    // No blank line inserted between the two list items.
+    assert.ok(out.includes("- a\n- b"), out);
+  });
+
+  it("leaves already-clean markdown unchanged (idempotent)", () => {
+    const clean = "Intro.\n\n## Heading\n\n- a\n- b";
+    assert.strictEqual(normalizeBlocks(clean), clean);
+    assert.strictEqual(normalizeBlocks(normalizeBlocks(clean)), clean);
+  });
+
+  it("does not touch `#`/`-` inside a fenced code block (e.g. Mermaid)", () => {
+    const fenced = "text\n```mermaid\n## not a heading\n- not a list\n```\nafter";
+    assert.strictEqual(normalizeBlocks(fenced), fenced);
+  });
+
+  it("never mis-splits a prose dash (A - B)", () => {
+    const out = normalizeBlocks("the A - B tradeoff is real");
+    assert.strictEqual(out, "the A - B tradeoff is real");
+  });
+
+  it("collapses 3+ newlines to 2", () => {
+    assert.strictEqual(normalizeBlocks("a\n\n\n\nb"), "a\n\nb");
+  });
+});
 
 function result(overrides: Partial<AskResult> = {}): AskResult {
   return {

--- a/bot/src/renderer.ts
+++ b/bot/src/renderer.ts
@@ -93,6 +93,76 @@ export function enforceCap(text: string, cap: number): string {
 }
 
 /**
+ * Make `##`/`###` headings and bullet lists render as real blocks on every
+ * platform.
+ *
+ * The QA model sometimes glues a heading or list onto the SAME line as the
+ * preceding prose — `…persistence. ## Overview …` or `…characteristics: * a`.
+ * Every chat platform's markdown parser (Slack mrkdwn, and the remark-gfm the
+ * SDK FormatConverter feeds Discord/Teams/Mattermost) only promotes an ATX
+ * heading / list item that is at the START of a line; a mid-line `##` renders
+ * as literal `##` text, producing the observed wall-of-text. (The web Ask UI is
+ * unaffected — it renders the persisted markdown with its own React renderer.)
+ *
+ * This pass: (1) breaks a heading/list glued mid-line onto its own line, then
+ * (2) guarantees a blank line before each heading and before the FIRST item of
+ * a list (never between items — that would split the list), and (3) collapses
+ * 3+ newlines to 2. Code-fenced blocks (```/~~~, e.g. Mermaid) are left
+ * untouched. Idempotent: already-clean markdown passes through unchanged.
+ */
+const _HEAD_RE = /^[ \t]*#{1,6}[ \t]+\S/;
+const _LIST_RE = /^[ \t]*([-*+]|\d+\.)[ \t]+/;
+const _FENCE_RE = /^[ \t]*(```|~~~)/;
+
+export function normalizeBlocks(md: string): string {
+  // Pass 1 — glue-break: split a heading/list off the preceding text. Headings
+  // break after any non-space char; lists only after sentence-ending
+  // punctuation (`.` `:` `]`) so a prose dash ("A - B") is never mis-split.
+  const expanded: string[] = [];
+  let inFence = false;
+  for (const line of md.split("\n")) {
+    if (_FENCE_RE.test(line)) {
+      expanded.push(line);
+      inFence = !inFence;
+      continue;
+    }
+    if (inFence) {
+      expanded.push(line);
+      continue;
+    }
+    const broken = line
+      .replace(/(\S)[ \t]+(#{1,6}[ \t]+)/g, "$1\n$2")
+      .replace(/([.:\]])[ \t]+([-*+][ \t]+\S)/g, "$1\n$2");
+    for (const seg of broken.split("\n")) expanded.push(seg);
+  }
+
+  // Pass 2 — block separation: a blank line before each heading / first list item.
+  const out: string[] = [];
+  inFence = false;
+  for (const line of expanded) {
+    if (_FENCE_RE.test(line)) {
+      inFence = !inFence;
+      out.push(line);
+      continue;
+    }
+    if (inFence) {
+      out.push(line);
+      continue;
+    }
+    const prev = out.length ? out[out.length - 1] : "";
+    const prevNonBlank = prev.trim() !== "";
+    if (_HEAD_RE.test(line) && prevNonBlank) {
+      out.push("");
+    } else if (_LIST_RE.test(line) && prevNonBlank && !_LIST_RE.test(prev)) {
+      out.push("");
+    }
+    out.push(line);
+  }
+
+  return out.join("\n").replace(/\n{3,}/g, "\n\n");
+}
+
+/**
  * Defense-in-depth: citation fields come from the backend but pass through
  * channel-message content, wiki titles, and user display names. Collapse
  * control chars / newlines (so a crafted value can't forge an extra
@@ -444,8 +514,10 @@ export function renderResponse(result: AskResult, platform: string): string {
 
   const cap = capFor(plat);
 
-  // Only the ANSWER body may be truncated under cap pressure.
-  const answerBody = (result.answer || "").trimEnd();
+  // Only the ANSWER body may be truncated under cap pressure. normalizeBlocks
+  // breaks mid-line-glued `##` headings / lists onto their own line so they
+  // render as real blocks on every platform (else they show as literal `##`).
+  const answerBody = normalizeBlocks(result.answer || "").trimEnd();
 
   // Trust caveats — the web-only provenance note and the low-confidence
   // "verify against the sources" warning — sit right under the answer AND must


### PR DESCRIPTION
## Bug
Bot replies on Mattermost/Slack render `## Heading` as **literal text in a wall of text** — while the *same* QA answer renders beautifully in the web Ask UI (proof the agent/markdown is fine; the bug is chat-only).

## Root cause (workflow-investigated, remark-gfm parser tested)
The QA model occasionally glues a heading/list onto the **same line** as preceding prose (`…persistence. ## Overview`, `…[4]. * Long-term Recall`). Every chat platform's markdown parser only promotes an ATX heading / list item at **line start**, so a mid-line `##` renders literally. It's a **line-start glue** problem, not 'missing blank lines'.

## Fix — chat-only, leaves the shared QA agent + web UI untouched
`normalizeBlocks()` in renderer.ts (applied to the answer body): breaks a heading/list glued mid-line onto its own line, ensures a blank line before each heading + the first list item (never between items), collapses 3+ newlines, and **skips fenced code** (Mermaid). Idempotent; clean markdown unchanged. **+7 unit tests** (symptom, idempotency, fence-safety, prose-dash, list-not-split). Full bot suite 442 pass; lint + tsc clean.

## Deferred (separate follow-up)
The rarer corruption fragments ('0)', 'py`)') — the marker-width dedup walk in `_dedup_exact_double` is genuinely off-boundary for some inputs, but a naive boundary guard re-exposes answer-doubling (verified). Needs careful separate work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)