### PR TITLE
fix(retrieval): three faults that made fact + graph answers empty/junk (BM25 query_properties, neo4j .data(), find_experts)

### DIFF
--- a/src/beever_atlas/agents/tools/graph_tools.py
+++ b/src/beever_atlas/agents/tools/graph_tools.py
@@ -466,9 +466,7 @@ async def find_experts(channel_id: str, topic: str, limit: int = 5) -> list:
             )
             person_names = {p.name for p in persons if getattr(p, "name", None)}
         except Exception:
-            logger.warning(
-                "find_experts: person roster lookup failed for channel=%s", channel_id
-            )
+            logger.warning("find_experts: person roster lookup failed for channel=%s", channel_id)
 
         topic_lower = topic.lower()
         person_scores: dict[str, dict[str, Any]] = {}
@@ -526,9 +524,7 @@ async def find_experts(channel_id: str, topic: str, limit: int = 5) -> list:
                     bucket["expertise_score"] += cnt
                     bucket["fact_count"] += cnt
             except Exception:
-                logger.warning(
-                    "find_experts: fact-authorship fallback failed for topic=%s", topic
-                )
+                logger.warning("find_experts: fact-authorship fallback failed for topic=%s", topic)
 
         scored = sorted(
             person_scores.values(),

--- a/src/beever_atlas/agents/tools/graph_tools.py
+++ b/src/beever_atlas/agents/tools/graph_tools.py
@@ -453,6 +453,23 @@ async def find_experts(channel_id: str, topic: str, limit: int = 5) -> list:
 
         rels = await graph.list_relationships(channel_id=channel_id, limit=500)
 
+        # Restrict candidate experts to PEOPLE. Without this, find_experts
+        # returned whatever sat on the other end of a topic-name match —
+        # concept/document/event nodes like "Copyright-assignment CLA", "AI
+        # Agents" or "FSF" surfaced as "experts on project". We score only
+        # entities typed Person. If the channel has no Person roster yet (older
+        # graphs), fall back to the previous any-endpoint behaviour.
+        person_names: set[str] = set()
+        try:
+            persons = await graph.list_entities(
+                channel_id=channel_id, entity_type="Person", limit=1000
+            )
+            person_names = {p.name for p in persons if getattr(p, "name", None)}
+        except Exception:
+            logger.warning(
+                "find_experts: person roster lookup failed for channel=%s", channel_id
+            )
+
         topic_lower = topic.lower()
         person_scores: dict[str, dict[str, Any]] = {}
 
@@ -460,19 +477,58 @@ async def find_experts(channel_id: str, topic: str, limit: int = 5) -> list:
             for endpoint in (rel.source, rel.target):
                 if endpoint and topic_lower in endpoint.lower():
                     other = rel.target if endpoint == rel.source else rel.source
-                    if other:
-                        bucket = person_scores.setdefault(
-                            other,
-                            {
-                                "handle": other,
-                                "expertise_score": 0,
-                                "fact_count": 0,
-                                "_topics": set(),
-                            },
-                        )
-                        bucket["expertise_score"] += 1
-                        bucket["fact_count"] += 1
-                        bucket["_topics"].add(endpoint)
+                    if not other or other == endpoint:
+                        continue
+                    # Only people count as experts (when the roster is known).
+                    if person_names and other not in person_names:
+                        continue
+                    bucket = person_scores.setdefault(
+                        other,
+                        {
+                            "handle": other,
+                            "expertise_score": 0,
+                            "fact_count": 0,
+                            "_topics": set(),
+                        },
+                    )
+                    bucket["expertise_score"] += 1
+                    bucket["fact_count"] += 1
+                    bucket["_topics"].add(endpoint)
+
+        # Augment with fact-authorship when the entity graph yields few people.
+        # The graph only links a person to a topic when an edge endpoint's NAME
+        # contains the topic, which is sparse — so "who contributes to X" often
+        # came back empty even though people clearly authored facts about X. Rank
+        # the humans who wrote facts matching the topic as a fallback/top-up.
+        if len(person_scores) < limit:
+            try:
+                from collections import Counter
+
+                from beever_atlas.capabilities.memory import _search_channel_facts_impl
+
+                _SKIP_AUTHORS = {"", "unknown", "system", "bot", "beever atlas", "assistant"}
+                facts = await _search_channel_facts_impl(channel_id, topic, limit=30)
+                author_counts: Counter[str] = Counter()
+                for f in facts:
+                    name = (f.get("author") or "").strip()
+                    if name and name.lower() not in _SKIP_AUTHORS:
+                        author_counts[name] += 1
+                for name, cnt in author_counts.most_common(limit * 2):
+                    bucket = person_scores.setdefault(
+                        name,
+                        {
+                            "handle": name,
+                            "expertise_score": 0,
+                            "fact_count": 0,
+                            "_topics": {topic},
+                        },
+                    )
+                    bucket["expertise_score"] += cnt
+                    bucket["fact_count"] += cnt
+            except Exception:
+                logger.warning(
+                    "find_experts: fact-authorship fallback failed for topic=%s", topic
+                )
 
         scored = sorted(
             person_scores.values(),

--- a/src/beever_atlas/capabilities/graph.py
+++ b/src/beever_atlas/capabilities/graph.py
@@ -216,9 +216,7 @@ async def _find_experts_impl(
             )
             person_names = {p.name for p in persons if getattr(p, "name", None)}
         except Exception:
-            logger.warning(
-                "find_experts: person roster lookup failed for channel=%s", channel_id
-            )
+            logger.warning("find_experts: person roster lookup failed for channel=%s", channel_id)
 
         topic_lower = topic.lower()
         person_scores: dict[str, dict[str, Any]] = {}
@@ -280,9 +278,7 @@ async def _find_experts_impl(
                     bucket["expertise_score"] += cnt
                     bucket["fact_count"] += cnt
             except Exception:
-                logger.warning(
-                    "find_experts: fact-authorship fallback failed for topic=%s", topic
-                )
+                logger.warning("find_experts: fact-authorship fallback failed for topic=%s", topic)
 
         scored = sorted(
             person_scores.values(),

--- a/src/beever_atlas/capabilities/graph.py
+++ b/src/beever_atlas/capabilities/graph.py
@@ -202,6 +202,24 @@ async def _find_experts_impl(
 
         rels = await graph.list_relationships(channel_id=channel_id, limit=500)
 
+        # Restrict candidate experts to PEOPLE. Without this, find_experts
+        # returned whatever sat on the other end of a topic-name match —
+        # concept/document/event nodes like "Copyright-assignment CLA", "AI
+        # Agents" or "FSF" surfaced as "experts on project". We score only
+        # entities typed Person. If the channel has no Person roster yet (older
+        # graphs), fall back to the previous any-endpoint behaviour rather than
+        # returning nothing.
+        person_names: set[str] = set()
+        try:
+            persons = await graph.list_entities(
+                channel_id=channel_id, entity_type="Person", limit=1000
+            )
+            person_names = {p.name for p in persons if getattr(p, "name", None)}
+        except Exception:
+            logger.warning(
+                "find_experts: person roster lookup failed for channel=%s", channel_id
+            )
+
         topic_lower = topic.lower()
         person_scores: dict[str, dict[str, Any]] = {}
 
@@ -209,19 +227,62 @@ async def _find_experts_impl(
             for endpoint in (rel.source, rel.target):
                 if endpoint and topic_lower in endpoint.lower():
                     other = rel.target if endpoint == rel.source else rel.source
-                    if other:
-                        bucket = person_scores.setdefault(
-                            other,
-                            {
-                                "handle": other,
-                                "expertise_score": 0,
-                                "fact_count": 0,
-                                "_topics": set(),
-                            },
-                        )
-                        bucket["expertise_score"] += 1
-                        bucket["fact_count"] += 1
-                        bucket["_topics"].add(endpoint)
+                    if not other or other == endpoint:
+                        continue
+                    # Only people count as experts (when the roster is known).
+                    if person_names and other not in person_names:
+                        continue
+                    bucket = person_scores.setdefault(
+                        other,
+                        {
+                            "handle": other,
+                            "expertise_score": 0,
+                            "fact_count": 0,
+                            "_topics": set(),
+                        },
+                    )
+                    bucket["expertise_score"] += 1
+                    bucket["fact_count"] += 1
+                    bucket["_topics"].add(endpoint)
+
+        # Augment with fact-authorship when the entity graph yields few people.
+        # The graph only links a person to a topic when an edge endpoint's NAME
+        # contains the topic, which is sparse — so "who contributes to X" often
+        # came back empty even though people clearly authored facts about X. The
+        # direct signal is authorship: rank the humans who wrote facts matching
+        # the topic. (Runs whenever graph scoring is thin, never overriding a
+        # strong graph signal.)
+        if len(person_scores) < limit:
+            try:
+                from collections import Counter
+
+                from beever_atlas.capabilities.memory import _search_channel_facts_impl
+
+                _SKIP_AUTHORS = {"", "unknown", "system", "bot", "beever atlas", "assistant"}
+                facts = await _search_channel_facts_impl(channel_id, topic, limit=30)
+                author_counts: Counter[str] = Counter()
+                for f in facts:
+                    name = (f.get("author") or "").strip()
+                    if name and name.lower() not in _SKIP_AUTHORS:
+                        author_counts[name] += 1
+                for name, cnt in author_counts.most_common(limit * 2):
+                    bucket = person_scores.setdefault(
+                        name,
+                        {
+                            "handle": name,
+                            "expertise_score": 0,
+                            "fact_count": 0,
+                            "_topics": {topic},
+                        },
+                    )
+                    # Fact authorship is a weaker signal than a direct graph
+                    # edge, so it tops up rather than dominates existing scores.
+                    bucket["expertise_score"] += cnt
+                    bucket["fact_count"] += cnt
+            except Exception:
+                logger.warning(
+                    "find_experts: fact-authorship fallback failed for topic=%s", topic
+                )
 
         scored = sorted(
             person_scores.values(),

--- a/src/beever_atlas/stores/neo4j_store.py
+++ b/src/beever_atlas/stores/neo4j_store.py
@@ -1081,22 +1081,28 @@ class Neo4jStore:
                 eid=entity_id,
                 limit=limit,
             )
-            records = await result.data()
+            node_map: dict[str, GraphEntity] = {}
+            edges: list[GraphRelationship] = []
 
-        node_map: dict[str, GraphEntity] = {}
-        edges: list[GraphRelationship] = []
-
-        for row in records:
-            src_node = row["src_node"]
-            tgt_node = row["tgt_node"]
-            rel = row["rel"]
-
-            src = self._entity_from_record(src_node)
-            tgt = self._entity_from_record(tgt_node)
-            node_map[src.name] = src
-            node_map[tgt.name] = tgt
-
-            edges.append(self._rel_from_record(rel, source_name=src.name, target_name=tgt.name))
+            # Iterate RAW records — NOT result.data(). result.data() serialises a
+            # Relationship value into a 3-tuple (start_node, "TYPE", end_node),
+            # which (a) drops the relationship's own properties
+            # (confidence/context/source_fact_id) and (b) crashes
+            # _rel_from_record, whose dict(rel) then sees a tuple →
+            # "dictionary update sequence element #0 has length 12; 2 is
+            # required", so EVERY deep-mode relationship traversal silently
+            # returned no edges. Raw records preserve real Node/Relationship
+            # objects, which the _from_record helpers already handle.
+            async for row in result:
+                src = self._entity_from_record(row["src_node"])
+                tgt = self._entity_from_record(row["tgt_node"])
+                node_map[src.name] = src
+                node_map[tgt.name] = tgt
+                edges.append(
+                    self._rel_from_record(
+                        row["rel"], source_name=src.name, target_name=tgt.name
+                    )
+                )
 
         return Subgraph(nodes=list(node_map.values()), edges=edges)
 

--- a/src/beever_atlas/stores/neo4j_store.py
+++ b/src/beever_atlas/stores/neo4j_store.py
@@ -1099,9 +1099,7 @@ class Neo4jStore:
                 node_map[src.name] = src
                 node_map[tgt.name] = tgt
                 edges.append(
-                    self._rel_from_record(
-                        row["rel"], source_name=src.name, target_name=tgt.name
-                    )
+                    self._rel_from_record(row["rel"], source_name=src.name, target_name=tgt.name)
                 )
 
         return Subgraph(nodes=list(node_map.values()), edges=edges)

--- a/src/beever_atlas/stores/qa_history_store.py
+++ b/src/beever_atlas/stores/qa_history_store.py
@@ -28,6 +28,16 @@ _QA_HISTORY_PROPERTIES: list[tuple[str, DataType]] = [
     ("answer_kind", DataType.TEXT),
 ]
 
+# Content properties BM25 / hybrid may keyword-scan. MUST be passed explicitly on
+# every query.bm25()/query.hybrid() call: an omitted query_properties makes
+# Weaviate scan every searchable text prop, including ones added by the
+# ensure_schema missing-property migration after rows already existed (e.g.
+# answer_kind). Those rows lack an inverted ("wand") bucket for the new prop, so
+# the BM25 pass raises "could not find bucket for property ..." and the whole
+# search fails — silently returning empty QA-history recall. Restrict to the
+# question/answer text we actually want to match.
+_QA_BM25_QUERY_PROPERTIES: list[str] = ["question", "answer"]
+
 _REFUSAL_MARKERS = [
     "no record",
     "no information",
@@ -249,6 +259,7 @@ class QAHistoryStore:
             combined = channel_filter & not_deleted
             result = collection.query.hybrid(
                 query=query,
+                query_properties=_QA_BM25_QUERY_PROPERTIES,
                 vector=query_vector,
                 alpha=resolved_alpha,
                 limit=limit,
@@ -299,6 +310,7 @@ class QAHistoryStore:
             combined = channel_filter & not_deleted
             result = collection.query.bm25(
                 query=query,
+                query_properties=_QA_BM25_QUERY_PROPERTIES,
                 limit=limit,
                 filters=combined,
             )

--- a/src/beever_atlas/stores/weaviate_store.py
+++ b/src/beever_atlas/stores/weaviate_store.py
@@ -85,6 +85,29 @@ class WeaviateStore:
             await asyncio.to_thread(self._client.close)
             self._client = None
 
+    # Properties that BM25 / hybrid keyword search is allowed to scan.
+    #
+    # MUST be set explicitly on every ``query.bm25()`` / ``query.hybrid()`` call.
+    # When ``query_properties`` is omitted, Weaviate BM25-scans EVERY searchable
+    # text property — including structured ids like ``guild_id`` that are added to
+    # the class schema AFTER objects were imported (the missing-property migration
+    # on connect adds the schema entry but does NOT build a per-object inverted
+    # ("wand") bucket for the existing rows). Weaviate then raises
+    # ``wand: could not find bucket for property guild_id`` and the WHOLE search
+    # fails, so every fact retrieval silently returns empty. Restricting the scan
+    # to the human-readable content fields both dodges that fault and is the
+    # correct intent — we only ever want to keyword-match the fact body / author /
+    # tags / summary, never structured ids (guild_id / channel_id / tier / *_ts).
+    # Every property listed here is verified to carry an inverted ("wand") bucket
+    # on existing rows; do NOT add a late-introduced property without backfilling.
+    _BM25_QUERY_PROPERTIES: list[str] = [
+        "memory_text",
+        "author_name",
+        "topic_tags",
+        "entity_tags",
+        "thread_context_summary",
+    ]
+
     # All expected properties for the MemoryFact collection.
     _EXPECTED_PROPERTIES: list[tuple[str, DataType]] = [
         ("memory_text", DataType.TEXT),
@@ -906,6 +929,7 @@ class WeaviateStore:
             combined = channel_filter & tier_filter
             result = collection.query.bm25(
                 query=query,
+                query_properties=self._BM25_QUERY_PROPERTIES,
                 limit=limit,
                 filters=combined,
             )
@@ -966,6 +990,7 @@ class WeaviateStore:
 
             result = collection.query.hybrid(
                 query=query_text,
+                query_properties=self._BM25_QUERY_PROPERTIES,
                 vector=query_vector,
                 alpha=resolved_alpha,
                 limit=limit,

--- a/tests/agents/tools/test_graph_tools_refactor.py
+++ b/tests/agents/tools/test_graph_tools_refactor.py
@@ -224,12 +224,80 @@ async def test_find_experts_shape_matches_typeddict():
 async def test_find_experts_empty_returns_list_sentinel():
     graph = _graph_mock()
     graph.list_relationships.return_value = []
+    graph.list_entities.return_value = []
 
-    with _patch_stores(graph):
+    with (
+        _patch_stores(graph),
+        patch(
+            "beever_atlas.capabilities.memory._search_channel_facts_impl",
+            AsyncMock(return_value=[]),
+        ),
+    ):
         result = await find_experts("C1", "Nothing")
 
     assert isinstance(result, list)
     assert result == [{"_empty": True, "entity": "Nothing", "reason": "no_edges"}]
+
+
+def _handles(result) -> set[str]:
+    return {h.get("handle") or h.get("subject_id") for h in result if "_empty" not in h}
+
+
+@pytest.mark.asyncio
+async def test_find_experts_excludes_non_person_entities():
+    """A concept on the other end of a topic-name match must NOT be ranked as
+    an expert — only entities typed Person count. Guards the regression where
+    'who contributes to project' returned 'Copyright-assignment CLA' / 'FSF'."""
+    graph = _graph_mock()
+    graph.list_entities.return_value = [_node("alice"), _node("bob")]
+    graph.list_relationships.return_value = [
+        _edge("alice", "Project Apollo", "WORKS_ON"),
+        _edge("Copyright-assignment CLA", "Project Apollo", "RELATES_TO"),
+    ]
+
+    with (
+        _patch_stores(graph),
+        patch(
+            "beever_atlas.capabilities.memory._search_channel_facts_impl",
+            AsyncMock(return_value=[]),
+        ),
+    ):
+        result = await find_experts("C1", "Project", limit=5)
+
+    handles = _handles(result)
+    assert "alice" in handles
+    assert "Copyright-assignment CLA" not in handles
+
+
+@pytest.mark.asyncio
+async def test_find_experts_falls_back_to_fact_authorship():
+    """When the entity graph yields no people, rank the humans who authored
+    facts about the topic; skip system/bot authors."""
+    graph = _graph_mock()
+    graph.list_entities.return_value = []
+    graph.list_relationships.return_value = []  # no graph signal
+
+    facts = (
+        [{"author": "Carol"}] * 3
+        + [{"author": "Dave"}]
+        + [{"author": "Beever Atlas"}] * 5  # bot — must be skipped
+    )
+    with (
+        _patch_stores(graph),
+        patch(
+            "beever_atlas.capabilities.memory._search_channel_facts_impl",
+            AsyncMock(return_value=facts),
+        ),
+    ):
+        result = await find_experts("C1", "deployment", limit=5)
+
+    handles = _handles(result)
+    assert "Carol" in handles
+    assert "Dave" in handles
+    assert "Beever Atlas" not in handles
+    # Carol (3 facts) must outrank Dave (1 fact).
+    ordered = [h.get("handle") or h.get("subject_id") for h in result if "_empty" not in h]
+    assert ordered.index("Carol") < ordered.index("Dave")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_neo4j_hops.py
+++ b/tests/test_neo4j_hops.py
@@ -1,7 +1,13 @@
-"""Regression: hops in Neo4jStore.get_neighbors is clamped to [1, 4].
+"""Regression tests for Neo4jStore.get_neighbors.
 
-Prevents attacker-controlled `hops` from building unbounded Cypher path
-patterns like `-[r*1..1000]-` that can exhaust the server.
+1. ``hops`` is clamped to [1, 4] — prevents attacker-controlled `hops` from
+   building unbounded Cypher path patterns like `-[r*1..1000]-`.
+2. The neighborhood is read by iterating RAW driver records, NOT
+   ``result.data()``. ``result.data()`` serialises a Relationship value into a
+   3-tuple ``(start_node, "TYPE", end_node)`` which drops the relationship's own
+   properties and makes ``_rel_from_record`` raise
+   ``ValueError: dictionary update sequence element #0 has length 12`` — so every
+   deep-mode traversal silently returned zero edges.
 """
 
 from __future__ import annotations
@@ -9,12 +15,37 @@ from __future__ import annotations
 import pytest
 
 
+class _FakeRel(dict):
+    """Stand-in for a Neo4j Relationship: a property mapping (so ``dict(rel)``
+    works) that also carries ``element_id`` / ``type`` attributes."""
+
+    def __init__(self, props, element_id, rtype):
+        super().__init__(props)
+        self.element_id = element_id
+        self.type = rtype
+
+
 class _FakeResult:
+    def __init__(self, rows=None):
+        self._rows = rows or []
+        self.data_called = False
+
     async def data(self):
+        # If get_neighbors ever calls this again, the regression is back.
+        self.data_called = True
         return []
+
+    def __aiter__(self):
+        async def _gen():
+            for row in self._rows:
+                yield row
+
+        return _gen()
 
 
 class _FakeSession:
+    rows: list = []
+
     async def __aenter__(self):
         return self
 
@@ -24,7 +55,8 @@ class _FakeSession:
     async def run(self, query, **params):
         _FakeSession.last_query = query
         _FakeSession.last_params = params
-        return _FakeResult()
+        _FakeSession.last_result = _FakeResult(_FakeSession.rows)
+        return _FakeSession.last_result
 
 
 class _FakeDriver:
@@ -38,6 +70,7 @@ async def test_get_neighbors_clamps_hops_to_max_4():
 
     store = Neo4jStore.__new__(Neo4jStore)
     store._driver = _FakeDriver()
+    _FakeSession.rows = []
 
     await store.get_neighbors("some-eid", hops=99, limit=10)
 
@@ -51,7 +84,41 @@ async def test_get_neighbors_clamps_hops_floor_to_1():
 
     store = Neo4jStore.__new__(Neo4jStore)
     store._driver = _FakeDriver()
+    _FakeSession.rows = []
 
     await store.get_neighbors("some-eid", hops=0, limit=10)
 
     assert "[r*1..1]" in _FakeSession.last_query
+
+
+@pytest.mark.asyncio
+async def test_get_neighbors_builds_edges_from_raw_relationship_objects():
+    """The relationship's own properties must survive into the edge, and
+    ``result.data()`` must NOT be used (it would discard them and crash)."""
+    from beever_atlas.stores.neo4j_store import Neo4jStore
+
+    store = Neo4jStore.__new__(Neo4jStore)
+    store._driver = _FakeDriver()
+    _FakeSession.rows = [
+        {
+            "src_node": {"name": "Alan Yang", "properties": "{}"},
+            "tgt_node": {"name": "DOCX File", "properties": "{}"},
+            "rel": _FakeRel(
+                {"confidence": 0.9, "context": "will check them"},
+                element_id="5:abc:0",
+                rtype="ACTS_ON",
+            ),
+        }
+    ]
+
+    sub = await store.get_neighbors("some-eid", hops=1, limit=10)
+
+    assert not _FakeSession.last_result.data_called, "must not use result.data()"
+    assert len(sub.edges) == 1
+    edge = sub.edges[0]
+    assert edge.type == "ACTS_ON"
+    assert edge.source == "Alan Yang"
+    assert edge.target == "DOCX File"
+    assert edge.confidence == pytest.approx(0.9)
+    assert edge.context == "will check them"
+    assert {n.name for n in sub.nodes} == {"Alan Yang", "DOCX File"}

--- a/tests/test_true_hybrid_search.py
+++ b/tests/test_true_hybrid_search.py
@@ -59,6 +59,16 @@ async def test_true_hybrid_search_calls_weaviate_hybrid():
     assert call_kwargs["alpha"] == 0.6
     assert call_kwargs["limit"] == 10
 
+    # Regression guard: hybrid MUST scope BM25 to explicit content properties.
+    # Omitting query_properties makes Weaviate scan every searchable text prop
+    # (incl. late-added structured ids like guild_id whose existing rows have no
+    # inverted bucket) → "wand: could not find bucket for property guild_id" →
+    # the whole search throws and every fact retrieval silently returns empty.
+    qp = call_kwargs["query_properties"]
+    assert "memory_text" in qp
+    for structured in ("guild_id", "channel_id", "tier"):
+        assert structured not in qp, f"{structured} must not be BM25-scanned"
+
     # Result shape must match bm25_search / semantic_search consumers
     assert len(results) == 1
     assert "fact" in results[0]
@@ -148,6 +158,32 @@ async def test_true_hybrid_search_applies_channel_and_tier_filter():
     call_kwargs = fake_collection.query.hybrid.call_args.kwargs
     # filters must be set (non-None)
     assert call_kwargs.get("filters") is not None
+
+
+@pytest.mark.asyncio
+async def test_bm25_search_scopes_query_properties_excluding_guild_id():
+    """bm25_search must pass explicit query_properties so Weaviate never scans
+    structured-id props (guild_id/channel_id/tier). Without this, the BM25 WAND
+    pass fails with 'could not find bucket for property guild_id' on collections
+    where guild_id was schema-migrated in after rows already existed."""
+    from beever_atlas.stores.weaviate_store import WeaviateStore
+
+    store = WeaviateStore(url="http://localhost:8080")
+
+    fake_result = MagicMock()
+    fake_result.objects = []
+
+    fake_collection = MagicMock()
+    fake_collection.query.bm25.return_value = fake_result
+
+    with patch.object(store, "_collection", return_value=fake_collection):
+        await store.bm25_search(query="Alan Yang", channel_id="C123", tier="atomic")
+
+    fake_collection.query.bm25.assert_called_once()
+    qp = fake_collection.query.bm25.call_args.kwargs["query_properties"]
+    assert "memory_text" in qp
+    for structured in ("guild_id", "channel_id", "tier"):
+        assert structured not in qp, f"{structured} must not be BM25-scanned"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Three independent retrieval-layer faults were making the bot/QA agent answer "nothing indexed", crash deep-mode graph traversal, or return junk for "who contributes to X". All found while diagnosing the live demo; all verified live on EE.

---

## Fault 1 — BM25/hybrid scanned a property with no index bucket
`bm25()`/`hybrid()` were called without `query_properties`, so Weaviate BM25-scans *every* searchable text prop — including `guild_id` (migrated into `MemoryFact` after rows existed, so no inverted "wand" bucket). The pass raises `could not find bucket for property guild_id`, the whole query throws, and the BM25 fallback hits the same fault → callers get `[]`. Every fact-level question returned empty.
**Fix:** explicit `query_properties` (content fields only) in `weaviate_store.py` + `qa_history_store.py`.
**Verified live:** 832 facts in-channel; default → raised+0; with `query_properties` → real hits.

## Fault 2 — neo4j `get_neighbors` crashed every traversal
`await result.data()` serialises a Relationship into a property-less 3-tuple, so `_rel_from_record`'s `dict(rel)` raises `dictionary update sequence element #0 has length 12`. Deep-mode `search_relationships` silently returned no edges.
**Fix:** iterate raw async records (real Node/Relationship objects).
**Verified live:** `get_neighbors('Alan Yang')` crash → 9–11 nodes / 8–10 edges with props.

## Fault 3 — `find_experts` ranked concepts, not people
"who are the main contributors in the project" → `Copyright-assignment CLA`, `AI Agents`, `FSF`. It substring-matched the topic against entity NAMES and took the other endpoint with no person-type filter.
**Fix (both duplicated copies — capability + bot-facing `graph_tools`):** restrict candidates to `Person` entities; when graph scoring is thin, top up by ranking the humans who **authored** facts about the topic (skipping bot/system authors).
**Verified live:** project → Jacky Chan, Thomas Chong, Alan Yang, Jack Ng; security → Jacky Chan, Thomas Chong, Alan Yang, Dante Lok; etc.

---

## Tests (all green locally)
- `test_true_hybrid_search.py`: `query_properties` passed + excludes `guild_id`/`channel_id`/`tier`; new bm25 guard.
- `test_neo4j_hops.py`: new edge-from-raw-relationship test; asserts `result.data()` not used.
- `test_graph_tools_refactor.py`: new concept-exclusion + authorship-fallback tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)