### PR TITLE
chore(release): bump version to 0.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "beever-atlas"
-version = "0.2.0"
+version = "0.3.0"
 description = "Wiki-first RAG system with dual semantic + graph memory"
 readme = { text = "", content-type = "text/markdown" }
 requires-python = ">=3.12"


### PR DESCRIPTION
## What & why

Bumps the package version `0.2.0 → 0.3.0`. This is the first release that contains the **standalone MCP stdio entrypoint** (`python -m beever_atlas.api.mcp_server`, #224).

**The bug this fixes:** the `v0.2.0` tag was cut **2026-05-17**, but the entrypoint landed in **#224 on 2026-06-03** — 17 days later. So a clean install of `v0.2.0` has **no `__main__.py`**, and its documented launch command crashes with *"No module named …__main__"*. That is why the **Glama quality-score build failed** and why **PR #7369** (punkpeye/awesome-mcp-servers, 88K⭐) stayed gated — its only remaining checkbox is the Glama score.

## Verification (read-only, repo untouched)

Built exactly what Glama would build, isolated in `/tmp`:

| Check | Result |
|---|---|
| Clean install from `@main` (28 tools, stdio handshake) | ✅ 28 tools / 1.12s, zero backends |
| `__main__.py` shipped | ✅ |
| Containerized build on `python:3.12-slim` (tarball install) | ✅ 28 tools / 3.74s in-container, 173 MB image, 317s cold build |

## Scope (deliberately surgical)

- **Only `pyproject.toml`** changes. `server.json` is left at `0.2.0` on purpose — its `identifier` pins `ghcr.io/beever-ai/beever-atlas:0.2.0`, an OCI image that **exists**. Bumping it would dangle the Official Registry at a `:0.3.0` image that doesn't exist yet (separate publish step needing ghcr auth + the linux/amd64 build).
- Historical `0.2.0` mentions in README/SECURITY/roadmap are API-stability prose, not the version.

## After merge

1. Tag `v0.3.0` on the merge commit and push it.
2. **Glama (manual, dashboard):** set the admin-section Dockerfile to install from the release **tarball** (not `git+https` — slim has no git):
   ```dockerfile
   FROM python:3.12-slim
   RUN pip install --no-cache-dir 'https://github.com/Beever-AI/beever-atlas/archive/refs/tags/v0.3.0.tar.gz'
   ENTRYPOINT ["python", "-m", "beever_atlas.api.mcp_server"]
   ```
3. Re-run Glama Build & Release → score posts → PR #7369 unblocks.
4. *(Separate follow-up)* re-publish to the Official Registry at 0.3.0 (server.json + 0.3.0 OCI image).

🤖 Generated with [Claude Code](https://claude.com/claude-code)