### PR TITLE
chore(registry): publish v0.3.0 to the Official MCP Registry

### DIFF
--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.Beever-AI/beever-atlas",
   "description": "Open-source LLM knowledge base: team chat into a typed knowledge graph and auto-generated wiki.",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "repository": {
     "url": "https://github.com/Beever-AI/beever-atlas",
     "source": "github"
@@ -10,7 +10,7 @@
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/beever-ai/beever-atlas:0.2.0",
+      "identifier": "ghcr.io/beever-ai/beever-atlas:0.3.0",
       "runtimeHint": "docker",
       "transport": {
         "type": "stdio"

--- a/uv.lock
+++ b/uv.lock
@@ -298,7 +298,7 @@ wheels = [
 
 [[package]]
 name = "beever-atlas"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "aioboto3" },


### PR DESCRIPTION
Bumps the registry manifest to **0.3.0** and refreshes `uv.lock` to match.

## Changes
- **`server.json`**: `version` → `0.3.0`, OCI `identifier` → `ghcr.io/beever-ai/beever-atlas:0.3.0`
- **`uv.lock`**: project self-version `0.2.0` → `0.3.0` (1 line, no dependency changes)

## Why `uv.lock` too
PR #277 bumped `pyproject.toml` only, leaving `uv.lock` pinned at `0.2.0`. The root `Dockerfile` builder runs `uv sync --frozen`, which **fails on the mismatch** — so this also un-breaks any image build from `main`.

## Done out-of-band (this PR is the housekeeping record)
- ✅ Built + pushed **multi-arch** (`linux/amd64`+`arm64`) `ghcr.io/beever-ai/beever-atlas:0.3.0`
- ✅ Published to the Official MCP Registry: `io.github.Beever-AI/beever-atlas` **v0.3.0** (status active)

Validator notes: requires `linux/amd64` and the case-sensitive namespace `io.github.Beever-AI` (both satisfied).

🤖 Generated with [Claude Code](https://claude.com/claude-code)