### PR TITLE
docs(scheduler): document CVE-2026-31072 (apscheduler RCE) mitigation guard [Dependabot #38]

### DIFF
--- a/src/beever_atlas/services/scheduler.py
+++ b/src/beever_atlas/services/scheduler.py
@@ -50,6 +50,24 @@ class SyncScheduler:
         # coordination is needed. The actual queue state lives in
         # ``channel_messages`` (Mongo), not in the scheduler.
         self._mongodb_uri = mongodb_uri
+        # SECURITY — CVE-2026-31072 / GHSA-9cfw-f3f9-7mm7 (apscheduler RCE).
+        # apscheduler's serializing data stores (SQLAlchemyDataStore /
+        # MongoDBDataStore) and serializing event brokers (e.g. RedisEventBroker /
+        # MQTTEventBroker) reconstruct schedules and events by deserializing
+        # stored task state via JSONSerializer / CBORSerializer. A crafted
+        # payload in the backing store can be deserialized into arbitrary object
+        # construction → remote code execution. There is currently NO patched
+        # apscheduler release that closes this; the only safe posture is to
+        # avoid the serializer code path entirely.
+        # MemoryDataStore never serializes — schedules live as in-process Python
+        # objects and are re-registered from ``startup()`` on every boot — so the
+        # vulnerable JSONSerializer / CBORSerializer path is unreachable here.
+        # DO NOT replace MemoryDataStore with a persistent serializing data store
+        # (SQLAlchemyDataStore / MongoDBDataStore) or switch to a serializing
+        # event broker (e.g. RedisEventBroker) until apscheduler ships a patched
+        # release — doing so re-introduces the deserialization RCE. (See also the
+        # bound-method pickling rationale above; that switch would also break job
+        # registration.)
         self._data_store = MemoryDataStore()
         self._scheduler = AsyncScheduler(data_store=self._data_store)
         self._global_semaphore: asyncio.Semaphore | None = None


### PR DESCRIPTION
## Summary

Addresses **Dependabot alert #38** (Critical) — `apscheduler` JSONSerializer/CBORSerializer RCE via insecure deserialization (`GHSA-9cfw-f3f9-7mm7` / `CVE-2026-31072`).

**There is no patched release to bump to** — `4.0.0a6` is the latest version on PyPI and the entire `>=4.0.0a1, <=4.0.0a6` range is affected. So this PR hardens + documents the existing mitigation rather than bumping.

## Why we are not exploitable

The RCE requires attacker-controlled bytes to flow through a **serializing** data store (`SQLAlchemyDataStore` / `MongoDBDataStore`) or a **serializing** event broker (`RedisEventBroker` / `MQTTEventBroker`), which deserialize task state via `JSONSerializer` / `CBORSerializer`.

`SyncScheduler` uses `MemoryDataStore` (`src/beever_atlas/services/scheduler.py`), which keeps live in-process Python objects and **never serializes**. Schedules are defined in code (`CronTrigger`/`IntervalTrigger`) and re-registered from `startup()` on every boot — no external serialized job data is ever loaded.

Verified: zero imports of `JSONSerializer`, `CBORSerializer`, `PickleSerializer`, `SQLAlchemyDataStore`, `MongoDBDataStore`, or any event broker anywhere in `src/` or `tests/`.

## Change

A `DO-NOT-REPLACE` security guard comment above the `MemoryDataStore()` construction, so a future contributor doesn't swap in a persistent serializing store/broker (which would re-introduce the RCE) before apscheduler ships a fix. **Comment-only — no behavior or dependency change.**

## Follow-up (cannot be done from this PR)

- **Dismiss alert #38** as `not_used` once merged (requires `security_events` scope):
  ```
  gh api -X PATCH repos/Beever-AI/beever-atlas/dependabot/alerts/38 \
    -f state=dismissed -f dismissed_reason=not_used \
    -f dismissed_comment="Vulnerable JSONSerializer/CBORSerializer path is unreachable — scheduler uses non-serializing MemoryDataStore (see scheduler.py guard comment). No patched apscheduler release exists (4.0.0a6 latest)."
  ```
- CI `audit.yml` already ignores `CVE-2026-31072` with matching rationale, so this stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
