### PR TITLE
fix(deps): bump starlette 0.52.1→1.3.1 — Host-header poisoning (GHSA-86qp-5c8j-p5mr) [Dependabot #33]

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1095,7 +1095,7 @@ wheels = [
 
 [[package]]
 name = "google-adk"
-version = "2.1.0"
+version = "2.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiosqlite" },
@@ -1123,9 +1123,9 @@ dependencies = [
     { name = "watchdog" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/02/d2/58823ea0d5ac32143773d377b014123191ce420480c003190e1f86a9667c/google_adk-2.1.0.tar.gz", hash = "sha256:fd1709bf5e70e5aaa7d148c7b788d2cd00bb659ee10505a731bb2ad609d28968", size = 3340742, upload-time = "2026-05-23T00:13:56.793Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4a/65/3ff3f50b10dac3323ddecd694515e9f9ed345886e0eaf666d0e42c90748b/google_adk-2.2.0.tar.gz", hash = "sha256:04cb6318aba8829fe7c941ee1b456ccb4745253898c13595708c9eb07b4582ff", size = 3391545, upload-time = "2026-06-04T22:15:12.9Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0f/5b/56a9992b6f9447437f29e3691a487b16dfdea42aedec16ceced9de88b9f8/google_adk-2.1.0-py3-none-any.whl", hash = "sha256:4ec8a0ccdf8af90f9fa505c740cae921b47590aee3d61bca14f7bfa8bc886e4e", size = 3852259, upload-time = "2026-05-23T00:13:59.611Z" },
+    { url = "https://files.pythonhosted.org/packages/64/f5/44a3b20b17bac130497f2d1dde8b93c90cfc026983cd94f24488d540ea70/google_adk-2.2.0-py3-none-any.whl", hash = "sha256:ebdf3d931dc2b9c5b30d995358fc2ae99d59594c48a4aaf7496869ccd2c5f245", size = 3912613, upload-time = "2026-06-04T22:15:15.411Z" },
 ]
 
 [[package]]
@@ -1151,7 +1151,7 @@ requests = [
 
 [[package]]
 name = "google-genai"
-version = "1.73.1"
+version = "2.8.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1165,9 +1165,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3d/d8/40f5f107e5a2976bbac52d421f04d14fc221b55a8f05e66be44b2f739fe6/google_genai-1.73.1.tar.gz", hash = "sha256:b637e3a3b9e2eccc46f27136d470165803de84eca52abfed2e7352081a4d5a15", size = 530998, upload-time = "2026-04-14T21:06:19.153Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/52/0244e310812f3063d09d60b30ae29ab7df9343bd005744cd5eeaa6ba39b4/google_genai-2.8.0.tar.gz", hash = "sha256:37a9b3cb127d763e7f4ca47452ae3562c87728773bd1b149f7b559c239da2bc1", size = 564955, upload-time = "2026-06-03T22:55:38.397Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/65/af/508e0528015240d710c6763f7c89ff44fab9a94a80b4377e265d692cbfd6/google_genai-1.73.1-py3-none-any.whl", hash = "sha256:af2d2287d25e42a187de19811ef33beb2e347c7e2bdb4dc8c467d78254e43a2c", size = 783595, upload-time = "2026-04-14T21:06:17.464Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/de/747ad1aa49e902da9a4699081c282a1ed8ceed3b4d295fd99a6d286e09e4/google_genai-2.8.0-py3-none-any.whl", hash = "sha256:4da0a223a100f4b37f609a68b835e3326ab0fa313314dc0fd9d34e76ee293844", size = 832497, upload-time = "2026-06-03T22:55:36.598Z" },
 ]
 
 [[package]]
@@ -3129,15 +3129,15 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "0.52.1"
+version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c4/68/79977123bb7be889ad680d79a40f339082c1978b5cfcf62c2d8d196873ac/starlette-0.52.1.tar.gz", hash = "sha256:834edd1b0a23167694292e94f597773bc3f89f362be6effee198165a35d62933", size = 2653702, upload-time = "2026-01-18T13:34:11.062Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/0d/13d1d239a25cbfb19e740db83143e95c772a1fe10202dda4b76792b114dd/starlette-0.52.1-py3-none-any.whl", hash = "sha256:0029d43eb3d273bc4f83a08720b4912ea4b071087a3b48db01b7c839f7954d74", size = 74272, upload-time = "2026-01-18T13:34:09.188Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Fixes **Dependabot alert #33** (Moderate) — Starlette missing Host header validation poisons `request.url.path`, bypassing path-based security checks (`GHSA-86qp-5c8j-p5mr` / `CVE-2026-48710`).

Bumps `starlette 0.52.1 → 1.3.1` (fix landed in `1.0.1`). Supersedes the held Dependabot PR #235 (which bumped starlette alone — unsatisfiable, see below).

## Why this is more than a one-line bump

`starlette` is transitive. **google-adk 2.1.0 pinned `starlette<1.0.0`**, so reaching 1.x requires co-upgrading:

| Package | Before | After | Reason |
|---|---|---|---|
| starlette | 0.52.1 | **1.3.1** | the security fix (≥1.0.1) |
| google-adk | 2.1.0 | **2.2.0** | only 2.2.0 lifts the `starlette<1` cap (within existing `>=2.1.0,<3`) |
| google-genai | 1.73.1 | **2.8.0** | google-adk 2.2.0 requires `google-genai>=2.4` |

`fastapi` (0.135.2) and `sse-starlette` are unchanged and compatible.

## Impact in this codebase

The vulnerable sink is loader-token path-prefix authorization — `verify_loader_token` uses `current_path.startswith(prefix)` (`infra/loader_token.py`), reached from `infra/auth.py:require_user_loader`. A poisoned path could let a loader token minted for one prefix be accepted on another. Exploitation requires a valid signed loader token **and** a crafted Host header; starlette ≥1.0.1 validates the Host header before URL construction, closing it.

## Verification

- `uv lock --check` → clean (176 packages)
- app factory imports under starlette 1.3.1 → 146 routes, 28 MCP tools mounted
- focused `pytest` subset (app/server/health/auth/loader/middleware/rate-limit) → **502 passed, 6 skipped, 0 failed**

## ⚠️ Reviewer notes before merge

1. **google-genai 1.x → 2.x is a major bump** that touches Gemini-backed agent paths. The unit suite is green, but there are **no live-LLM calls in CI** — please run a quick QA-agent smoke test on staging before merging.
2. **Remove the now-stale audit ignore** (separate commit — needs `workflow` scope): drop `--ignore-vuln PYSEC-2026-161` and its comment from `.github/workflows/audit.yml` (keep the `CVE-2026-31072` apscheduler ignore). I couldn't push the workflow-file change without the `workflow` OAuth scope. Leaving it does not fail CI; it just no longer gates a regression.
3. Minor follow-up: `fastapi.status.HTTP_422_UNPROCESSABLE_ENTITY` (used in `api/loader_token.py`) emits a `StarletteDeprecationWarning` under 1.x (renamed `…_CONTENT`; value still 422). Cosmetic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
