### PR TITLE
chore(bot): override transitive uuid to ^11.1.1 (GHSA-w5hq-g745-h8pq) [Dependabot #28]

### DIFF
--- a/bot/package-lock.json
+++ b/bot/package-lock.json
@@ -4936,13 +4936,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/vary": {

--- a/bot/package.json
+++ b/bot/package.json
@@ -30,5 +30,8 @@
     "tsx": "^4.22.4",
     "typescript": "6.0.3",
     "typescript-eslint": "^8.60.1"
+  },
+  "overrides": {
+    "uuid": "^11.1.1"
   }
 }


### PR DESCRIPTION
## Summary

Fixes **Dependabot alert #28** (Moderate) — `uuid` missing buffer bounds check in v3/v5/v6 when `buf` is provided (`GHSA-w5hq-g745-h8pq` / `CVE-2026-41907`).

Pins the transitive `uuid` to the patched `^11.1.1` via an npm `overrides` entry in `bot/package.json`.

## Why an override (not a normal bump)

`uuid` is transitive only:

```
@chat-adapter/teams → @microsoft/teams.apps → @azure/msal-node@3.8.10 → uuid@8.3.2
```

`@microsoft/teams.apps` pins `@azure/msal-node ^3.8.1`, and **every** msal-node 3.x pins `uuid ^8.3.0` — so no in-range update can reach the fixed `11.1.1`. An `overrides` entry is the correctly-scoped mechanism (and unlike forcing a direct dependency — which broke the Teams adapter in a prior incident — this was validated end-to-end).

## Exploitability

The advisory affects only `uuid.v3()/v5()/v6()` called **with** a `buf` argument. The sole consumer (msal-node `GuidGenerator`) calls only `uuid.v4()` with no arguments, so the vulnerable path is unreachable. This override removes the flagged version regardless (defense-in-depth).

## Verification (rebuilt on latest `main`, preserving the #266/#269 bot bumps)

- `npm ls uuid` → `uuid@11.1.1 overridden` along the single consuming path
- `npm run build` (tsc) → clean
- `npm test` → **442 passed, 0 failed**
- `npm run lint` → 0 errors (623 pre-existing warnings)
- `npm audit` → uuid no longer flagged

Diff is scoped to `bot/package.json` + `bot/package-lock.json` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
