### PR TITLE
ci(docker): auto-publish official image to GHCR + harden Dockerfile

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,109 @@
+name: Release — publish Docker image to GHCR
+
+# Builds and pushes the official multi-arch image to
+# ghcr.io/beever-ai/beever-atlas on every version tag, keeping `:latest`
+# pointed at the newest release automatically. This is the mechanism that keeps
+# the published image up to date — previously images were pushed by hand, which
+# let `:latest` drift behind the real release.
+#
+# Trigger options:
+#   - push a `v*.*.*` tag (the normal release path) → publishes :<version> + :latest
+#   - run manually (workflow_dispatch) with a version → rebuilds that tag's source
+#     and republishes :<version> + :latest (use this to repair a drifted :latest)
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Existing release version to (re)publish, without the leading v (e.g. 0.3.0). Rebuilds that git tag and refreshes :latest."
+        required: true
+
+concurrency:
+  # Serialize releases; never cancel an in-flight publish.
+  group: release-docker
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write       # for signed build provenance (sigstore)
+  attestations: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    env:
+      IMAGE: ghcr.io/beever-ai/beever-atlas   # lowercase: GHCR paths are case-sensitive
+    steps:
+      - name: Checkout (the tag's source, even on manual re-publish)
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && format('v{0}', github.event.inputs.version) || github.ref }}
+
+      - name: Set up QEMU (arm64 emulation)
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Derive tags and OCI labels
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE }}
+          # latest=auto tags :latest for the highest non-prerelease semver tag.
+          flavor: |
+            latest=auto
+          tags: |
+            type=semver,pattern={{version}}
+            type=raw,value=${{ github.event.inputs.version }},enable=${{ github.event_name == 'workflow_dispatch' }}
+            type=raw,value=latest,enable=${{ github.event_name == 'workflow_dispatch' }}
+          labels: |
+            org.opencontainers.image.title=beever-atlas
+            org.opencontainers.image.description=Wiki-first RAG system with dual semantic + graph memory
+            org.opencontainers.image.licenses=Apache-2.0
+            org.opencontainers.image.vendor=Beever AI Limited
+
+      - name: Build and push (multi-arch)
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          provenance: mode=max
+          sbom: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Attest build provenance (signed, pushed to registry)
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ env.IMAGE }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true
+
+      - name: Summary
+        run: |
+          {
+            echo "### Published \`${IMAGE}\`"
+            echo ""
+            echo "**Tags**"
+            echo '```'
+            echo "${{ steps.meta.outputs.tags }}"
+            echo '```'
+            echo "**Digest:** \`${{ steps.build.outputs.digest }}\`"
+            echo "**Platforms:** linux/amd64, linux/arm64"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,8 +50,14 @@ COPY --chown=app:app --from=builder /app/src /app/src
 COPY --chown=app:app --from=builder /app/scripts /app/scripts
 COPY --chown=app:app --from=builder /app/pyproject.toml /app/pyproject.toml
 
-# Ensure the venv is on PATH
-ENV PATH="/app/.venv/bin:$PATH"
+# Ensure the venv is on PATH. PYTHONUNBUFFERED is required, not cosmetic:
+# in MCP stdio mode (CMD overridden to `python -m beever_atlas.api.mcp_server`)
+# the JSON-RPC frames must flush immediately, and unbuffered stdout also keeps
+# container logs live in API-server mode. PYTHONDONTWRITEBYTECODE avoids .pyc
+# litter under the read-mostly non-root runtime.
+ENV PATH="/app/.venv/bin:$PATH" \
+    PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1
 
 # All RUN commands below execute as 'app'. New writable dirs MUST be created
 # here, before USER, OR with explicit `chown app:app` after USER (otherwise the
@@ -64,6 +70,18 @@ USER app
 # registry validator pulls the published manifest and reads this label to verify
 # OCI artifact ownership.
 LABEL io.modelcontextprotocol.server.name="io.github.Beever-AI/beever-atlas"
+
+# OCI image annotations. `image.source` is what links the GHCR package to this
+# repo (and surfaces the README + provenance on the package page); the rest feed
+# registry/Glama metadata and `docker inspect`. Dynamic values (version, revision,
+# created) are injected at release time by docker/metadata-action in
+# .github/workflows/release.yml and override these defaults.
+LABEL org.opencontainers.image.title="beever-atlas" \
+      org.opencontainers.image.description="Wiki-first RAG system with dual semantic + graph memory" \
+      org.opencontainers.image.source="https://github.com/Beever-AI/beever-atlas" \
+      org.opencontainers.image.url="https://github.com/Beever-AI/beever-atlas" \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.vendor="Beever AI Limited"
 
 EXPOSE 8000
 

--- a/llms-install.md
+++ b/llms-install.md
@@ -30,10 +30,16 @@ Start with **Path A** to verify everything wires up, then move to **Path B** for
 - **Docker** installed and running (`docker --version`, `docker compose version`).
 - Network access to build the image from the repo `Dockerfile`.
 
-> **Note:** A prebuilt image at `ghcr.io/beever-ai/beever-atlas` is **not published yet**.
-> Until it is, build locally from the repo `Dockerfile` (Path A/B below) or
-> `pip install` / `uv` the package from source. Do **not** reference a pullable
-> `ghcr.io` image — it does not exist yet.
+> **Prebuilt image:** published at `ghcr.io/beever-ai/beever-atlas` — public,
+> multi-arch (linux/amd64 + linux/arm64), built from this repo's `Dockerfile`.
+> Pull a pinned release tag (recommended) or `:latest`:
+>
+> ```bash
+> docker pull ghcr.io/beever-ai/beever-atlas:0.3.0   # or :latest
+> ```
+>
+> Building locally from the repo `Dockerfile` (Path A/B below) is still fully
+> supported and is required if you've made local changes.
 
 ---
 


### PR DESCRIPTION
## Why

The official image at `ghcr.io/beever-ai/beever-atlas` (referenced by `server.json` for the MCP registry) was **published by hand**, which caused two problems:

- **`:latest` drifted** — it still points at **0.2.0** while the current release is **0.3.0**.
- **`llms-install.md` claimed the image was "not published yet"** — false; it's been live (multi-arch) for two releases.

There was also no automation, so every release risked the same drift.

## What

1. **`.github/workflows/release.yml` (new)** — builds + pushes the multi-arch image (linux/amd64 + linux/arm64) to GHCR on every `v*.*.*` tag, tagging `:<version>` and refreshing `:latest` automatically (`latest=auto` skips pre-releases). Includes SBOM + signed build provenance (`actions/attest-build-provenance`). Uses the built-in `GITHUB_TOKEN` with `packages: write` — **no new secrets required**. A `workflow_dispatch` path rebuilds a given release tag to repair a drifted `:latest` without cutting a new version.
2. **`Dockerfile`** — adds OCI annotations (`org.opencontainers.image.source/url/title/description/licenses/vendor`) so the GHCR package links back to this repo and carries provenance/registry metadata, and sets `PYTHONUNBUFFERED=1` / `PYTHONDONTWRITEBYTECODE=1` (unbuffered stdout is needed for MCP stdio JSON-RPC framing and keeps API-mode logs live). No behaviour change.
3. **`llms-install.md`** — replaces the incorrect "not published yet" note with real `docker pull ghcr.io/beever-ai/beever-atlas:0.3.0` guidance.

## Validation

- `docker buildx build --check` — clean, no warnings
- `actionlint` (via container) on `release.yml` — clean
- Workflow action versions match repo convention (`actions/checkout@v6`, `docker/setup-buildx-action@v4`, etc.)

## Fixing the current `:latest` after merge

Either is fine:
- **Recommended:** Actions → *Release — publish Docker image to GHCR* → **Run workflow** with `version = 0.3.0`. It checks out `v0.3.0`, rebuilds, and republishes `0.3.0` + `latest`.
- Or it self-heals on the next `v*.*.*` tag.

## Out of scope (heads-up)

GitHub flagged a separate **critical** Dependabot alert (`security/dependabot/38`) on `main` — unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)