### PR TITLE
fix(consolidation): cursor-paginate fact reads to remove the 10k results ceiling (RES-946)

### DIFF
--- a/src/beever_atlas/stores/weaviate_store.py
+++ b/src/beever_atlas/stores/weaviate_store.py
@@ -1189,82 +1189,79 @@ class WeaviateStore:
     async def iter_unclustered_facts(
         self,
         channel_id: str,
-        page_size: int = 200,
+        page_size: int = 200,  # retained for API compatibility; cursor iteration self-batches
     ) -> AsyncIterator[AtomicFact]:
-        """Yield unclustered atomic facts (with vectors), one page at a time.
+        """Yield unclustered atomic facts (with vectors) for a channel.
 
-        Uses offset pagination with small pages so each gRPC response stays well
-        under Weaviate's 10MB cap. (Cursor ``after=`` is unavailable here because
-        Weaviate rejects ``after`` combined with a ``where`` filter.)
+        Walks the collection with Weaviate v4's ``collection.iterator()`` (cursor
+        pagination) and applies the ``channel_id`` / ``tier`` / ``cluster_id``
+        predicates CLIENT-SIDE, because ``iterator()`` does not accept a
+        ``filters=`` kwarg in weaviate-client v4 (same idiom as
+        ``iter_atomic_fact_ids_and_text`` / ``snapshot_all_facts_for_reembed``).
 
-        Note: Weaviate's ``QUERY_MAXIMUM_RESULTS`` (default 10000) caps the total
-        number of results an offset query can traverse. Channels above that size
-        require a schema-level bump of that setting.
+        Cursor iteration walks by object UUID, so — unlike the offset pagination
+        this replaced — it has NO ``QUERY_MAXIMUM_RESULTS`` (default 10000)
+        ceiling and no 10MB-per-page risk (the client batches internally). A
+        channel with >10k unclustered facts previously failed consolidation with
+        ``query maximum results exceeded``; it now streams through.
+
+        Scaling note: ``iterator()`` cannot filter server-side, so this scans the
+        whole MemoryFact collection to yield one channel's unclustered facts —
+        fine at Atlas's documented scale (~5k–50k facts). A very large
+        multi-channel install wants channel-scoped keyset pagination, which needs
+        an indexed unique monotonic property (a schema migration, out of scope).
         """
-        weaviate_filter = (
-            Filter.by_property("channel_id").equal(channel_id)
-            & Filter.by_property("tier").equal("atomic")
-            & Filter.by_property("cluster_id").equal("__none__")
-        )
 
-        def _fetch_page(offset: int) -> list[Any]:
+        def _walk() -> list[AtomicFact]:
             collection = self._collection()
-            return list(
-                collection.query.fetch_objects(
-                    filters=weaviate_filter,
-                    limit=page_size,
-                    offset=offset,
-                    include_vector=True,
-                ).objects
-            )
+            out: list[AtomicFact] = []
+            for obj in collection.iterator(  # type: ignore[arg-type]
+                include_vector=True,
+            ):
+                props = getattr(obj, "properties", {}) or {}
+                if (
+                    props.get("channel_id") != channel_id
+                    or props.get("tier") != "atomic"
+                    or props.get("cluster_id") != "__none__"
+                ):
+                    continue
+                out.append(self._obj_to_fact(obj, include_vector=True))
+            return out
 
-        offset = 0
-        while True:
-            page = await asyncio.to_thread(_fetch_page, offset)
-            if not page:
-                return
-            for obj in page:
-                yield self._obj_to_fact(obj, include_vector=True)
-            if len(page) < page_size:
-                return
-            offset += page_size
+        for fact in await asyncio.to_thread(_walk):
+            yield fact
 
     async def iter_all_fact_ids(
         self,
         channel_id: str,
-        page_size: int = 500,
+        page_size: int = 500,  # retained for API compatibility; cursor iteration self-batches
     ) -> AsyncIterator[tuple[str, str]]:
         """Yield ``(uuid, cluster_id)`` pairs for every atomic fact in a channel.
 
-        Returns only the two fields needed for cluster resets — no vectors, no
-        text — so each page is a few KB. Uses offset pagination (cursor ``after``
-        is incompatible with filters in Weaviate).
+        Returns only ``(uuid, cluster_id)`` — no vectors, no text. Walks the
+        collection with Weaviate v4's ``collection.iterator()`` (cursor
+        pagination) and filters ``channel_id`` / ``tier`` CLIENT-SIDE, because
+        ``iterator()`` takes no ``filters=`` kwarg. Unlike the offset pagination
+        this replaced, cursor iteration has NO ``QUERY_MAXIMUM_RESULTS`` (10k)
+        ceiling — the first failure point of ``full_reconsolidate`` on large
+        channels. See ``iter_unclustered_facts`` for the full-collection-scan
+        scaling caveat.
         """
-        weaviate_filter = Filter.by_property("channel_id").equal(channel_id) & Filter.by_property(
-            "tier"
-        ).equal("atomic")
 
-        def _fetch_page(offset: int) -> list[Any]:
+        def _walk() -> list[tuple[str, str]]:
             collection = self._collection()
-            return list(
-                collection.query.fetch_objects(
-                    filters=weaviate_filter,
-                    limit=page_size,
-                    offset=offset,
-                    return_properties=["cluster_id"],
-                ).objects
-            )
+            out: list[tuple[str, str]] = []
+            for obj in collection.iterator(  # type: ignore[arg-type]
+                include_vector=False,
+            ):
+                props = getattr(obj, "properties", {}) or {}
+                if props.get("channel_id") != channel_id or props.get("tier") != "atomic":
+                    continue
+                out.append((str(obj.uuid), props.get("cluster_id") or ""))
+            return out
 
-        offset = 0
-        while True:
-            page = await asyncio.to_thread(_fetch_page, offset)
-            if not page:
-                return
-            for obj in page:
-                yield str(obj.uuid), obj.properties.get("cluster_id") or ""
-            if len(page) < page_size:
-                return
-            offset += page_size
+        for pair in await asyncio.to_thread(_walk):
+            yield pair
 
     async def upsert_cluster(self, cluster: "TopicCluster") -> str:
         """Upsert a topic cluster as a MemoryFact with tier='topic'."""

--- a/tests/stores/test_weaviate_consolidation_cursor.py
+++ b/tests/stores/test_weaviate_consolidation_cursor.py
@@ -1,0 +1,93 @@
+"""Regression tests for RES-946 — consolidation fact reads must use Weaviate
+cursor pagination (``collection.iterator()``), not offset pagination.
+
+The old ``iter_all_fact_ids`` / ``iter_unclustered_facts`` used
+``fetch_objects(filters=..., offset=...)``, which is subject to Weaviate's
+``QUERY_MAXIMUM_RESULTS`` (default 10000): on channels with >10k atomic facts,
+``full_reconsolidate`` failed with ``query maximum results exceeded`` and the
+Space wiki could never consolidate. Cursor iteration walks by UUID with no such
+ceiling; ``iterator()`` takes no ``filters=`` kwarg so predicates are applied
+client-side.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from beever_atlas.stores.weaviate_store import WeaviateStore
+
+
+def _obj(uuid: str, channel_id: str, tier: str, cluster_id: str, *, with_vector: bool = False):
+    props = {
+        "channel_id": channel_id,
+        "tier": tier,
+        "cluster_id": cluster_id,
+        "memory_text": f"text-{uuid}",
+    }
+    ns = SimpleNamespace(uuid=uuid, properties=props)
+    if with_vector:
+        ns.vector = {"default": [0.1, 0.2, 0.3]}  # named-vector shape _obj_to_fact normalises
+    return ns
+
+
+def _fake_collection(objs):
+    fake = MagicMock(name="WeaviateCollection")
+    # iterator() takes no filters= kwarg in weaviate-client v4 — it walks the
+    # whole collection; predicates are applied client-side by the store.
+    fake.iterator = MagicMock(side_effect=lambda **_kw: iter(objs))
+    return fake
+
+
+@pytest.mark.asyncio
+async def test_iter_all_fact_ids_walks_cursor_past_10k_no_offset() -> None:
+    """>10k atomic rows in one channel must ALL be yielded (no 10k ceiling), and
+    offset pagination (``fetch_objects``) must not be used."""
+    objs = [_obj(f"a{i}", "CHAN", "atomic", "__none__") for i in range(12000)]
+    objs += [_obj(f"b{i}", "OTHER", "atomic", "c1") for i in range(50)]  # other channel
+    objs += [_obj(f"t{i}", "CHAN", "topic", "") for i in range(20)]  # other tier
+
+    store = WeaviateStore("http://localhost:8080")
+    fake = _fake_collection(objs)
+    store._collection = lambda: fake  # type: ignore[method-assign]
+
+    out = [pair async for pair in store.iter_all_fact_ids("CHAN")]
+
+    assert len(out) == 12000, "must yield every atomic row in the channel — no 10k ceiling"
+    assert all(isinstance(u, str) for u, _ in out)
+    assert {cid for _, cid in out} == {"__none__"}
+    fake.query.fetch_objects.assert_not_called()  # the old offset-pagination bug
+    fake.iterator.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_iter_unclustered_facts_filters_channel_tier_cluster_with_vectors() -> None:
+    """Only channel + atomic + ``cluster_id == "__none__"`` rows, with vectors,
+    past the 10k mark, and no offset pagination."""
+    objs = [_obj(f"u{i}", "CHAN", "atomic", "__none__", with_vector=True) for i in range(11000)]
+    objs += [_obj("clustered", "CHAN", "atomic", "c9", with_vector=True)]  # already clustered
+    objs += [_obj("wrongchan", "OTHER", "atomic", "__none__", with_vector=True)]
+    objs += [_obj("wrongtier", "CHAN", "topic", "__none__", with_vector=True)]
+
+    store = WeaviateStore("http://localhost:8080")
+    fake = _fake_collection(objs)
+    store._collection = lambda: fake  # type: ignore[method-assign]
+
+    facts = [f async for f in store.iter_unclustered_facts("CHAN")]
+
+    assert len(facts) == 11000, "no 10k ceiling; only the matching rows"
+    assert all(f.channel_id == "CHAN" and f.tier == "atomic" for f in facts)
+    assert all(f.cluster_id == "__none__" for f in facts)
+    assert all(f.text_vector == [0.1, 0.2, 0.3] for f in facts), "vectors must be populated"
+    fake.query.fetch_objects.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_iter_unclustered_facts_empty_channel_yields_nothing() -> None:
+    objs = [_obj("x", "OTHER", "atomic", "__none__", with_vector=True)]
+    store = WeaviateStore("http://localhost:8080")
+    store._collection = lambda: _fake_collection(objs)  # type: ignore[method-assign]
+    facts = [f async for f in store.iter_unclustered_facts("CHAN")]
+    assert facts == []


### PR DESCRIPTION
## Problem (RES-946)
Space consolidation could not run on channels above ~10k facts. `iter_all_fact_ids` and `iter_unclustered_facts` used **offset pagination** (`fetch_objects(filters=…, offset=…)`), which Weaviate caps at `QUERY_MAXIMUM_RESULTS` (default **10000**). Past that, `full_reconsolidate` failed with `query maximum results exceeded` and the Space wiki never built.

**Live evidence (RLP POC):** channel `rlp-ingest` at **12,169 facts** → `Full reconsolidation error … query maximum results exceeded` → `created=0 updated=0 facts=0 errors=1`.

## Fix
Switch both reads to **Weaviate v4 cursor pagination** via `collection.iterator()` with client-side `channel_id` / `tier` / `cluster_id` predicates — the same idiom already used by `iter_atomic_fact_ids_and_text` and `snapshot_all_facts_for_reembed` in this file. Cursor iteration walks by UUID: no offset ceiling, no 10MB-per-page risk (the client batches internally).

- Public signatures + yield shapes **unchanged** → the two `consolidation.py` callers and existing mocked tests are untouched.
- Docstrings updated to drop the now-false 10k-cap / "cursor incompatible with filters" notes.

## Scaling caveat (documented in-code)
`iterator()` can't filter server-side, so this scans the whole `MemoryFact` collection per channel — fine at Atlas's documented scale (~5k–50k facts). A very large multi-channel install wants channel-scoped keyset pagination, which needs an indexed unique monotonic property (a schema migration) — deliberately **out of scope** here.

## Tests
- New `tests/stores/test_weaviate_consolidation_cursor.py`: >10k rows across multiple channels/tiers flow through; only matching rows are yielded (with vectors for unclustered); `fetch_objects` (offset) is never called.
- Existing `tests/services/test_consolidation_streaming.py` still passes (interface preserved).
- `5 passed` locally.

Part of epic RES-943 (RLP full-corpus scale + no-cloud gaps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMMM6KQXmzAEA42UxpyMUm