### PR TITLE
fix(wiki): recover from streamed chunk-repetition abort instead of failing the page (RES-947)

### DIFF
--- a/src/beever_atlas/wiki/compiler.py
+++ b/src/beever_atlas/wiki/compiler.py
@@ -2695,6 +2695,29 @@ def _escape_control_chars_inside_strings(text: str) -> str:
     return "".join(result)
 
 
+def _is_stream_repetition_abort(exc: BaseException) -> bool:
+    """True when litellm aborted a streamed generation stuck repeating a chunk.
+
+    Dense OCR'd tables prime the model to reproduce giant ``---`` GFM separator
+    walls; litellm's ``raise_on_model_repetition`` guard (streaming handler only)
+    then aborts with ``litellm.MidStreamFallbackError: ... The model is repeating
+    the same chunk = ...``. The message substring is the robust primary signal —
+    ``MidStreamFallbackError`` is not exported at ``litellm`` top level (only via
+    ``litellm.exceptions``), so an ``isinstance`` check alone is fragile.
+    """
+    if "repeating the same chunk" in str(exc):
+        return True
+    try:
+        import litellm.exceptions as _lex
+
+        cls = getattr(_lex, "MidStreamFallbackError", None)
+        if cls is not None and isinstance(exc, cls):
+            return True
+    except Exception:  # noqa: BLE001
+        pass
+    return False
+
+
 def _is_degenerate_content(content: str) -> tuple[bool, str]:
     """Detect degenerate LLM output (too short, low alnum ratio, dash-wall, visuals-only).
 
@@ -3479,8 +3502,17 @@ class WikiCompiler:
         prompt: str,
         temperature: float = 0.2,
         page_kind: str = "topic",
+        stream_override: bool | None = None,
     ) -> str:
-        """Call the configured LLM and return raw text. Supports Gemini and Ollama."""
+        """Call the configured LLM and return raw text. Supports Gemini and Ollama.
+
+        ``stream_override`` forces streaming on/off for this call (``None`` = use
+        ``settings.wiki_llm_streaming``). When a streamed call is aborted by
+        litellm's repetition guard (dense OCR separator walls make the model
+        repeat a ``---`` row), we transparently retry the call non-streamed once
+        rather than letting the abort crash the page compile — the repetition
+        guard only runs in the streaming handler.
+        """
         from beever_atlas.infra.config import get_settings
 
         settings = get_settings()
@@ -3544,17 +3576,40 @@ class WikiCompiler:
                 kwargs = {"response_format": {"type": "json_object"}}
                 content = prompt
 
-            response = await dispatch_completion(
-                provider=sniff_provider(self._model_name),
-                model=normalize_litellm_model(self._model_name),
-                messages=[{"role": "user", "content": content}],
-                max_tokens=max_tokens,
-                temperature=temperature,
-                # Issue #223: stream this (up to 32k-token) page compile so a long
-                # generation never idles into the ~130s edge-proxy disconnect.
-                stream=settings.wiki_llm_streaming,
-                **kwargs,
+            stream = (
+                settings.wiki_llm_streaming if stream_override is None else stream_override
             )
+
+            async def _dispatch(use_stream: bool):
+                return await dispatch_completion(
+                    provider=sniff_provider(self._model_name),
+                    model=normalize_litellm_model(self._model_name),
+                    messages=[{"role": "user", "content": content}],
+                    max_tokens=max_tokens,
+                    temperature=temperature,
+                    # Issue #223: stream this (up to 32k-token) page compile so a
+                    # long generation never idles into the ~130s edge-proxy
+                    # disconnect.
+                    stream=use_stream,
+                    **kwargs,
+                )
+
+            try:
+                response = await _dispatch(stream)
+            except BaseException as exc:  # noqa: BLE001
+                # litellm aborts a streamed generation that gets stuck repeating a
+                # chunk (dense OCR ``---`` separator walls). The repetition guard
+                # only runs in the streaming handler, so retry once non-streamed —
+                # the full (possibly still dash-heavy) content then flows to
+                # ``_call_llm``'s existing degenerate guard / deterministic splice
+                # instead of crashing the page compile ("failed hard").
+                if not stream or not _is_stream_repetition_abort(exc):
+                    raise
+                logger.warning(
+                    "WikiCompiler: stream_repetition_abort page_kind=%s — retrying non-streamed",
+                    page_kind,
+                )
+                response = await _dispatch(False)
             return response.choices[0].message.content or "{}"  # type: ignore[index, union-attr]
 
     async def _call_llm(

--- a/tests/wiki/test_compiler_stream_repetition.py
+++ b/tests/wiki/test_compiler_stream_repetition.py
@@ -1,0 +1,107 @@
+"""Regression tests for RES-947 — a streamed wiki page compile that litellm aborts
+for chunk-repetition (dense OCR ``---`` separator walls) must NOT crash the page
+("subtopic page failed hard"). ``_llm_generate_json`` retries the call once
+non-streamed (litellm's repetition guard only runs in the streaming handler), so
+the full content flows to the existing degenerate guard instead of raising.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from beever_atlas.wiki import compiler as compiler_mod
+from beever_atlas.wiki.compiler import WikiCompiler, _is_stream_repetition_abort
+
+
+def _settings(**over):
+    base = dict(
+        wiki_token_budget_v2=False,
+        wiki_compiler_v2=False,  # JSON mode (not delimited)
+        wiki_llm_streaming=True,
+        ollama_api_base="http://localhost:11434",
+    )
+    base.update(over)
+    return SimpleNamespace(**base)
+
+
+def _resp(text: str):
+    return SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(content=text))])
+
+
+def test_is_stream_repetition_abort_detects_by_message() -> None:
+    assert _is_stream_repetition_abort(
+        RuntimeError("litellm.MidStreamFallbackError: The model is repeating the same chunk = ----")
+    )
+    assert not _is_stream_repetition_abort(ValueError("some other error"))
+
+
+@pytest.mark.asyncio
+async def test_llm_generate_json_retries_non_streamed_on_repetition_abort(monkeypatch) -> None:
+    """Streamed call aborts with a repetition error → retried non-streamed → returns
+    the good content, and dispatch is called twice (stream=True then stream=False)."""
+    calls: list[bool] = []
+
+    async def _fake_dispatch(**kwargs):
+        calls.append(bool(kwargs.get("stream")))
+        if kwargs.get("stream"):
+            raise RuntimeError(
+                "litellm.MidStreamFallbackError: The model is repeating the same chunk = ------"
+            )
+        return _resp('{"content": "real prose", "summary": "s"}')
+
+    monkeypatch.setattr(
+        "beever_atlas.services.llm_dispatch.dispatch_completion", _fake_dispatch
+    )
+    monkeypatch.setattr(compiler_mod, "get_settings", _settings, raising=False)
+    monkeypatch.setattr("beever_atlas.infra.config.get_settings", _settings, raising=False)
+
+    wc = object.__new__(WikiCompiler)
+    wc._model_name = "gemini-2.5-flash"
+
+    out = await wc._llm_generate_json("prompt", page_kind="topic")
+
+    assert out == '{"content": "real prose", "summary": "s"}'
+    assert calls == [True, False], "must try streamed first, then retry non-streamed"
+
+
+@pytest.mark.asyncio
+async def test_llm_generate_json_reraises_non_repetition_errors(monkeypatch) -> None:
+    """A non-repetition error is NOT swallowed — it propagates unchanged."""
+
+    async def _fake_dispatch(**_kwargs):
+        raise ValueError("genuine upstream failure")
+
+    monkeypatch.setattr(
+        "beever_atlas.services.llm_dispatch.dispatch_completion", _fake_dispatch
+    )
+    monkeypatch.setattr("beever_atlas.infra.config.get_settings", _settings, raising=False)
+
+    wc = object.__new__(WikiCompiler)
+    wc._model_name = "gemini-2.5-flash"
+
+    with pytest.raises(ValueError, match="genuine upstream failure"):
+        await wc._llm_generate_json("prompt", page_kind="topic")
+
+
+@pytest.mark.asyncio
+async def test_llm_generate_json_no_stream_does_not_retry(monkeypatch) -> None:
+    """When streaming is already off, a repetition abort is not retried (re-raised)."""
+    calls: list[bool] = []
+
+    async def _fake_dispatch(**kwargs):
+        calls.append(bool(kwargs.get("stream")))
+        raise RuntimeError("The model is repeating the same chunk = ----")
+
+    monkeypatch.setattr(
+        "beever_atlas.services.llm_dispatch.dispatch_completion", _fake_dispatch
+    )
+    monkeypatch.setattr("beever_atlas.infra.config.get_settings", _settings, raising=False)
+
+    wc = object.__new__(WikiCompiler)
+    wc._model_name = "gemini-2.5-flash"
+
+    with pytest.raises(RuntimeError):
+        await wc._llm_generate_json("prompt", page_kind="topic", stream_override=False)
+    assert calls == [False], "no non-streamed retry when already non-streamed"


### PR DESCRIPTION
## Problem (RES-947)
Dense OCR'd tables prime the wiki model to reproduce giant `---` GFM separator walls. litellm's streaming repetition guard aborts with `MidStreamFallbackError: ... The model is repeating the same chunk = ...`, which propagated to the **"subtopic page failed hard"** branch → the page fell back to empty. This hits the exact content dominant in an architecture/engineering corpus (drawing schedules, dimension tables).

**Live evidence (RLP POC):** `WikiCompiler: subtopic page failed hard (litellm.MidStreamFallbackError: litellm.InternalServerError: The model is repeating the same chunk = ------…)`.

## Fix
Handle it at the source in `_llm_generate_json`. The repetition guard only runs in litellm's **streaming** handler, so when a streamed dispatch aborts with a repetition error, retry the call **once non-streamed**. The full content then flows to `_call_llm`'s existing `_is_degenerate_content` dash-wall guard → deterministic Key Facts splice, rather than crashing. Fix lives in the shared helper, so every page kind inherits it (overview/people/activity/resources/glossary/subtopic).

- New `_is_stream_repetition_abort(exc)` — message-substring is the robust primary signal (`MidStreamFallbackError` isn't exported at litellm top level).
- New `stream_override` param on `_llm_generate_json`.
- Non-repetition errors re-raised unchanged; no retry when already non-streamed.

## Tests
`tests/wiki/test_compiler_stream_repetition.py`: detector; streamed-abort → non-streamed retry returns good content (dispatch called stream=True then stream=False); non-repetition errors propagate; no retry when already non-streamed. Existing `test_compiler_degenerate_guard` + `test_compiler_retry_gating` still pass — **17 passed** locally.

Part of epic RES-943 (RLP full-corpus scale + no-cloud gaps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMMM6KQXmzAEA42UxpyMUm