### PR TITLE
fix(sync): treat recently-started running jobs as active to stop concurrent pile-up (RES-948)

### DIFF
--- a/src/beever_atlas/services/sync_runner.py
+++ b/src/beever_atlas/services/sync_runner.py
@@ -113,6 +113,14 @@ def _coerce_since_timestamp(value: Any | None) -> datetime | None:
 class SyncRunner:
     """Orchestrates channel sync jobs using BatchProcessor and ADK pipeline."""
 
+    # A ``status=="running"`` sync_jobs row started within this window is treated
+    # as an active concurrent run even if this process's in-memory task registry
+    # does not know about it (a concurrent trigger, or a run owned by another
+    # worker process). Prevents a burst of triggers from each mis-recovering the
+    # others' fresh rows and piling up dozens of concurrent "running" jobs on one
+    # channel (RES-948).
+    _RECENT_RUNNING_GRACE_SECONDS = 120
+
     def __init__(self) -> None:
         self._batch_processor = BatchProcessor()
         self._active_tasks: dict[str, asyncio.Task[None]] = {}
@@ -127,6 +135,28 @@ class SyncRunner:
             self._active_tasks.pop(channel_id, None)
             return False
         return True
+
+    def _running_row_is_active(self, existing: Any, channel_id: str) -> bool:
+        """Whether a ``status=="running"`` sync_jobs row should block a new sync.
+
+        A running row is treated as active if EITHER this process is running its
+        task, OR it was started within :attr:`_RECENT_RUNNING_GRACE_SECONDS` — a
+        concurrent/other-process run whose task this process's in-memory registry
+        cannot see yet. Only a row that is BOTH not task-active here AND older than
+        the grace window is a genuine crashed/restart leftover safe to recover.
+        Without the recency check, concurrent triggers each mis-recover the
+        others' fresh rows and pile up dozens of "running" jobs (RES-948).
+        """
+        if self._is_task_active(channel_id):
+            return True
+        started = getattr(existing, "started_at", None)
+        if started is None:
+            return False
+        if started.tzinfo is None:
+            started = started.replace(tzinfo=UTC)
+        return (datetime.now(tz=UTC) - started) < timedelta(
+            seconds=self._RECENT_RUNNING_GRACE_SECONDS
+        )
 
     def has_active_sync(self, channel_id: str) -> bool:
         """Public check used by API status endpoints."""
@@ -213,10 +243,14 @@ class SyncRunner:
                     failed_stage="stale_recovery",
                 )
 
-        # 1. Guard: no concurrent sync for the same channel.
+        # 1. Guard: no concurrent sync for the same channel. See
+        # ``_running_row_is_active`` — a recently-started running row counts as
+        # active even if this process's task registry hasn't seen it yet, so a
+        # burst of triggers can't each mis-recover the others' fresh rows and pile
+        # up dozens of concurrent "running" jobs (RES-948).
         existing = await stores.mongodb.get_sync_status(channel_id)
         if existing is not None and existing.status == "running":
-            if self._is_task_active(channel_id):
+            if self._running_row_is_active(existing, channel_id):
                 raise ValueError(
                     f"Sync already running for channel {channel_id} (job_id={existing.id})."
                 )

--- a/tests/services/test_sync_runner_concurrent_guard.py
+++ b/tests/services/test_sync_runner_concurrent_guard.py
@@ -1,0 +1,63 @@
+"""Regression tests for RES-948 — a burst of sync triggers must not pile up dozens
+of concurrent "running" sync_jobs on one channel.
+
+``start_sync``'s concurrency guard used ``_is_task_active`` alone (an IN-PROCESS
+task registry). A "running" row created moments ago by a concurrent trigger — or
+by another worker process — is invisible to that registry, so each trigger treated
+the others' fresh rows as crashed leftovers, "recovered" them, and started yet
+another sync. ``_running_row_is_active`` now also treats a recently-started running
+row as active, so concurrent triggers are rejected instead of piling up.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+
+from beever_atlas.services.sync_runner import SyncRunner
+
+
+def _runner() -> SyncRunner:
+    r = object.__new__(SyncRunner)  # bypass __init__ (BatchProcessor)
+    r._active_tasks = {}
+    return r
+
+
+def _job(started_at):
+    return SimpleNamespace(id="job-1", status="running", started_at=started_at)
+
+
+def test_recently_started_running_row_blocks_without_local_task() -> None:
+    """A running row started seconds ago blocks even though this process has no
+    task for it — it is a concurrent / other-process run."""
+    r = _runner()
+    recent = datetime.now(tz=UTC) - timedelta(seconds=5)
+    assert r._running_row_is_active(_job(recent), "C") is True
+
+
+def test_old_running_row_without_task_is_recoverable() -> None:
+    """A running row older than the grace window with no local task is a genuine
+    stale leftover — recoverable (not blocking)."""
+    r = _runner()
+    old = datetime.now(tz=UTC) - timedelta(hours=2)
+    assert r._running_row_is_active(_job(old), "C") is False
+
+
+def test_task_active_always_blocks() -> None:
+    """If this process is running the sync task, block regardless of age."""
+    r = _runner()
+    r._active_tasks["C"] = SimpleNamespace(done=lambda: False)  # type: ignore[assignment]
+    old = datetime.now(tz=UTC) - timedelta(hours=5)
+    assert r._running_row_is_active(_job(old), "C") is True
+
+
+def test_missing_started_at_is_not_active() -> None:
+    r = _runner()
+    assert r._running_row_is_active(_job(None), "C") is False
+
+
+def test_naive_started_at_treated_as_utc() -> None:
+    """Naive datetimes (as Mongo may return) are coerced to UTC, not mis-dated."""
+    r = _runner()
+    naive_recent = datetime.now(tz=UTC).replace(tzinfo=None) - timedelta(seconds=5)
+    assert r._running_row_is_active(_job(naive_recent), "C") is True


### PR DESCRIPTION
## Problem (RES-948)
A burst of sync triggers piled up **dozens of concurrent `running` sync_jobs** on one channel (observed **58**), thrashing the GPU. `start_sync`'s guard rejected a new sync only when `_is_task_active(channel_id)` — an **in-process** check of `self._active_tasks`. A `running` row created moments ago by a **concurrent trigger** (or a **different worker process**) isn't in this process's registry, so the guard treated it as a crashed leftover, "recovered" it, and started another sync. Each trigger mis-recovered the others' fresh rows → pile-up.

## Fix
Add `_running_row_is_active(existing, channel_id)`: a `running` row blocks a new sync if **either** this process is running its task **or** it was started within `_RECENT_RUNNING_GRACE_SECONDS` (120s) — a concurrent/other-process run this registry can't see yet. Only a row that is **both** not-task-active here **and** older than the grace window is a genuine stale leftover, preserving the existing process-restart recovery path. Naive `started_at` (as Mongo may return) is coerced to UTC.

## Tests
`tests/services/test_sync_runner_concurrent_guard.py`: recent-row-blocks-without-local-task, old-row-recoverable, task-active-always-blocks, missing-started_at, naive-utc-coercion. **5 passed** locally.

Note: this closes the common race at the guard. A fully atomic one-job-per-channel claim (Mongo findAndModify/CAS) is a larger follow-up; the grace-window guard removes the observed pile-up without changing the recovery contract.

Part of epic RES-943 (RLP full-corpus scale + no-cloud gaps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMMM6KQXmzAEA42UxpyMUm