### PR TITLE
fix(llm): no-cloud extraction — redirect ADK agents off Gemini + keep JSON mode on vLLM/Qwen (RES-944)

### DIFF
--- a/src/beever_atlas/agents/ingestion/entity_extractor.py
+++ b/src/beever_atlas/agents/ingestion/entity_extractor.py
@@ -28,7 +28,8 @@ def create_entity_extractor(model=None) -> LlmAgent:
     """
     agent_kwargs: dict = {
         "name": "entity_extractor",
-        "model": model or get_llm_provider().resolve_model("entity_extractor"),
+        "model": model
+        or get_llm_provider().resolve_model("entity_extractor", force_json_object=True),
         "instruction": ENTITY_EXTRACTOR_INSTRUCTION,
         "output_key": "extracted_entities",
         "generate_content_config": types.GenerateContentConfig(

--- a/src/beever_atlas/agents/ingestion/fact_extractor.py
+++ b/src/beever_atlas/agents/ingestion/fact_extractor.py
@@ -22,7 +22,8 @@ def create_fact_extractor(model=None) -> LlmAgent:
     """
     agent_kwargs: dict = {
         "name": "fact_extractor",
-        "model": model or get_llm_provider().resolve_model("fact_extractor"),
+        "model": model
+        or get_llm_provider().resolve_model("fact_extractor", force_json_object=True),
         "instruction": FACT_EXTRACTOR_INSTRUCTION,
         "output_key": "extracted_facts",
         "generate_content_config": types.GenerateContentConfig(

--- a/src/beever_atlas/infra/config.py
+++ b/src/beever_atlas/infra/config.py
@@ -142,6 +142,26 @@ class Settings(BaseSettings):
     # close the cutover. Until that lands, False is the only safe default.
     llm_use_litellm_for_gemini: bool = Field(default=False)
 
+    # RES-944 — no-cloud mode. The ADK ingestion agents resolve their model via
+    # ``LLMProvider.resolve_model``, whose default map ``DEFAULT_AGENT_MODELS``
+    # hardcodes ``gemini-*`` and SHADOWS ``llm_fast_model``. So setting
+    # ``LLM_FAST_MODEL=openai/vllm-qwen`` does NOT redirect the agents — they
+    # keep calling cloud Gemini. When ``llm_self_hosted_only`` is True the
+    # provider bypasses that map (uses ``llm_fast_model`` for every un-assigned
+    # agent), treats ``llm_default_endpoint_id`` as the fallback endpoint for
+    # base_url/credential routing, and FAILS CLOSED — ``resolve_model`` raises
+    # ``ConfigurationError`` if any agent still resolves to a cloud model, so a
+    # misconfiguration can never silently leak inference to Gemini. Default
+    # False → zero behaviour change for existing cloud installs.
+    llm_self_hosted_only: bool = Field(
+        default=False,
+        description="No-cloud mode: force every ADK agent to the self-hosted model (llm_fast_model / llm_default_endpoint_id) and fail closed if any agent resolves to a cloud (Gemini/Vertex) model.",
+    )
+    llm_default_endpoint_id: str = Field(
+        default="",
+        description="Endpoint id used for base_url + credential routing of any agent without an explicit per-agent Assignment. Primarily used with llm_self_hosted_only to point all agents at the self-hosted vLLM endpoint. Must reference a loaded Endpoint.",
+    )
+
     # SSRF guard for the operator-facing Endpoint Test/Discover routes. When
     # True, ``base_url`` is resolved + validated against ``infra.http_safe``
     # before any outbound probe — private/link-local/metadata IPs are refused.

--- a/src/beever_atlas/llm/model_resolver.py
+++ b/src/beever_atlas/llm/model_resolver.py
@@ -95,11 +95,66 @@ SUPPORTED_PROVIDERS: tuple[str, ...] = (
 )
 
 
+# RES-944 — cached lazily so importing this module doesn't pull in ADK's
+# ``lite_llm`` (and litellm) at load time, matching the lazy imports already
+# used throughout ``resolve_model_object``.
+_JSON_AWARE_LITELLM_CLS: Any = None
+
+
+def _json_aware_litellm_cls() -> Any:
+    """Return (and memoise) a ``LiteLlm`` subclass that forces JSON-object output.
+
+    RES-944: ADK's ``LiteLlm`` derives ``response_format`` only from
+    ``LlmRequest.config.response_schema`` and *ignores*
+    ``response_mime_type='application/json'`` — which the fact/entity extractors
+    set (they deliberately avoid ``response_schema``/``output_schema`` because
+    ADK raises on those before the recovery callback can run). On ADK's native
+    Gemini path the mime type is honoured directly, so cloud extraction worked;
+    but the moment an extractor is routed to a self-hosted OpenAI-compatible
+    endpoint (vLLM/Qwen) the mime type is dropped, the model returns prose, the
+    recovery parser finds no fact array, and extraction yields **0 facts**.
+
+    ADK stores constructor kwargs in ``_additional_args`` and merges them *over*
+    the computed completion args (``completion_args.update(self._additional_args)``),
+    so baking ``response_format={'type': 'json_object'}`` in makes ADK emit it on
+    every completion for this (per-agent) model object — and it wins even when the
+    computed ``response_format`` is ``None``. vLLM honours ``json_object`` via
+    guided decoding; litellm maps it back to ``response_mime_type`` for Gemini, so
+    the cloud path is unaffected. Immutable after construction → concurrency-safe
+    across the pipeline's parallel batches.
+    """
+    global _JSON_AWARE_LITELLM_CLS
+    if _JSON_AWARE_LITELLM_CLS is not None:
+        return _JSON_AWARE_LITELLM_CLS
+
+    from google.adk.models.lite_llm import LiteLlm
+
+    class JsonAwareLiteLlm(LiteLlm):
+        """LiteLlm that always requests OpenAI-style ``json_object`` output."""
+
+        def __init__(self, model: str, **kwargs: Any) -> None:
+            kwargs.setdefault("response_format", {"type": "json_object"})
+            super().__init__(model=model, **kwargs)
+
+    _JSON_AWARE_LITELLM_CLS = JsonAwareLiteLlm
+    return JsonAwareLiteLlm
+
+
+def _make_litellm(model_string: str, extra: dict[str, Any], force_json_object: bool) -> Any:
+    """Construct an ADK LiteLlm wrapper, JSON-forcing when requested (RES-944)."""
+    if force_json_object:
+        return _json_aware_litellm_cls()(model=model_string, **extra)
+    from google.adk.models.lite_llm import LiteLlm
+
+    return LiteLlm(model=model_string, **extra)
+
+
 def resolve_model_object(
     model_string: str,
     *,
     api_key: str | None = None,
     api_base: str | None = None,
+    force_json_object: bool = False,
 ) -> Any:
     """Convert a model string to an ADK-compatible model object.
 
@@ -124,6 +179,15 @@ def resolve_model_object(
     400s with ``AuthenticationError``. Pass-through is optional so the
     legacy callers that don't know about per-Endpoint credentials still
     work.
+
+    RES-944: ``force_json_object`` — when True and the model is wrapped in
+    LiteLlm (any OpenAI-compatible endpoint, incl. self-hosted vLLM/Qwen and
+    Gemini-via-litellm), the wrapper is a ``JsonAwareLiteLlm`` that bakes
+    ``response_format={'type': 'json_object'}`` into every completion. This is a
+    no-op for the native-Gemini bare-string path (ADK honours the agent's
+    ``response_mime_type`` there already). Used by the fact/entity extractors so
+    JSON-mode survives the route to a no-cloud endpoint instead of silently
+    degrading to prose → 0 facts.
     """
     settings = get_settings()
 
@@ -135,9 +199,7 @@ def resolve_model_object(
 
     if model_string.startswith("ollama_chat/"):
         os.environ.setdefault("OLLAMA_API_BASE", settings.ollama_api_base)
-        from google.adk.models.lite_llm import LiteLlm
-
-        return LiteLlm(model=model_string, **extra)
+        return _make_litellm(model_string, extra, force_json_object)
 
     if not settings.llm_use_litellm_for_gemini:
         # The flag name is Gemini-specific. When False:
@@ -164,9 +226,7 @@ def resolve_model_object(
             # Any non-Gemini provider prefix → LiteLlm wrap. The flag only
             # disables LiteLlm for Gemini; OpenAI/Anthropic/Mistral/etc.
             # have no native ADK client and must go through LiteLLM.
-            from google.adk.models.lite_llm import LiteLlm
-
-            return LiteLlm(model=model_string, **extra)
+            return _make_litellm(model_string, extra, force_json_object)
         # Bare non-Gemini string (no prefix, no provider) — return as-is and
         # let ADK figure it out. ``validate_model_string`` upstream should
         # have rejected this shape already.
@@ -182,9 +242,7 @@ def resolve_model_object(
         # ``validate_model_string`` should have caught this upstream.
         return model_string
 
-    from google.adk.models.lite_llm import LiteLlm
-
-    return LiteLlm(model=model_string, **extra)
+    return _make_litellm(model_string, extra, force_json_object)
 
 
 def is_ollama_model(model_string: str) -> bool:

--- a/src/beever_atlas/llm/provider.py
+++ b/src/beever_atlas/llm/provider.py
@@ -6,7 +6,7 @@ import logging
 import time
 from typing import Any
 
-from beever_atlas.infra.config import Settings
+from beever_atlas.infra.config import ConfigurationError, Settings
 from beever_atlas.llm.model_resolver import (
     AGENT_NAMES,
     DEFAULT_AGENT_MODELS,
@@ -15,6 +15,18 @@ from beever_atlas.llm.model_resolver import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _is_cloud_model(model_str: str) -> bool:
+    """True if a resolved model string points at a hosted cloud LLM (Gemini /
+    Vertex / Google PaLM) rather than a self-hosted endpoint.
+
+    RES-944: used by the ``llm_self_hosted_only`` fail-closed guard. Substring
+    (not just prefix) so it also catches an OpenAI-compat shim that still points
+    at Google, e.g. ``openai/gemini-2.5-flash`` after ``route_for_endpoint``.
+    """
+    m = (model_str or "").lower()
+    return "gemini" in m or "vertex" in m or m.startswith(("google/", "google_ai/", "palm/"))
 
 _MODEL_ALIASES: dict[str, str] = {
     # Gemini 2.0 Flash Lite is retired for new users.
@@ -97,6 +109,50 @@ class LLMProvider:
             raise ValueError(f"Unknown tier: {tier}")
         return self._resolve_alias(model, f"tier={tier}")
 
+    def _base_model_string(self, agent_name: str) -> str:
+        """Resolve an agent's model string: Assignment → default map → env.
+
+        RES-944: in no-cloud mode (``llm_self_hosted_only``) the hardcoded
+        Gemini ``DEFAULT_AGENT_MODELS`` map is bypassed — it otherwise shadows
+        ``llm_fast_model`` and pins every un-assigned ADK agent to cloud Gemini
+        regardless of ``LLM_FAST_MODEL``. The operator-configured self-hosted
+        model (``llm_fast_model``) is then used directly. An explicit per-agent
+        Assignment (``_agent_overrides``) still wins in either mode.
+        """
+        model_str = self._agent_overrides.get(agent_name)
+        if not model_str:
+            if self._settings.llm_self_hosted_only:
+                model_str = self._settings.llm_fast_model
+            else:
+                model_str = DEFAULT_AGENT_MODELS.get(agent_name)
+        if not model_str:
+            model_str = self._settings.llm_fast_model
+        return model_str
+
+    def assert_self_hosted_only(self) -> None:
+        """Fail closed if no-cloud mode is on but any agent resolves to a cloud
+        model (RES-944).
+
+        Intended as a startup assertion so a misconfigured no-cloud deployment
+        is caught before ingest begins, rather than silently leaking inference
+        to Gemini at the first agent call. No-op when ``llm_self_hosted_only``
+        is off. Uses the raw model strings (no LiteLlm construction / no
+        credentials needed).
+        """
+        if not self._settings.llm_self_hosted_only:
+            return
+        offenders = {
+            name: model
+            for name, model in self.get_all_model_strings().items()
+            if _is_cloud_model(model)
+        }
+        if offenders:
+            raise ConfigurationError(
+                "llm_self_hosted_only is set but these agents still resolve to "
+                f"cloud models: {offenders}. Set LLM_FAST_MODEL to the self-hosted "
+                "model (e.g. openai/vllm-qwen) or add per-agent Assignments."
+            )
+
     def resolve_model(self, agent_name: str, *, force_json_object: bool = False) -> Any:
         """Resolve the model for a specific agent.
 
@@ -118,16 +174,9 @@ class LLMProvider:
         ``AuthenticationError`` while LiteLLM falls back to
         ``OPENAI_API_KEY`` from env.
         """
-        # 1. Check MongoDB overrides (Assignment-derived + legacy)
-        model_str = self._agent_overrides.get(agent_name)
-        # 2. Fall back to default map
-        if not model_str:
-            model_str = DEFAULT_AGENT_MODELS.get(agent_name)
-        # 3. Fall back to env var
-        if not model_str:
-            model_str = self._settings.llm_fast_model
-
-        model_str = self._resolve_alias(model_str, f"agent={agent_name}")
+        model_str = self._resolve_alias(
+            self._base_model_string(agent_name), f"agent={agent_name}"
+        )
 
         # Ollama fallback: if model is Ollama but service is unreachable
         if is_ollama_model(model_str):
@@ -147,6 +196,11 @@ class LLMProvider:
         api_key: str | None = None
         api_base: str | None = None
         ep_id = self._agent_endpoint_overrides.get(agent_name)
+        # RES-944: in no-cloud mode, an agent without an explicit per-agent
+        # Assignment routes through the configured default endpoint so its
+        # base_url + credential reach the self-hosted vLLM upstream.
+        if not ep_id and self._settings.llm_self_hosted_only:
+            ep_id = self._settings.llm_default_endpoint_id or None
         if ep_id:
             ep_meta = self._endpoint_meta.get(ep_id)
             if ep_meta and isinstance(ep_meta.get("base_url"), str):
@@ -259,6 +313,18 @@ class LLMProvider:
                 # skip its client-side check.
                 api_key = "placeholder-no-auth"
 
+        # RES-944: fail closed. In no-cloud mode a model that still resolves to
+        # Gemini/Vertex (e.g. an operator left LLM_FAST_MODEL at its gemini
+        # default) must never reach the wire — raise instead of silently calling
+        # cloud. ``route_for_endpoint`` above has already rewritten OpenAI-compat
+        # shims, so this checks the final, post-routing model string.
+        if self._settings.llm_self_hosted_only and _is_cloud_model(model_str):
+            raise ConfigurationError(
+                f"llm_self_hosted_only is set but agent {agent_name!r} resolved to "
+                f"cloud model {model_str!r}. Set LLM_FAST_MODEL to the self-hosted "
+                "model (e.g. openai/vllm-qwen) or add a per-agent Assignment."
+            )
+
         return resolve_model_object(
             model_str,
             api_key=api_key,
@@ -271,12 +337,9 @@ class LLMProvider:
 
         Useful for API responses and display.
         """
-        model_str = self._agent_overrides.get(agent_name)
-        if not model_str:
-            model_str = DEFAULT_AGENT_MODELS.get(agent_name)
-        if not model_str:
-            model_str = self._settings.llm_fast_model
-        return self._resolve_alias(model_str, f"agent={agent_name}")
+        return self._resolve_alias(
+            self._base_model_string(agent_name), f"agent={agent_name}"
+        )
 
     def get_all_model_strings(self) -> dict[str, str]:
         """Get the effective model string for every known agent."""

--- a/src/beever_atlas/llm/provider.py
+++ b/src/beever_atlas/llm/provider.py
@@ -313,17 +313,33 @@ class LLMProvider:
                 # skip its client-side check.
                 api_key = "placeholder-no-auth"
 
-        # RES-944: fail closed. In no-cloud mode a model that still resolves to
-        # Gemini/Vertex (e.g. an operator left LLM_FAST_MODEL at its gemini
-        # default) must never reach the wire — raise instead of silently calling
-        # cloud. ``route_for_endpoint`` above has already rewritten OpenAI-compat
-        # shims, so this checks the final, post-routing model string.
-        if self._settings.llm_self_hosted_only and _is_cloud_model(model_str):
-            raise ConfigurationError(
-                f"llm_self_hosted_only is set but agent {agent_name!r} resolved to "
-                f"cloud model {model_str!r}. Set LLM_FAST_MODEL to the self-hosted "
-                "model (e.g. openai/vllm-qwen) or add a per-agent Assignment."
-            )
+        # RES-944: fail closed. In no-cloud mode the resolved model must never
+        # reach a cloud upstream. ``route_for_endpoint`` above has already
+        # rewritten OpenAI-compat shims, so this checks the final, post-routing
+        # values. Two egress paths to block:
+        if self._settings.llm_self_hosted_only:
+            # (1) A model that still resolves to Gemini/Vertex — e.g. an operator
+            #     left LLM_FAST_MODEL at its gemini default.
+            if _is_cloud_model(model_str):
+                raise ConfigurationError(
+                    f"llm_self_hosted_only is set but agent {agent_name!r} resolved to "
+                    f"cloud model {model_str!r}. Set LLM_FAST_MODEL to the self-hosted "
+                    "model (e.g. openai/vllm-qwen) or add a per-agent Assignment."
+                )
+            # (2) An OpenAI-compat model with no base_url. litellm's ``openai/``
+            #     provider then DEFAULTS to https://api.openai.com — i.e. it would
+            #     silently ship on-prem document text to OpenAI cloud. This happens
+            #     when llm_default_endpoint_id is unset, typo'd, or not yet loaded
+            #     into _endpoint_meta (so no api_base was attached). Require a
+            #     resolved self-hosted base_url instead of leaking.
+            if model_str.startswith("openai/") and not api_base:
+                raise ConfigurationError(
+                    f"llm_self_hosted_only is set but agent {agent_name!r} resolved to "
+                    f"OpenAI-compatible model {model_str!r} with no base_url — litellm "
+                    "would default to the OpenAI cloud host. Point llm_default_endpoint_id "
+                    "at a loaded self-hosted endpoint (or add a per-agent Assignment) so a "
+                    "base_url is attached."
+                )
 
         return resolve_model_object(
             model_str,

--- a/src/beever_atlas/llm/provider.py
+++ b/src/beever_atlas/llm/provider.py
@@ -97,13 +97,18 @@ class LLMProvider:
             raise ValueError(f"Unknown tier: {tier}")
         return self._resolve_alias(model, f"tier={tier}")
 
-    def resolve_model(self, agent_name: str) -> Any:
+    def resolve_model(self, agent_name: str, *, force_json_object: bool = False) -> Any:
         """Resolve the model for a specific agent.
 
         Priority: MongoDB Assignment → legacy MongoDB override → default map → LLM_FAST_MODEL.
         Returns a string (Gemini bare strings, flag-off path) or a
         ``LiteLlm`` instance (every other path, including Gemini when
         ``LLM_USE_LITELLM_FOR_GEMINI=True``).
+
+        RES-944: ``force_json_object`` is forwarded to ``resolve_model_object``
+        so JSON-mode extractors keep structured output when routed to a
+        self-hosted OpenAI-compatible endpoint (vLLM/Qwen). No-op for the
+        native-Gemini path.
 
         PR-ν.1: when the agent has an Assignment, also looks up the
         Assignment's endpoint to fetch its base_url + runtime credential
@@ -254,7 +259,12 @@ class LLMProvider:
                 # skip its client-side check.
                 api_key = "placeholder-no-auth"
 
-        return resolve_model_object(model_str, api_key=api_key, api_base=api_base)
+        return resolve_model_object(
+            model_str,
+            api_key=api_key,
+            api_base=api_base,
+            force_json_object=force_json_object,
+        )
 
     def get_model_string(self, agent_name: str) -> str:
         """Get the raw model string for an agent (without LiteLlm wrapping).

--- a/tests/llm/test_json_aware_litellm.py
+++ b/tests/llm/test_json_aware_litellm.py
@@ -1,0 +1,90 @@
+"""RES-944 — extraction must keep JSON-mode output when routed to a self-hosted
+OpenAI-compatible endpoint (vLLM/Qwen), instead of silently degrading to prose.
+
+ADK's ``LiteLlm`` builds ``response_format`` only from ``response_schema`` and
+ignores ``response_mime_type='application/json'`` (which the fact/entity
+extractors set). ``JsonAwareLiteLlm`` bakes ``response_format={'type':
+'json_object'}`` into the wrapper so the no-cloud path emits structured JSON.
+
+These are unit tests over model construction only. End-to-end proof (facts > 0
+on live Qwen) requires a rebuilt POC stack and is intentionally NOT run here —
+it must run on the POC box, never against prod.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from google.adk.models.lite_llm import LiteLlm
+
+from beever_atlas.llm import model_resolver
+from beever_atlas.llm.model_resolver import (
+    _json_aware_litellm_cls,
+    resolve_model_object,
+)
+
+
+def _patch_settings(monkeypatch: pytest.MonkeyPatch, *, use_litellm_for_gemini: bool) -> None:
+    fake = SimpleNamespace(
+        llm_use_litellm_for_gemini=use_litellm_for_gemini,
+        ollama_api_base="http://localhost:11434",
+    )
+    monkeypatch.setattr(model_resolver, "get_settings", lambda: fake)
+
+
+def test_json_aware_class_is_a_litellm_subclass() -> None:
+    cls = _json_aware_litellm_cls()
+    assert issubclass(cls, LiteLlm)
+    # Memoised — same class object across calls (lazy singleton).
+    assert cls is _json_aware_litellm_cls()
+
+
+def test_json_aware_bakes_response_format() -> None:
+    obj = _json_aware_litellm_cls()(model="openai/vllm-qwen")
+    assert obj._additional_args["response_format"] == {"type": "json_object"}
+
+
+def test_explicit_response_format_is_not_overridden() -> None:
+    # setdefault → a caller-supplied response_format wins.
+    obj = _json_aware_litellm_cls()(
+        model="openai/vllm-qwen", response_format={"type": "text"}
+    )
+    assert obj._additional_args["response_format"] == {"type": "text"}
+
+
+@pytest.mark.parametrize("flag", [True, False])
+def test_vllm_path_forces_json_object_regardless_of_gemini_flag(
+    monkeypatch: pytest.MonkeyPatch, flag: bool
+) -> None:
+    # A self-hosted vLLM/Qwen endpoint is non-Gemini, so it wraps in LiteLlm on
+    # both the cutover-on and flag-off paths. force_json_object must make it the
+    # JSON-aware subclass either way.
+    _patch_settings(monkeypatch, use_litellm_for_gemini=flag)
+    obj = resolve_model_object(
+        "openai/vllm-qwen", api_base="https://vllm.votee.dev/v1", force_json_object=True
+    )
+    assert isinstance(obj, _json_aware_litellm_cls())
+    assert obj._additional_args["response_format"] == {"type": "json_object"}
+    assert obj._additional_args["api_base"] == "https://vllm.votee.dev/v1"
+
+
+def test_without_force_plain_litellm_has_no_forced_json(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_settings(monkeypatch, use_litellm_for_gemini=True)
+    obj = resolve_model_object("openai/vllm-qwen", force_json_object=False)
+    assert isinstance(obj, LiteLlm)
+    assert not isinstance(obj, _json_aware_litellm_cls())
+    assert "response_format" not in obj._additional_args
+
+
+def test_native_gemini_bare_string_is_unaffected_by_force(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Flag OFF → bare Gemini returns as a string for ADK's native path, which
+    # already honours response_mime_type. force_json_object is a no-op here.
+    _patch_settings(monkeypatch, use_litellm_for_gemini=False)
+    result = resolve_model_object("gemini-2.5-flash", force_json_object=True)
+    assert result == "gemini-2.5-flash"

--- a/tests/llm/test_self_hosted_only.py
+++ b/tests/llm/test_self_hosted_only.py
@@ -81,3 +81,29 @@ def test_assert_self_hosted_only_passes_when_all_self_hosted() -> None:
 def test_assert_self_hosted_only_is_noop_when_flag_off() -> None:
     p = _provider(llm_fast_model="gemini-2.5-flash", llm_self_hosted_only=False)
     p.assert_self_hosted_only()  # cloud is fine when the flag is off → no raise
+
+
+# ── egress guard: OpenAI-compat model with no base_url would leak to cloud ──
+def test_openai_shim_without_base_url_fails_closed() -> None:
+    # No endpoint configured → api_base stays None → litellm openai/ provider
+    # would default to api.openai.com. No-cloud mode must refuse, not leak.
+    p = _provider(llm_fast_model="openai/vllm-qwen", llm_self_hosted_only=True)
+    with pytest.raises(ConfigurationError, match="no base_url"):
+        p.resolve_model("fact_extractor")
+
+
+def test_openai_shim_with_loaded_endpoint_base_url_passes() -> None:
+    # A loaded default endpoint supplies base_url → on-prem, no leak → no raise.
+    p = _provider(
+        llm_fast_model="openai/vllm-qwen",
+        llm_self_hosted_only=True,
+        llm_default_endpoint_id="ep-vllm",
+    )
+    p._endpoint_meta["ep-vllm"] = {
+        "base_url": "https://vllm.votee.dev/v1",
+        "preset": "vllm",
+    }
+    from google.adk.models.lite_llm import LiteLlm
+
+    obj = p.resolve_model("fact_extractor")  # egress guard must NOT raise
+    assert isinstance(obj, LiteLlm)

--- a/tests/llm/test_self_hosted_only.py
+++ b/tests/llm/test_self_hosted_only.py
@@ -1,0 +1,83 @@
+"""RES-944 — no-cloud mode. Setting LLM_FAST_MODEL alone did NOT redirect the ADK
+agents because ``DEFAULT_AGENT_MODELS`` hardcodes ``gemini-*`` and shadows the env
+config. ``llm_self_hosted_only`` bypasses that map and fails closed if any agent
+still resolves to a cloud model.
+
+Unit tests over the model-string resolution + guard only (no LiteLlm construction,
+no network). End-to-end "no google.genai traffic on the live box" is an operational
+check, not run here.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from beever_atlas.infra.config import ConfigurationError, Settings
+from beever_atlas.llm.provider import LLMProvider, _is_cloud_model
+
+
+def _provider(**overrides) -> LLMProvider:
+    settings = Settings(**overrides)
+    return LLMProvider(settings)
+
+
+# ── _is_cloud_model ────────────────────────────────────────────────────────
+@pytest.mark.parametrize(
+    "model,is_cloud",
+    [
+        ("gemini-2.5-flash", True),
+        ("gemini/gemini-2.5-flash", True),
+        ("openai/gemini-2.5-flash", True),  # OpenAI-compat shim still pointing at Google
+        ("vertex_ai/gemini-1.5-pro", True),
+        ("google/gemini-pro", True),
+        ("openai/vllm-qwen", False),
+        ("ollama_chat/qwen2.5", False),
+        ("", False),
+    ],
+)
+def test_is_cloud_model(model: str, is_cloud: bool) -> None:
+    assert _is_cloud_model(model) is is_cloud
+
+
+# ── default map bypass ─────────────────────────────────────────────────────
+def test_default_map_shadows_env_when_cloud_mode_off() -> None:
+    # The documented bug: LLM_FAST_MODEL is ignored for the extractors because
+    # DEFAULT_AGENT_MODELS pins them to gemini.
+    p = _provider(llm_fast_model="openai/vllm-qwen", llm_self_hosted_only=False)
+    assert p.get_model_string("fact_extractor") == "gemini-2.5-flash"
+
+
+def test_self_hosted_only_bypasses_default_map() -> None:
+    p = _provider(llm_fast_model="openai/vllm-qwen", llm_self_hosted_only=True)
+    assert p.get_model_string("fact_extractor") == "openai/vllm-qwen"
+    assert p.get_model_string("entity_extractor") == "openai/vllm-qwen"
+
+
+def test_explicit_assignment_still_wins_in_cloud_mode() -> None:
+    p = _provider(llm_fast_model="openai/vllm-qwen", llm_self_hosted_only=True)
+    p._agent_overrides["fact_extractor"] = "openai/some-other-selfhosted"
+    assert p.get_model_string("fact_extractor") == "openai/some-other-selfhosted"
+
+
+# ── fail-closed guard ──────────────────────────────────────────────────────
+def test_resolve_model_raises_when_cloud_model_in_nocloud_mode() -> None:
+    # Operator turned on no-cloud but left LLM_FAST_MODEL at its gemini default.
+    p = _provider(llm_fast_model="gemini-2.5-flash", llm_self_hosted_only=True)
+    with pytest.raises(ConfigurationError, match="cloud model"):
+        p.resolve_model("fact_extractor")
+
+
+def test_assert_self_hosted_only_flags_offending_agents() -> None:
+    p = _provider(llm_fast_model="gemini-2.5-flash", llm_self_hosted_only=True)
+    with pytest.raises(ConfigurationError, match="fact_extractor"):
+        p.assert_self_hosted_only()
+
+
+def test_assert_self_hosted_only_passes_when_all_self_hosted() -> None:
+    p = _provider(llm_fast_model="openai/vllm-qwen", llm_self_hosted_only=True)
+    p.assert_self_hosted_only()  # must not raise
+
+
+def test_assert_self_hosted_only_is_noop_when_flag_off() -> None:
+    p = _provider(llm_fast_model="gemini-2.5-flash", llm_self_hosted_only=False)
+    p.assert_self_hosted_only()  # cloud is fine when the flag is off → no raise


### PR DESCRIPTION
RES-944 has **two** root causes that together kept extraction on cloud Gemini and producing 0 facts on the no-cloud path. This PR fixes both. All changes are gated behind default-off flags / opt-in params → **zero behaviour change** for existing cloud installs.

## Part 1 — config could not redirect the ADK agents (primary ticket symptom)
Even with `LLM_FAST_MODEL=openai/vllm-qwen` (and `Settings()` confirming it loaded), extraction still emitted `google.genai` 400s. `LLMProvider.resolve_model` resolves an agent's model as **Assignment → `DEFAULT_AGENT_MODELS` → `llm_fast_model`**, and `DEFAULT_AGENT_MODELS` **hardcodes `gemini-*`**, so the env var was shadowed and never took effect.

**Fix — `llm_self_hosted_only` (default False):**
- Bypasses the hardcoded Gemini default map; every un-assigned agent uses `llm_fast_model`. Explicit per-agent Assignments still win. Shared resolution extracted into `_base_model_string` so `resolve_model` and `get_model_string` can't drift.
- Routes un-assigned agents through `llm_default_endpoint_id` for the self-hosted endpoint's base_url + credential.
- **Fails closed:** `resolve_model` raises `ConfigurationError` if an agent still resolves to a cloud model; `assert_self_hosted_only()` (startup assertion) reports every offender at once — a no-cloud misconfig can never silently leak to Gemini.

## Part 2 — JSON mode was dropped once on vLLM (0 facts)
The fact/entity extractors request structured output via `response_mime_type="application/json"`. ADK's **native Gemini** path honours it, but ADK's **LiteLlm** wrapper builds `response_format` only from `response_schema` and ignores the mime type (verified in `adk==2.2.0` `_get_completion_inputs`). So once an extractor reaches a self-hosted OpenAI-compatible endpoint the request carries no JSON directive → prose → recovery parser finds no fact array → 0 facts.

**Fix — `JsonAwareLiteLlm`:** lazily-defined `LiteLlm` subclass that bakes `response_format={"type":"json_object"}` into `_additional_args` (ADK merges those **over** the computed args, so it wins even when the computed `response_format` is None). Immutable after construction → concurrency-safe. Threaded via `force_json_object` through `resolve_model_object` → `resolve_model`; the two extractors opt in. No-op for native Gemini. vLLM honours `json_object` via guided decoding; litellm maps it back to `response_mime_type` for Gemini.

## Tests
- `tests/llm/test_self_hosted_only.py` (15): `_is_cloud_model` matrix (incl. `openai/gemini` shim), default-map-shadows-env (the bug), cloud-mode bypass, explicit-assignment-wins, resolve + assert fail-closed on cloud, pass when all self-hosted, no-op when flag off.
- `tests/llm/test_json_aware_litellm.py` (7): subclass/lazy-singleton, `response_format` baked, explicit format wins, vLLM forces json on both gemini-flag paths, plain LiteLlm unforced, native-Gemini no-op.
- **22 passed.** Full `tests/llm` suite otherwise green (the one `test_embedding_runtime::test_cache_returns_within_ttl` failure is a **pre-existing** flaky real-clock TTL test — reproduced identically on `main` with this PR's changes stashed; the `test_provider_failover_seam` errors are a pre-existing `CREDENTIAL_MASTER_KEY`-not-set env prerequisite, all pass once the key is exported).

## Operational note (not code)
Making **live Qwen** extraction produce `facts>0` also requires: (1) setting `llm_self_hosted_only=true` + `llm_default_endpoint_id` (or per-agent Assignments) pointing at `vllm.votee.dev/v1`; (2) the **F2 token cap (RES-945, #336)** so the prompt fits Qwen's 64k window. End-to-end validation must run on the **POC box against a rebuilt stack, never against prod.**

Part of epic RES-943 (RLP full-corpus scale + no-cloud gaps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMMM6KQXmzAEA42UxpyMUm